### PR TITLE
fix(sidecar): bind port to all interfaces, not just 127.0.0.1

### DIFF
--- a/sidecar/GETTING_STARTED.md
+++ b/sidecar/GETTING_STARTED.md
@@ -123,7 +123,12 @@ Before you start, you need two things already in place (if you're not sure, chec
    - **Domain**: pick your own domain from the dropdown (this is the domain you already own and manage in Cloudflare — see the prerequisite note above if nothing appears here)
    - **Path**: leave this blank
    - **Type**: `HTTP`
-   - **URL**: `127.0.0.1:8081` (this is the sidecar's address on your server — not ABS's own port, the sidecar's)
+   - **URL**: `127.0.0.1:8081` in almost every case — **except** if `cloudflared` itself runs in
+     its *own* Docker container (rather than directly on the server), in which case
+     `127.0.0.1` means "inside the cloudflared container," not your server, and can't
+     reach the sidecar. If that's your setup, use the server's own LAN IP instead
+     (e.g. `192.168.1.50:8081` — find yours with `ip a` on the server, look under the
+     network interface that isn't `lo`).
 
 4. Click **Save**. Cloudflare automatically does two things for you in the background: it issues an **HTTPS certificate** (this is what makes your address start with `https://` and show as secure, instead of the unencrypted `http://`), and it creates a **DNS record** (this is the internet's phonebook entry that points `watchshelf.<your-domain>` at your Cloudflare tunnel). You don't need to do anything for either of these — no YAML file to touch, no server restart needed. It can take a minute or two for this to fully take effect, so wait about a minute before testing in the next step.
 
@@ -133,7 +138,7 @@ Before you start, you need two things already in place (if you're not sure, chec
    ```
    You can also just open `https://watchshelf.<your-domain>/health` in a browser. (This `/health` address is a built-in check that the sidecar you already installed responds to automatically — you don't need to set anything up for it.)
    - **Success**: the output is exactly `ok`.
-   - **Failure** (timeout or error page): first, if it's only been a few seconds since you clicked Save in step 4, wait a minute and try again — the certificate/DNS setup needs a short time to finish. If it still fails after that, the two most common causes are the Public Hostname pointing at the wrong port (it must be `8081`, the sidecar — not ABS's own port) or the tunnel's status dot showing grey/not connected in the dashboard.
+   - **Failure** (timeout or error page): first, if it's only been a few seconds since you clicked Save in step 4, wait a minute and try again — the certificate/DNS setup needs a short time to finish. If it still fails after that, the most common causes are: the Public Hostname pointing at the wrong port (it must be `8081`, the sidecar — not ABS's own port); the tunnel's status dot showing grey/not connected in the dashboard; or — if you used your server's LAN IP in step 3 because `cloudflared` runs in its own container — an out-of-date sidecar still only listening on `127.0.0.1`. If it's the last one: on the server, run `docker compose up -d` again in the `sidecar` folder to pick up the current config, which listens on all interfaces.
 
 Once you see `ok`, type `https://watchshelf.<your-domain>` into your watch app and you're done.
 

--- a/sidecar/docker-compose.yml
+++ b/sidecar/docker-compose.yml
@@ -22,7 +22,14 @@ services:
       # Docker Desktop (Mac/Windows) - harmless if you don't use that address.
       - "host.docker.internal:host-gateway"
     ports:
-      - "127.0.0.1:8081:8081"    # exposed to localhost only; your reverse proxy fronts it
+      # Bound to all interfaces, not just 127.0.0.1: your reverse proxy (nginx,
+      # Apache, Caddy, or a cloudflared instance) very often runs in ITS OWN
+      # container or even a separate host on your LAN - it needs to reach this
+      # port via the host's real (LAN) IP, not just loopback. This is still
+      # only reachable on your local network, not the public internet - only
+      # your reverse proxy's own public HTTPS route exposes it further, and
+      # that already requires a valid ABS login token to do anything.
+      - "8081:8081"
     restart: unless-stopped
     # If ABS runs in Docker on the same host, join its network instead of using the
     # public URL, e.g.:


### PR DESCRIPTION
## Fix: sidecar port binding assumed the reverse proxy always shares the host's loopback

Debugged live with a user hitting `login failed (400)` on the watch that turned
out to actually be a `502` from Cloudflare's edge (not the sidecar) once we
tested `curl https://watchshelf.<domain>/health` through the tunnel directly.

Root cause: their Cloudflare Tunnel connector (`cloudflared`) runs in its own
container, so they correctly pointed the Public Hostname route at the box's LAN
IP (`192.168.x.x:8081`) instead of `127.0.0.1:8081` — but the sidecar's Docker
port binding (`127.0.0.1:8081:8081`) only accepts connections addressed to
`127.0.0.1`, refusing everything else, even from the same machine.

**Fix:** bind to all interfaces (`8081:8081`). Still only reachable on the
local network — the sidecar's actual public exposure is entirely through
whatever reverse proxy route you configure, which already requires a valid ABS
login token to do anything useful.

Also updated the Cloudflare Tunnel section of `GETTING_STARTED.md` to call out
the separate-container case explicitly, with a diagnostic pointer for anyone
who hits this in the future.

🧙 Built with [WOZCODE](https://wozcode.com)