### PR TITLE
feat: log out and switch to a different server

### DIFF
--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -23,6 +23,7 @@
     <string id="settingApiKeyPrompt">Long-lived ABS API key (Bearer)</string>
     <string id="browseLibrary">Browse library</string>
     <string id="logIn">Log in</string>
+    <string id="logOut">Log out</string>
     <string id="loggingIn">Logging in...</string>
     <string id="loginFailed">Login failed</string>
     <string id="fieldServer">WatchShelf URL</string>

--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -34,7 +34,7 @@ module Versions {
     const current = V1;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b12";
+    const tag = "b13";
 }
 
 // Keys for a TrackInfo dict (one downloaded/queued CHAPTER = one Media track).

--- a/source/DownloadedMenu.mc
+++ b/source/DownloadedMenu.mc
@@ -14,6 +14,12 @@ class DownloadedMenu extends WatchUi.Menu2 {
         // logs the user in first if they aren't configured yet.
         addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.browseLibrary), null, "browse", null));
 
+        // Only offer to log out if actually logged in - avoids a pointless item
+        // on a fresh, unconfigured install.
+        if (AbsApi.isConfigured()) {
+            addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.logOut), null, "logout", null));
+        }
+
         var tracks = Application.Storage.getValue(Store.TRACKS);
         if (tracks == null) { tracks = {}; }
 

--- a/source/DownloadedMenuDelegate.mc
+++ b/source/DownloadedMenuDelegate.mc
@@ -22,6 +22,15 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
             return;
         }
 
+        // "Log out" -> clear the stored server/token and go straight to a fresh
+        // on-watch login (switchToView, not push, so Back doesn't return to a
+        // stale pre-logout menu - matches how LoginView.onLogin returns on success).
+        if ((refId instanceof Toybox.Lang.String) && refId.equals("logout")) {
+            AbsApi.logout();
+            WatchUi.switchToView(new LoginView(), new LibraryViewDelegate(), WatchUi.SLIDE_LEFT);
+            return;
+        }
+
         var deleteList = Application.Storage.getValue(Store.DELETE_LIST);
         if (deleteList == null) { deleteList = []; }
         deleteList.add(refId);


### PR DESCRIPTION
Adds a **Log out** item to the "Downloaded" screen (next to "Browse library", shown only when logged in) that clears the stored server/token and drops into a fresh on-watch login for a different server. Reuses `AbsApi.logout()` (already existed, was never wired up) and the same `switchToView(LoginView)` pattern already used by successful login, so it's consistent with proven behavior. Build `b13`, compiles clean.

🧙 Built with [WOZCODE](https://wozcode.com)