### PR TITLE
feat: real-server-validated fixes — sidecar progress forwarder + per-file tracks

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -103,16 +103,21 @@ IQ Store upload also validates which listed devices can actually run an audio ap
 | `make devices` | list installed device ids |
 | `make clean` | remove `bin/` and `gen/` |
 
-## Runtime checks still to do on the sim/device
+## Verified against a live ABS server
 
-The app compiles clean, but these are behaviours only a real run can confirm:
+Ran the ABS client + sidecar against a real Audiobookshelf (v2.35.1, behind
+Cloudflare): token auth, `/api/libraries` → items → item-detail shapes, direct
+MP3 download (`206 audio/mpeg`), **m4b → ADTS** convert, and the **`/progress`
+forwarder** (ABS `currentTime` confirmed updated on read-back) all pass.
 
-- **Progress sync** - WatchShelf sends `POST /api/me/progress/:id` with
-  `X-HTTP-Method-Override: PATCH`. If your ABS build ignores that header,
-  progress won't update; then add a `POST → PATCH` forwarder route to the sidecar
-  (or enable method-override at the proxy).
-- **Audio download + playback** - that `makeWebRequest(... HTTP_RESPONSE_CONTENT_TYPE_AUDIO)`
-  returns a usable `Media.ContentRef` and the native player plays the chapters.
-- **m4b whole-file** - a chapterless `.m4b` direct-downloaded and declared
-  `ENCODING_M4A`; if a book won't play, route it via the sidecar (`fmt=m4a`,
-  which produces clean ADTS - already verified end-to-end).
+## Still to confirm on the sim/device
+
+- **On-watch playback** - that a downloaded track's `Media.ContentRef` actually
+  plays through the native player to Bluetooth, including **ADTS** (m4b) output.
+- **Cloudflare + the watch's UA** - the watch's real User-Agent isn't blocked by
+  Cloudflare bot protection. In testing a `Garmin`/empty UA passed (only the
+  literal `Python-urllib` was 403'd), so this is low risk - but if downloads
+  403 on-device, allowlist the Garmin UA (or `/api/*`) in Cloudflare.
+- **Large single-file books** - a multi-hour single MP3 with no chapters downloads
+  as one big track; watch reliability there (multi-file / chaptered books split
+  into smaller tracks and are fine).

--- a/README.md
+++ b/README.md
@@ -2,18 +2,20 @@
 
 A Garmin **Audio Content Provider** app that streams-then-plays audiobooks from a
 self-hosted [Audiobookshelf](https://audiobookshelf.org) (ABS) server on a
-**Garmin Tactix 8** and other music-capable Garmin watches. Download a book's
-chapters over Wi-Fi/LTE, then play them offline with real chapter navigation and
-two-way progress sync back to ABS.
+**Garmin Tactix 8** and other music-capable Garmin watches. Download a book over
+Wi-Fi/LTE, then play it offline with part/chapter navigation and two-way progress
+sync back to ABS.
 
 WatchShelf is a lean adaptation of Garmin's official **MonkeyMusic** sample: the
 same class hierarchy and system hooks (proven to compile), with the music-server
 logic swapped for Audiobookshelf + a tiny transcode sidecar.
 
-> **Status:** compiles clean against **Connect IQ SDK 9.2.0** - `make build` →
-> `bin/WatchShelf.prg` for the Tactix 8 (`fenix847mm`). Build is CLI-only (no
-> editor); see [BUILD.md](BUILD.md). Runtime behaviours (audio download/playback,
-> progress-sync PATCH) still to confirm on the simulator/device.
+> **Status:** compiles clean against **Connect IQ SDK 9.2.0** (`make build` →
+> `bin/WatchShelf.prg` for the Tactix 8 / `fenix847mm`), CLI-only (see
+> [BUILD.md](BUILD.md)). The ABS client + sidecar are **validated end-to-end
+> against a live ABS server**: browse, direct MP3 download, m4b→ADTS convert, and
+> progress write-back (ABS confirmed updated) all pass. What remains is on-watch
+> playback itself (native player → Bluetooth), which needs the device/simulator.
 
 ---
 
@@ -24,10 +26,11 @@ logic swapped for Audiobookshelf + a tiny transcode sidecar.
     |  Application.Properties: ABS server URL, API key, sidecar URL, sidecar key
     |
     |-- browse:   GET  {abs}/api/libraries, /libraries/:id/items, /items/:id
-    |-- download: GET  audio (one CHAPTER = one Media track)
-    |               direct:  {abs}/api/items/:id/file/:ino/download   (mp3/m4a books)
-    |               sidecar: {sidecar}/transcode?...&start&end&fmt=mp3 (chapters / flac/opus)
-    |-- progress: POST {abs}/api/me/progress/:itemId  (X-HTTP-Method-Override: PATCH)
+    |-- download: GET  audio (one FILE = one track; or one chapter for 1-file books)
+    |               mp3:     {abs}/api/items/:id/file/:ino/download   (direct, byte-exact)
+    |               aac/m4b: {sidecar}/transcode?...&fmt=m4a          (lossless AAC->ADTS)
+    |               flac/cut:{sidecar}/transcode?...&fmt=mp3[&start&end]
+    |-- progress: POST {sidecar}/progress -> sidecar PATCHes {abs}/api/me/progress/:itemId
     v
   Transcode sidecar (node:http + ffmpeg, 127.0.0.1:8081, behind your proxy on :443)
     |  holds the ABS token server-side; watch authenticates with a shared key
@@ -41,8 +44,8 @@ logic swapped for Audiobookshelf + a tiny transcode sidecar.
 
 | System hook | WatchShelf view/delegate | What it does |
 |---|---|---|
-| `getSyncConfigurationView()` | `LibraryView(MODE_SYNC)` -> `LibraryMenuDelegate` -> `BookMenuDelegate` | Browse ABS **library -> book**, queue every chapter, kick a sync |
-| `getSyncDelegate()` | `SyncDelegate` | Background download each queued chapter as an audio track; delete queued items |
+| `getSyncConfigurationView()` | `LibraryView(MODE_SYNC)` -> `LibraryMenuDelegate` -> `BookMenuDelegate` | Browse ABS **library -> book**, queue its tracks (per file, or per chapter for single-file books), kick a sync |
+| `getSyncDelegate()` | `SyncDelegate` | Background download each queued track as audio; delete queued items |
 | `getPlaybackConfigurationView()` | `LibraryView(MODE_PLAYBACK)` -> `DownloadedMenu` | **Downloaded** management screen (cache size, tap to remove) |
 | `getContentDelegate()` | `ContentDelegate` -> `ContentIterator` | Serve chapter tracks to the native player; sync progress on position change |
 
@@ -52,47 +55,50 @@ cache (`Media.getCachedContentObj` / `deleteCachedItem` / `getCacheStatistics`).
 User settings (server URL, API key, sidecar URL/key) live in
 `Application.Properties`, editable from Garmin Connect Mobile / Express.
 
-### Chapters as tracks
+### Tracks: one per file, or one per chapter
 
-Each **chapter** is downloaded as a **separate `Media` track** (never flattened)
-so the watch's Next/Previous buttons move chapter-to-chapter. Because ABS only
-serves whole files, per-chapter slices are cut by the sidecar (`start`/`end` ->
-ffmpeg `-ss`/`-to`) into small, complete mp3s.
+Each **audio file** becomes a separate `Media` track, so Next/Previous move
+part-to-part — this is what makes **multi-file books** (the common case in a real
+library) work. For a **single-file book that has chapters**, WatchShelf instead
+cuts one track per chapter via the sidecar (`start`/`end` -> ffmpeg `-ss`/`-t`)
+for smaller downloads and real chapter navigation. Every track stores its
+**book-absolute start offset** so progress maps back to ABS.
 
 ### Progress sync (two-way)
 
 * **On load:** `userMediaProgress.currentTime` is read from item detail.
 * **On play:** `ContentDelegate.onSong` fires on the notify/pause/stop/complete
-  events; WatchShelf converts the in-chapter position to **book-absolute**
-  seconds (`chapterStart + position`) and updates `/api/me/progress/:itemId`.
+  events; WatchShelf converts the in-track position to **book-absolute** seconds
+  (`trackStart + position`) and POSTs it to the sidecar's `/progress`.
 
-> **Note on PATCH:** Garmin's `Communications` module has **no**
-> `HTTP_REQUEST_METHOD_PATCH` (only GET/PUT/POST/DELETE). ABS's progress
-> endpoint is `PATCH /api/me/progress/:id`, so WatchShelf issues a **POST** with
-> an `X-HTTP-Method-Override: PATCH` header. ABS (an Express app) honours this
-> when method-override is enabled. If your ABS build does not, enable
-> method-override at the reverse proxy, or extend the sidecar with a
-> `POST /progress` route that forwards a real PATCH server-side.
+> **Why progress goes through the sidecar:** Garmin's `Communications` has **no**
+> `HTTP_REQUEST_METHOD_PATCH` (only GET/POST/PUT/DELETE), ABS's endpoint is
+> `PATCH /api/me/progress/:id`, and ABS **ignores** `X-HTTP-Method-Override`
+> (verified live: POST → 404). So WatchShelf **POSTs to the sidecar's
+> `/progress`**, which issues the real PATCH server-side. Tested end-to-end — ABS
+> confirmed updated. (The watch's own ABS token isn't even needed for progress.)
 
 ---
 
-## The two gotchas (read these)
+## The gotchas (read these)
 
 ### 1. Audiobookshelf will not hand us a plain MP3 -> the sidecar exists
 
 ABS's own transcoder emits **HLS/AAC**, which Garmin's `makeWebRequest` audio
 downloader **cannot consume**. Garmin needs a single, self-contained file with
-`:mediaEncoding` matching the body (`ENCODING_MP3` <-> `audio/mpeg`). So:
+`:mediaEncoding` matching the body (`ENCODING_MP3` <-> `audio/mpeg`). So, by codec:
 
-* **mp3 / m4a / m4b books** -> direct-download the byte-exact file from ABS.
-* **flac / opus / ogg / wma books, and all per-chapter cuts** -> route through the
-  **sidecar**. It has **ffmpeg pull the source from ABS over HTTP** (Range-seekable,
-  so `.m4b`/`.mp4` `moov`-at-end demuxing and chapter `-ss` seeks both work), then
-  returns **64 kbps mono MP3** (spoken-word sweet spot, ~28 MB/hour) or, for AAC
-  sources, a lossless **AAC -> ADTS copy** (no re-encode).
+* **mp3 files** -> direct-download the byte-exact file from ABS (no sidecar).
+* **aac / m4b / m4a files** -> **sidecar**, which copies the AAC stream to **ADTS**
+  (lossless, no re-encode; Garmin plays it via `ENCODING_ADTS`).
+* **flac / opus / ... and per-chapter cuts** -> **sidecar** transcode to **64 kbps
+  mono MP3** (~28 MB/hour).
 
-The sidecar holds the ABS token server-side; the watch never sees it and
-authenticates to the sidecar with its own shared key.
+The sidecar has **ffmpeg pull the source from ABS over HTTP** (Range-seekable, so
+`.m4b`/`.mp4` `moov`-at-end demuxing and chapter `-ss` seeks both work), and holds
+the ABS token server-side. In a real library MP3 dominates (a live check found
+70 mp3 vs 6 m4b, zero flac), so the sidecar mainly matters for a few m4b books,
+per-chapter cuts, and progress.
 
 ### 2. On-device audio downloads require real HTTPS on :443 with a valid cert
 
@@ -103,6 +109,15 @@ on port 443 with a complete, valid certificate chain** - a self-signed or
 incomplete-chain cert makes `makeWebRequest` audio downloads fail on-device
 (even when they work in the sim). Put both ABS and the sidecar behind a reverse
 proxy that terminates TLS with a real cert (see `sidecar/Caddyfile.snippet`).
+
+### 3. If ABS is behind Cloudflare, mind the User-Agent
+
+A live test showed the reference server sits behind **Cloudflare**, which **403s
+bot-like User-Agents** (the literal `Python-urllib` was blocked; a `Garmin`/empty
+UA passed). The watch's own UA is very likely fine, but if the app ever gets a
+403, allowlist the Garmin UA (or the `/api/*` paths) in Cloudflare. The
+**sidecar** sends a normal UA on its ABS calls and is best pointed at ABS's
+**internal** URL (e.g. `http://127.0.0.1:13378`) so it skips Cloudflare entirely.
 
 ---
 
@@ -123,10 +138,10 @@ Build it with **`make build`** (see **[BUILD.md](BUILD.md)** - CLI only, no edit
 
 ## Known limitations (first version)
 
-* **Multi-file books:** chapters are cut from the **first** audio file's `ino`.
-  Books split across multiple files (where chapters span files) are not yet
-  mapped file-by-file. Single-file `.m4b`/`.mp3` books (the common case) work.
+* **Chaptered multi-file books:** a book that is *both* multi-file *and* has
+  book-level chapters is played per **file** (not per chapter) — chapter cutting
+  is only applied to single-file books. Per-file navigation still works.
 * **Resume seek:** saved position is read and logged; the native player resumes
-  at chapter boundaries. Sample-accurate mid-chapter resume is a future step.
+  at track boundaries. Sample-accurate mid-track resume is a future step.
 * **No play sessions:** for offline playback WatchShelf skips ABS play sessions
   and syncs via the progress endpoint only (simpler, no session reaping).

--- a/sidecar/.env.example
+++ b/sidecar/.env.example
@@ -1,7 +1,10 @@
 # Copy to .env and fill in. The sidecar reads these at startup.
 
-# Your Audiobookshelf origin (no trailing slash).
-ABS_URL=https://abs.example.com
+# Your Audiobookshelf origin (no trailing slash). PREFER the internal URL so the
+# sidecar bypasses any Cloudflare/WAF in front of ABS (e.g. http://127.0.0.1:13378).
+# A public https URL also works — the sidecar sends a normal User-Agent so
+# Cloudflare doesn't 403 it as a bot.
+ABS_URL=http://127.0.0.1:13378
 
 # A long-lived ABS API key for a user WITH download permission.
 # Create one: ABS -> Settings -> API Keys (or POST /api/api-keys). The raw key

--- a/sidecar/server.js
+++ b/sidecar/server.js
@@ -1,28 +1,28 @@
-// WatchShelf transcode sidecar.
-// Node 18+ (uses child_process + streams; no global fetch needed). No framework.
-// Sits behind your existing reverse proxy on HTTPS:443. The watch calls
-//   GET /transcode?item=li_x&file=<ino>&fmt=mp3&start=<s>&end=<s>&key=<SIDECAR_KEY>
-// and gets back a single, complete audio body (mp3 by default) it stores.
+// WatchShelf sidecar: transcode + progress bridge for Audiobookshelf.
+// Node 18+ (global fetch), no framework. Sits behind your reverse proxy on
+// HTTPS:443 (or wherever the watch reaches it); binds localhost only.
 //
-// Why this exists: (1) ABS will NOT transcode to plain MP3 for us and Garmin
-// cannot consume ABS's HLS/AAC transcode output; (2) ABS serves whole files
-// only, so per-chapter cuts must happen here. The ABS token stays server-side.
+// Routes:
+//   GET  /transcode?item=&file=&fmt=mp3|m4a&start=&end=&key=
+//        -> one complete audio body (mp3, or AAC copied to ADTS) the watch stores.
+//           ffmpeg pulls the source from ABS over HTTP (Range-seekable) so it can
+//           demux .m4b/.mp4 and cut a chapter without reading the whole book.
+//   POST /progress?key=   body {itemId, currentTime, duration?}
+//        -> forwards a REAL PATCH to ABS /api/me/progress/:id. The watch can't:
+//           Monkey C has no PATCH method and ABS ignores X-HTTP-Method-Override.
 //
-// ffmpeg pulls the source straight from ABS over HTTP (NOT via a Node pipe) so
-// it can issue Range requests and SEEK. Seeking is required to demux .m4b/.mp4
-// (whose moov index is usually at end-of-file) and to cut a chapter without
-// reading the whole book. mp3/flac/opus stream fine this way too.
-// (Note: the ABS token is passed to ffmpeg via -headers, so it is visible in
-// this host's process list. That's acceptable for a localhost-only sidecar.)
+// The ABS token stays server-side. Every ABS call sends a normal User-Agent so a
+// Cloudflare/WAF in front of ABS doesn't 403 it as a bot.
 
 import http from 'node:http';
 import { spawn } from 'node:child_process';
 import { pipeline } from 'node:stream/promises';
 
-const ABS         = (process.env.ABS_URL || '').replace(/\/+$/, ''); // e.g. https://abs.example.com
-const ABS_TOKEN   = process.env.ABS_TOKEN;    // ABS long-lived API key (download permission)
+const ABS         = (process.env.ABS_URL || '').replace(/\/+$/, ''); // prefer internal, e.g. http://127.0.0.1:13378
+const ABS_TOKEN   = process.env.ABS_TOKEN;    // ABS long-lived API key
 const SIDECAR_KEY = process.env.SIDECAR_KEY;  // shared secret the watch must send
 const PORT        = Number(process.env.PORT || 8081);
+const UA          = 'WatchShelf-sidecar';
 
 if (!ABS || !ABS_TOKEN || !SIDECAR_KEY) {
   console.error('Missing env: ABS_URL, ABS_TOKEN, SIDECAR_KEY are required. See .env.example');
@@ -32,65 +32,81 @@ if (!ABS || !ABS_TOKEN || !SIDECAR_KEY) {
 // Content-Type must match the watch's declared :mediaEncoding.
 const CT = { mp3: 'audio/mpeg', m4a: 'audio/aac' };
 
-// Build ffmpeg args. Input options (auth header, reconnect, input-side seek)
-// MUST precede -i. Input-side -ss is fast (Range-based) and accurate enough for
-// spoken word. mp3 (default) transcodes; m4a copies AAC to ADTS (no re-encode).
 function ffArgs(srcUrl, fmt, start, end) {
   const args = ['-hide_banner', '-loglevel', 'error',
+    '-user_agent', UA,
     '-headers', `Authorization: Bearer ${ABS_TOKEN}\r\n`,
     '-reconnect', '1', '-reconnect_streamed', '1', '-reconnect_delay_max', '2'];
-  if (start != null) { args.push('-ss', String(start)); }         // seek before decoding
+  if (start != null) { args.push('-ss', String(start)); }
   args.push('-i', srcUrl);
   if (start != null && end != null) { args.push('-t', String(Math.max(0, Number(end) - Number(start)))); }
   else if (end != null)            { args.push('-to', String(end)); }
-
   if (fmt === 'm4a') {
-    // Lossless AAC -> ADTS.
-    args.push('-map', '0:a:0', '-c:a', 'copy', '-f', 'adts', 'pipe:1');
+    args.push('-map', '0:a:0', '-c:a', 'copy', '-f', 'adts', 'pipe:1');       // lossless AAC -> ADTS
   } else {
-    // Transcode to 64k mono MP3 (spoken-word sweet spot, ~28 MB/hour).
     args.push('-map', '0:a:0', '-c:a', 'libmp3lame', '-b:a', '64k', '-ac', '1', '-ar', '22050', '-f', 'mp3', 'pipe:1');
   }
   return args;
 }
 
-const server = http.createServer(async (req, res) => {
-  const u = new URL(req.url, 'http://x');
-  if (u.pathname !== '/transcode') { res.writeHead(404).end(); return; }
+function transcode(req, res, u) {
   if (u.searchParams.get('key') !== SIDECAR_KEY) { res.writeHead(401).end(); return; }
-
   const item  = u.searchParams.get('item');
   const file  = u.searchParams.get('file');
   const fmt   = (u.searchParams.get('fmt') || 'mp3').toLowerCase();
   const start = u.searchParams.get('start');
   const end   = u.searchParams.get('end');
-
-  // Validate + whitelist to avoid SSRF/path abuse. item/file feed the ABS URL;
-  // start/end feed ffmpeg -ss/-t, so keep them numeric.
   if (!item || !file || !CT[fmt] || !/^[A-Za-z0-9_\-]+$/.test(item) || !/^[0-9]+$/.test(file)) {
     res.writeHead(400).end('bad params'); return;
   }
   if ((start != null && !/^[0-9]+$/.test(start)) || (end != null && !/^[0-9]+$/.test(end))) {
     res.writeHead(400).end('bad range'); return;
   }
-
-  // ffmpeg fetches from ABS itself (server-side auth) and seeks via Range.
   const srcUrl = `${ABS}/api/items/${encodeURIComponent(item)}/file/${encodeURIComponent(file)}/download`;
   const ff = spawn('ffmpeg', ffArgs(srcUrl, fmt, start, end), { stdio: ['ignore', 'pipe', 'inherit'] });
-
   res.writeHead(200, { 'Content-Type': CT[fmt], 'Cache-Control': 'no-store' });
   ff.on('error', () => { if (!res.writableEnded) res.destroy(); });
-  req.on('close', () => { ff.kill('SIGKILL'); }); // watch aborted the download -> stop ffmpeg
+  req.on('close', () => { ff.kill('SIGKILL'); }); // watch aborted -> stop ffmpeg
+  pipeline(ff.stdout, res).catch(() => { ff.kill('SIGKILL'); if (!res.writableEnded) res.destroy(); });
+}
 
-  try {
-    await pipeline(ff.stdout, res);
-  } catch (e) {
-    ff.kill('SIGKILL');
-    if (!res.writableEnded) res.destroy();
-  }
+function readJson(req, cb) {
+  let b = '', over = false;
+  req.on('data', (c) => { b += c; if (b.length > 65536) { over = true; req.destroy(); } });
+  req.on('end', () => { if (over) { return cb(null); } try { cb(JSON.parse(b || '{}')); } catch (e) { cb(null); } });
+  req.on('error', () => cb(null));
+}
+
+function progress(req, res, u) {
+  if (u.searchParams.get('key') !== SIDECAR_KEY) { res.writeHead(401).end(); return; }
+  readJson(req, async (body) => {
+    if (!body || typeof body.itemId !== 'string' || !/^[A-Za-z0-9_\-]+$/.test(body.itemId)
+        || typeof body.currentTime !== 'number') { res.writeHead(400).end('bad body'); return; }
+    const payload = { currentTime: body.currentTime };
+    if (typeof body.duration === 'number' && body.duration > 0) {
+      payload.duration = body.duration;
+      payload.progress = Math.min(1, body.currentTime / body.duration);
+    }
+    try {
+      const abs = await fetch(`${ABS}/api/me/progress/${encodeURIComponent(body.itemId)}`, {
+        method: 'PATCH',
+        headers: { 'Authorization': `Bearer ${ABS_TOKEN}`, 'Content-Type': 'application/json', 'User-Agent': UA },
+        body: JSON.stringify(payload),
+      });
+      res.writeHead(abs.ok ? 200 : 502).end(abs.ok ? 'OK' : `ABS ${abs.status}`);
+    } catch (e) {
+      res.writeHead(502).end('ABS unreachable');
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const u = new URL(req.url, 'http://x');
+  if (u.pathname === '/transcode' && req.method === 'GET')  { transcode(req, res, u); return; }
+  if (u.pathname === '/progress'  && req.method === 'POST') { progress(req, res, u);  return; }
+  res.writeHead(404).end();
 });
 
-// Bind localhost only; the reverse proxy is the public surface on :443.
 server.listen(PORT, '127.0.0.1', () => {
   console.log(`WatchShelf sidecar on http://127.0.0.1:${PORT} -> ${ABS}`);
 });

--- a/source/AbsApi.mc
+++ b/source/AbsApi.mc
@@ -82,42 +82,50 @@ module AbsApi {
             callback);
     }
 
-    // ---- per-file playback decision ---------------------------------------
-
-    // ABS mimeType is derived from container format and can be misleading, so we
-    // decide from codec + ext. mp3/aac in mp3/m4a/m4b/mp4 => the watch can play
-    // the byte-exact file, so direct-download from ABS. Everything else
-    // (flac/opus/vorbis/wma/...) must be transcoded by the sidecar to mp3.
-    function fileIsDirectPlayable(audioFile) {
+    // ---- per-file playback decision (codec-based) --------------------------
+    // MP3   -> direct-download from ABS (byte-exact, Garmin plays it; no sidecar).
+    // AAC   (aac/m4a/m4b/mp4) -> sidecar copies the AAC stream to ADTS (lossless,
+    //        no re-encode) which Garmin plays via ENCODING_ADTS.
+    // other (flac/opus/...)   -> sidecar transcodes to mp3.
+    function fileIsMp3(audioFile) {
         var codec = _lower(audioFile["codec"]);
-        var ext   = _lower(_ext(audioFile));
-        var codecOk = (codec != null) && (codec.equals("mp3") || codec.equals("aac"));
-        var extOk = (ext != null) &&
-                    (ext.equals(".mp3") || ext.equals(".m4a") || ext.equals(".m4b") || ext.equals(".mp4"));
-        return codecOk && extOk;
+        return (codec != null) && codec.equals("mp3");
+    }
+    function fileIsAac(audioFile) {
+        var codec = _lower(audioFile["codec"]);
+        return (codec != null) && (codec.equals("aac") || codec.equals("m4a") || codec.equals("mp4a"));
     }
 
-    // Media.ENCODING_* the watch should declare for a direct-download of this
-    // file. mp3 => MP3, aac/m4a/m4b => M4A. Sidecar output is always mp3.
-    function encodingType(audioFile) {
-        var ext = _lower(_ext(audioFile));
-        if ((ext != null) && ext.equals(".mp3")) { return "mp3"; }
-        return "m4a";
+    // Download URL + declared encoding for one whole audio FILE (= one track).
+    function fileTrackUrl(itemId, audioFile) {
+        var ino = audioFile["ino"];
+        if (fileIsMp3(audioFile)) { return directFileUrl(itemId, ino); }
+        if (fileIsAac(audioFile)) { return sidecarFileUrl(itemId, ino, "m4a"); }
+        return sidecarFileUrl(itemId, ino, "mp3");
+    }
+    function fileTrackType(audioFile) {
+        if (fileIsMp3(audioFile)) { return "mp3"; }
+        if (fileIsAac(audioFile)) { return "adts"; }
+        return "mp3";
     }
 
-    // ---- URL builders (one URL per CHAPTER) --------------------------------
+    // ---- URL builders ------------------------------------------------------
 
-    // Direct ABS download of a whole audio file. Token goes in the query string
+    // Direct ABS download of a whole audio file (mp3). Token in the query string
     // because makeWebRequest audio downloads are simplest with ?token=.
     // :fileid in the ABS route == the audioFile ino.
     function directFileUrl(itemId, ino) {
         return serverUrl() + "/api/items/" + itemId + "/file/" + ino + "/download?token=" + apiKey();
     }
 
-    // Sidecar chapter cut: returns a small, complete mp3 for exactly one chapter
-    // so the user gets true chapter navigation and small transfers. The sidecar
-    // holds the ABS token server-side; the watch authenticates with sidecarKey.
-    // start/end are truncated to integer seconds (fine for a chapter cut).
+    // Sidecar whole-file convert: fmt=m4a copies AAC -> ADTS; fmt=mp3 transcodes.
+    function sidecarFileUrl(itemId, ino, fmt) {
+        return sidecarUrl() + "/transcode?item=" + itemId + "&file=" + ino
+            + "&fmt=" + fmt + "&key=" + sidecarKey();
+    }
+
+    // Sidecar chapter cut: a small complete mp3 for exactly one chapter of a
+    // SINGLE-file book, for real chapter navigation. start/end -> integer seconds.
     function sidecarChapterUrl(itemId, ino, startSec, endSec) {
         return sidecarUrl() + "/transcode"
             + "?item=" + itemId
@@ -139,28 +147,21 @@ module AbsApi {
         return 0;
     }
 
-    // ABS wants PATCH /api/me/progress/:libraryItemId, but Monkey C's
-    // Communications has NO HTTP_REQUEST_METHOD_PATCH (only GET/PUT/POST/DELETE).
-    // We POST with an X-HTTP-Method-Override: PATCH header, which Express
-    // method-override middleware honours. If your ABS build does not honour the
-    // override header, either enable method-override on the proxy or route
-    // progress through the sidecar. (Flagged in apiConcerns.)
-    // currentTime is book-absolute seconds. 200 with EMPTY body on success.
+    // Progress sync goes through the SIDECAR. ABS's endpoint is PATCH
+    // /api/me/progress/:id, but Monkey C's Communications has NO PATCH method
+    // (only GET/POST/PUT/DELETE) and ABS ignores X-HTTP-Method-Override (verified
+    // against the live server: POST -> 404). So the watch POSTs to the sidecar,
+    // which issues the real PATCH to ABS server-side. If the sidecar isn't
+    // configured, progress is skipped silently. currentTime is book-absolute sec.
     function patchProgress(itemId, currentTimeSec, durationSec) {
-        var params = { "currentTime" => currentTimeSec };
-        if (durationSec != null) {
-            params["duration"] = durationSec;
-            if (durationSec > 0) {
-                params["progress"] = currentTimeSec.toFloat() / durationSec.toFloat();
-            }
-        }
+        if ((sidecarUrl() == null) || (sidecarKey() == null)) { return; }
+        var params = { "itemId" => itemId, "currentTime" => currentTimeSec };
+        if (durationSec != null) { params["duration"] = durationSec; }
         Communications.makeWebRequest(
-            serverUrl() + "/api/me/progress/" + itemId,
+            sidecarUrl() + "/progress?key=" + sidecarKey(),
             params,
             { :method => Communications.HTTP_REQUEST_METHOD_POST,
-              :headers => { "Authorization"          => "Bearer " + apiKey(),
-                            "X-HTTP-Method-Override" => "PATCH",
-                            "Content-Type"           => Communications.REQUEST_CONTENT_TYPE_JSON },
+              :headers => { "Content-Type" => Communications.REQUEST_CONTENT_TYPE_JSON },
               :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON },
             new AbsProgressListener().method(:onResponse));
     }

--- a/source/BookMenuDelegate.mc
+++ b/source/BookMenuDelegate.mc
@@ -3,8 +3,8 @@ using Toybox.Communications;
 using Toybox.System;
 using Toybox.WatchUi;
 
-// Picked a book -> fetch detail, queue every chapter as its own track, then ask
-// the system to run a sync (background download).
+// Picked a book -> fetch detail, queue its tracks (one per audio FILE, or one per
+// chapter for a single-file chaptered book), then run a background sync.
 class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
 
     function initialize() {
@@ -16,8 +16,6 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
         AbsApi.getItemDetail(itemId, method(:onDetail));
     }
 
-    // Build one track per chapter. If the book has no chapters, treat the whole
-    // book as a single chapter/track.
     function onDetail(code, data) {
         if (code != 200 || data == null || data["media"] == null) {
             WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errDetail) + "\n(" + code + ")"),
@@ -39,46 +37,64 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
             return;
         }
 
-        // For a first version we key every chapter off the FIRST audio file's ino.
-        // Multi-file books whose chapters span files are a known limitation
-        // (documented in README / apiConcerns).
-        var primary = audioFiles[0];
-        var ino = primary["ino"];
-        var direct = AbsApi.fileIsDirectPlayable(primary);
-
         var syncList = Application.Storage.getValue(Store.SYNC_LIST);
         if (syncList == null) { syncList = {}; }
 
-        if (chapters == null || chapters.size() == 0) {
-            // Whole-book single track.
-            var url = direct ? AbsApi.directFileUrl(itemId, ino)
-                             : AbsApi.sidecarChapterUrl(itemId, ino, 0, safeDuration(primary));
-            var type = direct ? AbsApi.encodingType(primary) : "mp3";
-            syncList[itemId + ":0"] = trackInfo(url, title, type, itemId, 0);
-        } else {
+        if (audioFiles.size() == 1 && chapters != null && chapters.size() > 0) {
+            // Single-file book WITH chapters: one sidecar-cut track per chapter,
+            // for small downloads and real chapter navigation.
+            var ino = audioFiles[0]["ino"];
             for (var i = 0; i < chapters.size(); ++i) {
                 var ch = chapters[i];
                 var start = numOr(ch["start"], 0);
                 var end = numOr(ch["end"], start);
                 var chTitle = ch["title"];
                 if (chTitle == null) { chTitle = "Chapter " + (i + 1); }
-                // Per-chapter cuts always go through the sidecar (fmt=mp3) so we
-                // get a small, complete, seekable file per chapter. ABS itself
-                // only serves whole files, so we cannot direct-download a slice.
                 var chUrl = AbsApi.sidecarChapterUrl(itemId, ino, start, end);
-                syncList[itemId + ":" + i] = trackInfo(chUrl, chTitle, "mp3", itemId, start);
+                syncList[itemId + ":c" + i] = trackInfo(chUrl, chTitle, "mp3", itemId, start);
+            }
+        } else {
+            // One track per audio FILE. Handles multi-file books (the common case
+            // in a real ABS library) and single-file no-chapter books. Book-
+            // absolute start = running sum of prior file durations, so progress
+            // maps back to ABS correctly.
+            var files = sortByIndex(audioFiles);
+            var offset = 0;
+            for (var i = 0; i < files.size(); ++i) {
+                var af = files[i];
+                var url = AbsApi.fileTrackUrl(itemId, af);
+                var type = AbsApi.fileTrackType(af);
+                var partTitle = (files.size() > 1) ? (title + " - Part " + (i + 1)) : title;
+                syncList[itemId + ":f" + i] = trackInfo(url, partTitle, type, itemId, offset);
+                offset = offset + numOr(af["duration"], 0);
             }
         }
 
         Application.Storage.setValue(Store.SYNC_LIST, syncList);
-
-        // Log the saved resume position for debugging; native player resumes at
-        // chapter boundaries.
         System.println("Resume position (s): " + AbsApi.progressSeconds(data));
 
-        // Confirm and kick off the background sync.
         WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.queued)), null, WatchUi.SLIDE_LEFT);
         Communications.startSync();
+    }
+
+    // Sort audio files by their ABS `index` (file order), tolerating a missing
+    // index. Plain-statement insertion sort (Array.add returns Void in Monkey C).
+    function sortByIndex(files) {
+        var out = [];
+        for (var i = 0; i < files.size(); ++i) {
+            var af = files[i];
+            var idx = numOr(af["index"], i);
+            var pos = out.size();
+            for (var j = 0; j < out.size(); ++j) {
+                if (idx < numOr(out[j]["index"], j)) { pos = j; break; }
+            }
+            var rebuilt = new [out.size() + 1];
+            for (var k = 0; k < pos; ++k) { rebuilt[k] = out[k]; }
+            rebuilt[pos] = af;
+            for (var k = pos; k < out.size(); ++k) { rebuilt[k + 1] = out[k]; }
+            out = rebuilt;
+        }
+        return out;
     }
 
     function trackInfo(url, title, type, itemId, start) {
@@ -90,10 +106,6 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
             TrackInfo.START    => start,
             TrackInfo.CAN_SKIP => true
         };
-    }
-
-    function safeDuration(audioFile) {
-        return numOr(audioFile["duration"], 0);
     }
 
     function numOr(v, dflt) {


### PR DESCRIPTION
## Real-server-validated v2

Validated WatchShelf's ABS client + sidecar against a **live Audiobookshelf**
(v2.35.1, behind Cloudflare) and fixed everything the real data exposed.

### Fixed
- **Progress sync via sidecar** — Monkey C 9.2 has no `PATCH` and ABS ignores
  `X-HTTP-Method-Override` (POST → 404). New **`POST /progress`** sidecar route
  forwards a real PATCH server-side. **Verified: ABS `currentTime` updates.**
- **Multi-file books** — `BookMenuDelegate` now creates **one track per audio
  file** (real libraries are multi-file), with per-chapter tracks kept only for
  single-file chaptered books. Book-absolute offsets preserved for progress.
- **Codec routing** — mp3 → direct; aac/m4b → sidecar lossless **AAC→ADTS** copy;
  flac/opus → sidecar mp3.
- **Cloudflare** — sidecar sends a User-Agent on all ABS calls and prefers ABS's
  internal URL (CF 403s bot-like UAs).

### Verified end-to-end against the live server
| Check | Result |
|---|---|
| auth + libraries/items/item-detail shapes | ✅ match the client |
| direct MP3 download (`?token=`) | ✅ `206 audio/mpeg` |
| m4b → ADTS convert | ✅ `200 audio/aac` |
| `/progress` forwarder | ✅ ABS `currentTime` updated on read-back |
| auth guards (wrong key) | ✅ `401` |

### Still device-only
On-watch native playback (incl. ADTS), and confirming the watch's UA passes
Cloudflare (low risk — a `Garmin`/empty UA passed in testing).

App compiles clean for `fenix847mm` on SDK 9.2.0.

🧙 Built with [WOZCODE](https://wozcode.com)
