### PR TITLE
feat: add a way to clear stuck download queue state

### DIFF
--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -9,6 +9,8 @@
     <string id="queued">Queued.\nSyncing...</string>
     <string id="deleting">Removing...</string>
     <string id="tapToDelete">Tap to remove</string>
+    <string id="clearQueue">Clear queue</string>
+    <string id="queueCleared">Queue cleared</string>
 
     <!-- errors -->
     <string id="errLibraries">Could not load libraries</string>

--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -34,7 +34,7 @@ module Versions {
     const current = V1;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b14";
+    const tag = "b15";
 }
 
 // Keys for a TrackInfo dict (one downloaded/queued CHAPTER = one Media track).

--- a/source/DownloadedMenu.mc
+++ b/source/DownloadedMenu.mc
@@ -20,6 +20,15 @@ class DownloadedMenu extends WatchUi.Menu2 {
             addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.logOut), null, "logout", null));
         }
 
+        // A crashed/interrupted sync can leave queued entries behind (they're
+        // only cleared as each one finishes downloading), which then get
+        // reprocessed on every future sync alongside anything new. Offer a way
+        // to wipe just the pending queue - sideloaded apps can't be cleanly
+        // uninstalled to reset this, so it has to be reachable from in here.
+        if (hasQueued()) {
+            addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.clearQueue), null, "clearqueue", null));
+        }
+
         var tracks = Application.Storage.getValue(Store.TRACKS);
         if (tracks == null) { tracks = {}; }
 
@@ -29,6 +38,13 @@ class DownloadedMenu extends WatchUi.Menu2 {
             var name = trackTitle(refId, tracks);
             addItem(new WatchUi.MenuItem(name, WatchUi.loadResource(Rez.Strings.tapToDelete), refId, null));
         }
+    }
+
+    function hasQueued() {
+        var syncList = Application.Storage.getValue(Store.SYNC_LIST);
+        var deleteList = Application.Storage.getValue(Store.DELETE_LIST);
+        return ((syncList != null) && (syncList.size() > 0))
+            || ((deleteList != null) && (deleteList.size() > 0));
     }
 
     // Prefer the cached media's own metadata title; fall back to stored TrackInfo.

--- a/source/DownloadedMenuDelegate.mc
+++ b/source/DownloadedMenuDelegate.mc
@@ -31,6 +31,18 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
             return;
         }
 
+        // "Clear queue" -> abandon anything pending (a crashed/interrupted sync
+        // can leave entries behind, since they're only cleared as each finishes)
+        // WITHOUT starting a sync - we want to drop them, not process them.
+        // Same push-a-confirmation pattern as the delete-a-track case below;
+        // re-entering this menu afterward re-evaluates hasQueued() fresh.
+        if ((refId instanceof Toybox.Lang.String) && refId.equals("clearqueue")) {
+            Application.Storage.setValue(Store.SYNC_LIST, {});
+            Application.Storage.setValue(Store.DELETE_LIST, []);
+            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.queueCleared)), null, WatchUi.SLIDE_LEFT);
+            return;
+        }
+
         var deleteList = Application.Storage.getValue(Store.DELETE_LIST);
         if (deleteList == null) { deleteList = []; }
         deleteList.add(refId);


### PR DESCRIPTION
Sideloaded apps can't be cleanly uninstalled on Garmin devices (nothing to delete once the watch imports the .prg), so there was no way to reset `Application.Storage` between test attempts. Since `BookMenuDelegate.onFiles` queues downloads additively and a crashed sync leaves entries behind, this adds a **Clear queue** item to the Downloaded screen (shown only when something's actually pending) to wipe stuck state without needing a reinstall.

🧙 Built with [WOZCODE](https://wozcode.com)