### PR TITLE
fix(sidecar): strip mount prefix so Cloudflare Tunnel works

### DIFF
--- a/sidecar/.env.example
+++ b/sidecar/.env.example
@@ -3,3 +3,4 @@
 ABS_URL=http://127.0.0.1:13378
 PORT=8081
 # BIND=127.0.0.1   # set 0.0.0.0 in Docker
+# BASE_PATH=/watchshelf-transcode  # prefix the sidecar strips; only change if you mount it elsewhere

--- a/sidecar/Caddyfile.snippet
+++ b/sidecar/Caddyfile.snippet
@@ -1,7 +1,12 @@
 # The watch calls https://<your-abs-domain>/watchshelf-transcode/... and the app
 # derives that path from the ABS server URL you logged in with. So this route must
 # live on WHATEVER fronts your Audiobookshelf domain (the same thing Cloudflare
-# points at). handle_path strips the prefix so the sidecar sees /list,/files,/transcode.
+# points at).
+#
+# The sidecar STRIPS the /watchshelf-transcode prefix itself (BASE_PATH), so it works
+# whether the proxy strips the prefix (Caddy handle_path / nginx trailing-slash) or
+# forwards it unchanged (Cloudflare Tunnel, which cannot rewrite paths). Just point the
+# route at the sidecar; no rewrite needed.
 #
 # --- Caddy (add inside your existing ABS site block) ---
 books.jedibrooker.com {
@@ -18,9 +23,23 @@ books.jedibrooker.com {
 #     proxy_read_timeout 600s;
 # }
 #
-# --- Cloudflare Tunnel (cloudflared config.yml ingress, BEFORE the ABS catch-all) ---
-# - hostname: books.jedibrooker.com
-#   path: /watchshelf-transcode/*
-#   service: http://127.0.0.1:8081
-# - hostname: books.jedibrooker.com
-#   service: http://127.0.0.1:13378
+# --- Cloudflare Tunnel (cloudflared) -------------------------------------------
+# cloudflared forwards the FULL path (it can't strip) - the sidecar strips it, so
+# just route the prefix to the sidecar. The path rule is a Go regexp, and the
+# prefixed rule MUST come BEFORE the ABS catch-all.
+#
+# config.yml (file-managed tunnel):
+#   ingress:
+#     - hostname: books.jedibrooker.com
+#       path: ^/watchshelf-transcode(/.*)?$
+#       service: http://127.0.0.1:8081        # the sidecar
+#     - hostname: books.jedibrooker.com
+#       service: http://127.0.0.1:13378       # your existing Audiobookshelf
+#     - service: http_status:404
+#
+# Dashboard-managed tunnel (Zero Trust > Networks > Tunnels > your tunnel >
+# Public Hostnames): add a hostname entry ABOVE the existing ABS one -
+#   Subdomain/Domain: books.jedibrooker.com   Path: watchshelf-transcode/*
+#   Service: HTTP  ->  localhost:8081
+# then Save. (If cloudflared runs in its own container, use the sidecar's
+# container name / host IP instead of localhost.)

--- a/sidecar/server.js
+++ b/sidecar/server.js
@@ -20,6 +20,10 @@ import { pipeline } from 'node:stream/promises';
 
 const ABS  = (process.env.ABS_URL || '').replace(/\/+$/, '');
 const PORT = Number(process.env.PORT || 8081);
+// Mount prefix. cloudflared (and some proxies) forward it unchanged; we strip it so
+// routes match. A prefix-stripping proxy (Caddy handle_path) sends bare /list, which
+// also works. Set BASE_PATH='' to disable if your proxy already strips.
+const BASE_PATH = (process.env.BASE_PATH ?? '/watchshelf-transcode').replace(/\/+$/, '');
 const UA   = 'WatchShelf-sidecar';
 if (!ABS) { console.error('ABS_URL is required (e.g. http://127.0.0.1:13378)'); process.exit(1); }
 
@@ -136,7 +140,9 @@ function progress(req, res, u) {
 
 const server = http.createServer((req, res) => {
   const u = new URL(req.url, 'http://x');
-  const p = u.pathname, g = req.method === 'GET';
+  let p = u.pathname;
+  if (BASE_PATH && p.startsWith(BASE_PATH)) { p = p.slice(BASE_PATH.length) || '/'; }
+  const g = req.method === 'GET';
   if (p === '/health') { res.writeHead(200).end('ok'); return; }
   if (p === '/list'        && g) { list(req, res, u); return; }
   if (p === '/authors'     && g) { authors(req, res, u); return; }


### PR DESCRIPTION
## Fix: Cloudflare Tunnel routing (sidecar strips its own mount prefix)

**Symptom:** with the app sideloaded, "All books" → `could not load books (-400)`, "Authors" → "None found". Root cause: the sidecar wasn't reachable — every `/watchshelf-transcode/*` request hit Audiobookshelf and 404'd.

Behind **Cloudflare Tunnel**, cloudflared forwards the full path (`/watchshelf-transcode/list`) unchanged — it can't rewrite paths like Caddy's `handle_path` — so the sidecar's `/list` route never matched.

**Fix:** the sidecar now strips a configurable `BASE_PATH` (default `/watchshelf-transcode`) itself. Works both ways:
- proxy strips the prefix (Caddy/nginx) → sidecar gets `/list` ✅
- proxy forwards it whole (cloudflared) → sidecar strips → `/list` ✅

### Verified against `books.jedibrooker.com`
Ran the sidecar locally, hit it with the exact cloudflared-style path:
`/watchshelf-transcode/list` → books, `/watchshelf-transcode/authors` → authors, `/watchshelf-transcode/health` → `ok`.

Docs: corrected the cloudflared `config.yml` ingress + dashboard-tunnel steps in `Caddyfile.snippet`.

🧙 Built with [WOZCODE](https://wozcode.com)
