### PR TITLE
fix(sidecar): pass mediaType through /libraries

### DIFF
--- a/sidecar/server.js
+++ b/sidecar/server.js
@@ -159,13 +159,15 @@ function login(req, res) {
   });
 }
 
-// GET /libraries?token -> slim {libraries:[{id,name}]} (proxied from ABS /api/libraries).
+// GET /libraries?token -> slim {libraries:[{id,name,mediaType}]} (proxied from
+// ABS /api/libraries). mediaType is passed through - the watch uses it to skip
+// podcast libraries and only list book libraries.
 async function libraries(req, res, u) {
   const token = u.searchParams.get('token');
   if (!token) { res.writeHead(400).end('bad params'); return; }
   try {
     const d = await absJson('/api/libraries', token);
-    res.writeHead(200, jsonHead).end(JSON.stringify({ libraries: (d.libraries || []).map((l) => ({ id: l.id, name: l.name })) }));
+    res.writeHead(200, jsonHead).end(JSON.stringify({ libraries: (d.libraries || []).map((l) => ({ id: l.id, name: l.name, mediaType: l.mediaType })) }));
   } catch (e) { res.writeHead(502).end(String(e.message || 'ABS')); }
 }
 


### PR DESCRIPTION
Root cause of "Choose Library shows nothing" — found via a live debugging session where login + `/libraries` both worked correctly with the user's real account, but the on-watch menu came up empty regardless.

`LibraryView.mc`'s `onLibraries` only adds a library to the menu if `lib["mediaType"].equals("book")` (intentionally skips podcast libraries). The sidecar's `/libraries` proxy only forwarded `{id, name}`, silently dropping `mediaType` — so every library failed that filter and the menu was always empty, independent of how many libraries actually existed or whether the account had access to them.

Verified against the live server: `/libraries` now returns `{"id":...,"name":"All Books","mediaType":"book"}`.

🧙 Built with [WOZCODE](https://wozcode.com)