### PR TITLE
fix(app): shrink download chunks to song-length (~3 min)

### DIFF
--- a/source/BookMenuDelegate.mc
+++ b/source/BookMenuDelegate.mc
@@ -27,7 +27,11 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
             return;
         }
 
-        var chunk = 1800;  // 30-min chunks (~14MB at 64kbps mono); well under the watch limit
+        // Song-length chunks (~3 min, ~1.4MB at 64kbps mono) - matching how real,
+        // proven-working ACP apps like Spotify actually download audio (individual
+        // songs, a few MB each), not the originally-assumed 30-min/~14MB chunks,
+        // which failed immediately on real hardware ("Media Error Occurred").
+        var chunk = 180;
         var files = data["files"];
         var title = data["title"];
         if (title == null) { title = "Book"; }

--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -34,7 +34,7 @@ module Versions {
     const current = V1;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b13";
+    const tag = "b14";
 }
 
 // Keys for a TrackInfo dict (one downloaded/queued CHAPTER = one Media track).


### PR DESCRIPTION
## Diagnostic fix: shrink chunks from 30-min/14MB to 3-min/1.4MB

"Media Error Occurred" persisted after fixing Content-Length and ID3 metadata
(#13), and appeared **immediately** on selection - too fast to be a failure
discovered after a full ~14MB transfer, pointing at the request itself
rather than corrupted content.

Two independent research threads converged on chunk size:
- The Connect IQ SDK's own `compiler.json` for this exact device
  (`fenix8solar51mm`) declares a 512KB memory ceiling for the
  `audioContentProvider` app type - the original chunks were ~28x over that
  (some nuance on whether this literally bounds the whole download vs. app
  runtime memory, but directionally consistent).
- Real, proven-working Garmin audio apps (Spotify's official integration)
  download individual **songs** - a few MB, a few minutes each - nothing
  close to a 30-minute chunk.

Chunk length: 1800s -> 180s. Verified against the live server: a 180s chunk
is exactly 1,440,496 bytes with a correct `Content-Length`.

A 25-hour book now splits into ~500 small chunks instead of ~50 large ones.
Once this confirms the actual root cause on real hardware, worth tuning back
up to find the real safe ceiling rather than staying maximally conservative.

🧙 Built with [WOZCODE](https://wozcode.com)