### PR TITLE
feat: browse by author / series / collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It auths with the watch's own ABS token, so there's nothing extra to configure.
  Watch (WatchShelf, Monkey C)
   |  on-watch login: server URL + username + password -> ABS token (stored; pw discarded)
   |
-  |-- browse:   GET  {server}/watchshelf-transcode/list?lib      -> all books (lean)
+  |-- browse:   GET  {server}/watchshelf-transcode/{list|authors|series|collections} -> lean lists
   |-- open:     GET  {server}/watchshelf-transcode/files?item    -> the book's files (lean)
   |-- queue:    split each file into 30-min chunks
   |-- sync:     GET  {server}/watchshelf-transcode/transcode?item&file&start&end -> mp3 chunk
@@ -61,7 +61,8 @@ make build            # -> bin/WatchShelf.prg for the Tactix 8 Solar (fenix8sola
 Sideload `bin/WatchShelf.prg` to the watch's `GARMIN/APPS/` (the tactix 8 is MTP on
 macOS — use OpenMTP or Android File Transfer; power-cycle the watch if a client can't
 see it). WatchShelf appears under the watch's **Music / audio providers**. Open it →
-**Log in** → **Browse library** → pick a book → it downloads in chunks.
+**Log in** → **Browse library** → **All books / By author / By series / By
+collection** → pick a book → it downloads in chunks.
 
 ## Known limitations
 

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -35,4 +35,9 @@
     <string id="fieldServer">Server URL</string>
     <string id="fieldUser">Username</string>
     <string id="fieldPass">Password</string>
+    <string id="allBooks">All books</string>
+    <string id="byAuthor">By author</string>
+    <string id="bySeries">By series</string>
+    <string id="byCollection">By collection</string>
+    <string id="errNone">None found</string>
 </strings>

--- a/sidecar/server.js
+++ b/sidecar/server.js
@@ -1,19 +1,18 @@
 // WatchShelf sidecar. The watch can't download giant audiobook files whole, so
 // this cuts small on-demand chunks with ffmpeg (via HTTP Range - it never pulls
-// the whole file), and serves a lean file list for books whose ABS detail is too
-// big for the watch to accept.
-//
-// Auth: the watch passes its OWN ABS token as ?token=, which the sidecar uses to
-// read from ABS - no separate secret to configure. The only required env is
-// ABS_URL (point it at ABS's INTERNAL address to bypass Cloudflare, e.g.
-// http://127.0.0.1:13378).
+// the whole file), and serves lean lists (books, authors, series, collections,
+// per-book files) so nothing overflows the watch. Auth = the watch's own ABS
+// token (?token=). Only required env: ABS_URL.
 //
 // Routes:
 //   GET /health
-//   GET /files?item=<id>&token=<absToken>
-//        -> {"title":"...","files":[{"ino":N,"duration":S,"size":B,"codec":"mp3"}]}
-//   GET /transcode?item=<id>&file=<ino>&fmt=mp3|m4a&start=<s>&end=<s>&token=<absToken>
-//        -> a small mp3 (or ADTS) chunk.
+//   GET /list?lib&token[&author=id|&series=id|&collection=id]  -> {books:[{id,title,author}]}
+//   GET /authors?lib&token       -> {authors:[{id,name,count}]}
+//   GET /series?lib&token        -> {series:[{id,name,count}]}
+//   GET /collections?lib&token   -> {collections:[{id,name}]}
+//   GET /files?item&token        -> {title,files:[{ino,duration,size,codec}]}
+//   GET /transcode?item&file&fmt&start&end&token -> a small mp3 chunk
+//   POST /progress?token  {itemId,currentTime,duration} -> real PATCH to ABS
 
 import http from 'node:http';
 import { spawn } from 'node:child_process';
@@ -24,8 +23,11 @@ const PORT = Number(process.env.PORT || 8081);
 const UA   = 'WatchShelf-sidecar';
 if (!ABS) { console.error('ABS_URL is required (e.g. http://127.0.0.1:13378)'); process.exit(1); }
 
-const CT  = { mp3: 'audio/mpeg', m4a: 'audio/aac' };
+const CT   = { mp3: 'audio/mpeg', m4a: 'audio/aac' };
 const IDRE = /^[A-Za-z0-9_\-]+$/, NUM = /^[0-9]+$/;
+const b64  = (s) => Buffer.from(String(s)).toString('base64');
+const bearer = (t) => ({ Authorization: `Bearer ${t}`, 'User-Agent': UA });
+const jsonHead = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
 
 function ffArgs(srcUrl, token, fmt, start, end) {
   const a = ['-hide_banner', '-loglevel', 'error', '-user_agent', UA,
@@ -55,40 +57,59 @@ function transcode(req, res, u) {
   pipeline(ff.stdout, res).catch(() => { ff.kill('SIGKILL'); if (!res.writableEnded) res.destroy(); });
 }
 
-async function files(req, res, u) {
-  const item = u.searchParams.get('item'), token = u.searchParams.get('token');
-  if (!item || !token || !IDRE.test(item)) { res.writeHead(400).end('bad params'); return; }
-  try {
-    const r = await fetch(`${ABS}/api/items/${encodeURIComponent(item)}?expanded=1`,
-      { headers: { Authorization: `Bearer ${token}`, 'User-Agent': UA } });
-    if (!r.ok) { res.writeHead(502).end('ABS ' + r.status); return; }
-    const d = await r.json();
-    const m = d.media || {};
-    const out = {
-      title: (m.metadata || {}).title || 'Book',
-      files: (m.audioFiles || []).map((a) => ({
-        ino: a.ino, duration: a.duration, size: (a.metadata || {}).size || a.size || 0, codec: a.codec,
-      })),
-    };
-    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }).end(JSON.stringify(out));
-  } catch (e) { res.writeHead(502).end('ABS unreachable'); }
+const bookOf = (it) => ({
+  id: it.id,
+  title: ((it.media || {}).metadata || {}).title || '?',
+  author: ((it.media || {}).metadata || {}).authorName || '',
+});
+
+async function absJson(path, token) {
+  const r = await fetch(`${ABS}${path}`, { headers: bearer(token) });
+  if (!r.ok) { const e = new Error('ABS ' + r.status); e.status = r.status; throw e; }
+  return r.json();
 }
 
 async function list(req, res, u) {
   const lib = u.searchParams.get('lib'), token = u.searchParams.get('token');
+  const author = u.searchParams.get('author'), series = u.searchParams.get('series'), collection = u.searchParams.get('collection');
   if (!lib || !token || !IDRE.test(lib)) { res.writeHead(400).end('bad params'); return; }
   try {
-    const r = await fetch(`${ABS}/api/libraries/${encodeURIComponent(lib)}/items?minified=1&limit=1000&sort=media.metadata.title`,
-      { headers: { Authorization: `Bearer ${token}`, 'User-Agent': UA } });
-    if (!r.ok) { res.writeHead(502).end('ABS ' + r.status); return; }
-    const d = await r.json();
-    const out = (d.results || []).map((it) => ({
-      id: it.id,
-      title: ((it.media || {}).metadata || {}).title || '?',
-      author: ((it.media || {}).metadata || {}).authorName || '',
-    }));
-    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }).end(JSON.stringify({ books: out }));
-  } catch (e) { res.writeHead(502).end('ABS unreachable'); }
+    let books;
+    if (collection && IDRE.test(collection)) {
+      books = ((await absJson(`/api/collections/${encodeURIComponent(collection)}`, token)).books || []).map(bookOf);
+    } else {
+      let filter = '';
+      if (author && IDRE.test(author)) { filter = `&filter=authors.${b64(author)}`; }
+      else if (series && IDRE.test(series)) { filter = `&filter=series.${b64(series)}`; }
+      books = ((await absJson(`/api/libraries/${encodeURIComponent(lib)}/items?minified=1&limit=1000&sort=media.metadata.title${filter}`, token)).results || []).map(bookOf);
+    }
+    res.writeHead(200, jsonHead).end(JSON.stringify({ books }));
+  } catch (e) { res.writeHead(502).end(String(e.message || 'ABS')); }
+}
+
+async function groups(req, res, u, path, map) {
+  const lib = u.searchParams.get('lib'), token = u.searchParams.get('token');
+  if (!lib || !token || !IDRE.test(lib)) { res.writeHead(400).end('bad params'); return; }
+  try {
+    const d = await absJson(`/api/libraries/${encodeURIComponent(lib)}/${path}`, token);
+    res.writeHead(200, jsonHead).end(JSON.stringify(map(d)));
+  } catch (e) { res.writeHead(502).end(String(e.message || 'ABS')); }
+}
+const authors     = (q, s, u) => groups(q, s, u, 'authors', (d) => ({ authors: (d.authors || []).map((a) => ({ id: a.id, name: a.name, count: a.numBooks })).sort((x, y) => String(x.name).localeCompare(String(y.name))) }));
+const series      = (q, s, u) => groups(q, s, u, 'series?limit=1000', (d) => ({ series: (d.results || []).map((x) => ({ id: x.id, name: x.name, count: (x.books || []).length })) }));
+const collections = (q, s, u) => groups(q, s, u, 'collections', (d) => ({ collections: (d.results || []).map((c) => ({ id: c.id, name: c.name })) }));
+
+async function files(req, res, u) {
+  const item = u.searchParams.get('item'), token = u.searchParams.get('token');
+  if (!item || !token || !IDRE.test(item)) { res.writeHead(400).end('bad params'); return; }
+  try {
+    const m = (await absJson(`/api/items/${encodeURIComponent(item)}?expanded=1`, token)).media || {};
+    const out = {
+      title: (m.metadata || {}).title || 'Book',
+      files: (m.audioFiles || []).map((a) => ({ ino: a.ino, duration: a.duration, size: (a.metadata || {}).size || a.size || 0, codec: a.codec })),
+    };
+    res.writeHead(200, jsonHead).end(JSON.stringify(out));
+  } catch (e) { res.writeHead(502).end(String(e.message || 'ABS')); }
 }
 
 function readJson(req, cb) {
@@ -107,7 +128,7 @@ function progress(req, res, u) {
     if (typeof body.duration === 'number' && body.duration > 0) { payload.duration = body.duration; payload.progress = Math.min(1, body.currentTime / body.duration); }
     try {
       const r = await fetch(`${ABS}/api/me/progress/${encodeURIComponent(body.itemId)}`,
-        { method: 'PATCH', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': UA }, body: JSON.stringify(payload) });
+        { method: 'PATCH', headers: { ...bearer(token), 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
       res.writeHead(r.ok ? 200 : 502).end(r.ok ? 'ok' : 'ABS ' + r.status);
     } catch (e) { res.writeHead(502).end('ABS unreachable'); }
   });
@@ -115,11 +136,15 @@ function progress(req, res, u) {
 
 const server = http.createServer((req, res) => {
   const u = new URL(req.url, 'http://x');
-  if (u.pathname === '/health') { res.writeHead(200).end('ok'); return; }
-  if (u.pathname === '/list'      && req.method === 'GET') { list(req, res, u); return; }
-  if (u.pathname === '/files'     && req.method === 'GET') { files(req, res, u); return; }
-  if (u.pathname === '/transcode' && req.method === 'GET') { transcode(req, res, u); return; }
-  if (u.pathname === '/progress'  && req.method === 'POST') { progress(req, res, u); return; }
+  const p = u.pathname, g = req.method === 'GET';
+  if (p === '/health') { res.writeHead(200).end('ok'); return; }
+  if (p === '/list'        && g) { list(req, res, u); return; }
+  if (p === '/authors'     && g) { authors(req, res, u); return; }
+  if (p === '/series'      && g) { series(req, res, u); return; }
+  if (p === '/collections' && g) { collections(req, res, u); return; }
+  if (p === '/files'       && g) { files(req, res, u); return; }
+  if (p === '/transcode'   && g) { transcode(req, res, u); return; }
+  if (p === '/progress'    && req.method === 'POST') { progress(req, res, u); return; }
   res.writeHead(404).end();
 });
 const BIND = process.env.BIND || '127.0.0.1';

--- a/source/AbsApi.mc
+++ b/source/AbsApi.mc
@@ -47,15 +47,30 @@ module AbsApi {
     // lists and cuts small on-demand chunks. Auth is the watch's own ABS token.
     function sidecarBase() { return serverUrl() + "/watchshelf-transcode"; }
 
-    // GET /list -> { books: [{id, title, author}] } (all books, tiny).
-    function getBookList(libId, cb) {
+    // GET /list -> { books: [{id, title, author}] }. filterType is
+    // "author"/"series"/"collection" (with filterId), or null for all books.
+    function getBookList(libId, filterType, filterId, cb) {
+        var params = { "lib" => libId, "token" => authToken() };
+        if (filterType != null && filterId != null) { params[filterType] = filterId; }
         Communications.makeWebRequest(
-            sidecarBase() + "/list",
+            sidecarBase() + "/list", params,
+            { :method => Communications.HTTP_REQUEST_METHOD_GET,
+              :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON },
+            cb);
+    }
+
+    // Lean group lists for browse-by: /authors, /series, /collections.
+    function getGroups(path, libId, cb) {
+        Communications.makeWebRequest(
+            sidecarBase() + path,
             { "lib" => libId, "token" => authToken() },
             { :method => Communications.HTTP_REQUEST_METHOD_GET,
               :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON },
             cb);
     }
+    function getAuthors(libId, cb)     { getGroups("/authors", libId, cb); }
+    function getSeries(libId, cb)      { getGroups("/series", libId, cb); }
+    function getCollections(libId, cb) { getGroups("/collections", libId, cb); }
 
     // GET /files -> { title, files: [{ino, duration, size, codec}] } (tiny).
     function getFiles(itemId, cb) {

--- a/source/Browse.mc
+++ b/source/Browse.mc
@@ -1,0 +1,72 @@
+using Toybox.WatchUi;
+
+// Browse entry: All books / By author / By series / By collection. Group lists
+// come from the sidecar (lean); picking one shows a filtered book list that flows
+// into the normal download path (BookMenuDelegate).
+module Browse {
+    function start(libId) {
+        var m = new WatchUi.Menu2({ :title => WatchUi.loadResource(Rez.Strings.browseLibrary) });
+        m.addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.allBooks), null, "all", null));
+        m.addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.byAuthor), null, "authors", null));
+        m.addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.bySeries), null, "series", null));
+        m.addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.byCollection), null, "collections", null));
+        WatchUi.pushView(m, new BrowseDelegate(libId), WatchUi.SLIDE_LEFT);
+    }
+
+    // Build + push a book menu from { books:[{id,title,author}] }.
+    function showBooks(code, data) {
+        if (code != 200 || data == null || data["books"] == null || data["books"].size() == 0) {
+            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errItems) + "\n(" + code + ")"),
+                null, WatchUi.SLIDE_LEFT);
+            return;
+        }
+        var books = data["books"];
+        var m = new WatchUi.Menu2({ :title => WatchUi.loadResource(Rez.Strings.pickBook) });
+        for (var i = 0; i < books.size(); ++i) {
+            var b = books[i];
+            m.addItem(new WatchUi.MenuItem(b["title"], b["author"], b["id"], null));
+        }
+        WatchUi.pushView(m, new BookMenuDelegate(), WatchUi.SLIDE_LEFT);
+    }
+}
+
+class BrowseDelegate extends WatchUi.Menu2InputDelegate {
+    private var mLib;
+    function initialize(libId) { Menu2InputDelegate.initialize(); mLib = libId; }
+    function onSelect(item) {
+        var mode = item.getId();
+        if (mode.equals("all")) { AbsApi.getBookList(mLib, null, null, method(:onBooks)); }
+        else if (mode.equals("authors")) { AbsApi.getAuthors(mLib, method(:onAuthors)); }
+        else if (mode.equals("series")) { AbsApi.getSeries(mLib, method(:onSeries)); }
+        else { AbsApi.getCollections(mLib, method(:onCollections)); }
+    }
+    function onBooks(code, data) { Browse.showBooks(code, data); }
+    function onAuthors(code, data)     { pushGroups(code, data, "authors", "author"); }
+    function onSeries(code, data)      { pushGroups(code, data, "series", "series"); }
+    function onCollections(code, data) { pushGroups(code, data, "collections", "collection"); }
+
+    function pushGroups(code, data, key, filterType) {
+        if (code != 200 || data == null || data[key] == null || data[key].size() == 0) {
+            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errNone)), null, WatchUi.SLIDE_LEFT);
+            return;
+        }
+        var groups = data[key];
+        var m = new WatchUi.Menu2({ :title => WatchUi.loadResource(Rez.Strings.browseLibrary) });
+        for (var i = 0; i < groups.size(); ++i) {
+            var g = groups[i];
+            var sub = (g["count"] != null) ? (g["count"].toString() + " books") : null;
+            m.addItem(new WatchUi.MenuItem(g["name"], sub, g["id"], null));
+        }
+        WatchUi.pushView(m, new GroupDelegate(mLib, filterType), WatchUi.SLIDE_LEFT);
+    }
+    function onBack() { WatchUi.popView(WatchUi.SLIDE_RIGHT); }
+}
+
+class GroupDelegate extends WatchUi.Menu2InputDelegate {
+    private var mLib;
+    private var mType;
+    function initialize(libId, filterType) { Menu2InputDelegate.initialize(); mLib = libId; mType = filterType; }
+    function onSelect(item) { AbsApi.getBookList(mLib, mType, item.getId(), method(:onBooks)); }
+    function onBooks(code, data) { Browse.showBooks(code, data); }
+    function onBack() { WatchUi.popView(WatchUi.SLIDE_RIGHT); }
+}

--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -36,7 +36,7 @@ module Versions {
     const current = V1;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b10";
+    const tag = "b11";
 }
 
 // Keys for a TrackInfo dict (one downloaded/queued CHAPTER = one Media track).

--- a/source/LibraryMenuDelegate.mc
+++ b/source/LibraryMenuDelegate.mc
@@ -1,32 +1,8 @@
 using Toybox.WatchUi;
 
-// Picked a library -> get the lean book list from the sidecar, show all books.
+// Picked a library -> show the browse-mode menu (all / author / series / collection).
 class LibraryMenuDelegate extends WatchUi.Menu2InputDelegate {
-
-    function initialize() {
-        Menu2InputDelegate.initialize();
-    }
-
-    function onSelect(item) {
-        AbsApi.getBookList(item.getId(), method(:onList));
-    }
-
-    function onList(code, data) {
-        if ((code == 200) && (data != null) && (data["books"] != null)) {
-            var books = data["books"];
-            var menu = new WatchUi.Menu2({ :title => WatchUi.loadResource(Rez.Strings.pickBook) });
-            for (var i = 0; i < books.size(); ++i) {
-                var b = books[i];
-                menu.addItem(new WatchUi.MenuItem(b["title"], b["author"], b["id"], null));
-            }
-            WatchUi.pushView(menu, new BookMenuDelegate(), WatchUi.SLIDE_LEFT);
-        } else {
-            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errItems) + "\n(" + code + ")"),
-                null, WatchUi.SLIDE_LEFT);
-        }
-    }
-
-    function onBack() {
-        WatchUi.popView(WatchUi.SLIDE_RIGHT);
-    }
+    function initialize() { Menu2InputDelegate.initialize(); }
+    function onSelect(item) { Browse.start(item.getId()); }
+    function onBack() { WatchUi.popView(WatchUi.SLIDE_RIGHT); }
 }


### PR DESCRIPTION
## Browse by author / series / collection

The book list was flat "all books"; now picking a library offers **All books /
By author / By series / By collection**, then drills into a filtered book list
that flows into the normal chunked-download path.

- **Sidecar**: 3 new lean endpoints — `/authors`, `/series`, `/collections` — plus
  `/list` now accepts `&author=`, `&series=`, `&collection=` (ABS `filter=authors.<b64>`
  / `series.<b64>`, or the collection's books).
- **App**: `Browse.mc` (mode menu + group drill-down); `LibraryMenuDelegate` opens it.

### Validated against `books.jedibrooker.com`
19 authors, 9 series, 0 collections; `?author=` → 11 Banks books, `?series=` → 10
Culture books. Builds clean (`b11`) for `fenix8solar51mm`.

🧙 Built with [WOZCODE](https://wozcode.com)
