### PR TITLE
feat: delete a whole audiobook, or all downloads, at once

### DIFF
--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -8,9 +8,9 @@
     <string id="downloaded">Downloaded</string>
     <string id="queued">Queued.\nSyncing...</string>
     <string id="deleting">Removing...</string>
-    <string id="tapToDelete">Tap to remove</string>
     <string id="clearQueue">Clear queue</string>
     <string id="queueCleared">Queue cleared</string>
+    <string id="deleteAllDownloads">Delete all downloads</string>
 
     <!-- errors -->
     <string id="errLibraries">Could not load libraries</string>

--- a/source/BookMenuDelegate.mc
+++ b/source/BookMenuDelegate.mc
@@ -50,14 +50,15 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
                 var end = pos + chunk;
                 if (end > dur) { end = dur; }
                 syncList[mItemId + ":" + idx] = {
-                    TrackInfo.ITEM_ID  => mItemId,
-                    TrackInfo.INO      => ino,
-                    TrackInfo.CSTART   => pos,
-                    TrackInfo.CEND     => end,
-                    TrackInfo.START    => bookOffset + pos,
-                    TrackInfo.TITLE    => title + " " + (idx + 1),
-                    TrackInfo.TYPE     => "mp3",
-                    TrackInfo.CAN_SKIP => true
+                    TrackInfo.ITEM_ID    => mItemId,
+                    TrackInfo.INO        => ino,
+                    TrackInfo.CSTART     => pos,
+                    TrackInfo.CEND       => end,
+                    TrackInfo.START      => bookOffset + pos,
+                    TrackInfo.TITLE      => title + " " + (idx + 1),
+                    TrackInfo.BOOK_TITLE => title,
+                    TrackInfo.TYPE       => "mp3",
+                    TrackInfo.CAN_SKIP   => true
                 };
                 idx += 1;
                 pos = end;

--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -34,7 +34,7 @@ module Versions {
     const current = V1;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b15";
+    const tag = "b16";
 }
 
 // Keys for a TrackInfo dict (one downloaded/queued CHAPTER = one Media track).
@@ -42,12 +42,13 @@ module TrackInfo {
     // We store the chunk PARAMETERS (not the full URL) so hundreds of chunks stay
     // small in Storage - the download URL (which embeds the long token) is rebuilt
     // at download time via AbsApi.sidecarChunkUrl().
-    const TITLE    = "title";      // display title
-    const TYPE     = "type";       // "mp3" -> Media.ENCODING_*
-    const ITEM_ID  = "itemId";     // ABS libraryItemId
-    const INO      = "ino";        // audio file inode
-    const CSTART   = "cstart";     // chunk start within the file (seconds)
-    const CEND     = "cend";       // chunk end within the file (seconds)
-    const START    = "start";      // book-absolute start (seconds) for progress
-    const CAN_SKIP = "canSkip";
+    const TITLE      = "title";      // display title (this CHUNK - "Book Name 7")
+    const BOOK_TITLE = "bookTitle";  // display title of the BOOK this chunk belongs to
+    const TYPE       = "type";       // "mp3" -> Media.ENCODING_*
+    const ITEM_ID    = "itemId";     // ABS libraryItemId - groups a book's chunks together
+    const INO        = "ino";        // audio file inode
+    const CSTART     = "cstart";     // chunk start within the file (seconds)
+    const CEND       = "cend";       // chunk end within the file (seconds)
+    const START      = "start";      // book-absolute start (seconds) for progress
+    const CAN_SKIP   = "canSkip";
 }

--- a/source/DownloadedMenu.mc
+++ b/source/DownloadedMenu.mc
@@ -2,8 +2,10 @@ using Toybox.Application;
 using Toybox.Media;
 using Toybox.WatchUi;
 
-// Lists every downloaded chapter track. Selecting an item removes it; the native
-// player is what actually plays the ContentIterator's set.
+// Lists downloaded books (grouped from their individual chunk tracks - a book is
+// ~3-min chunks, so a long audiobook can be 100+ tracks; showing each one
+// individually would make this screen unusable). Selecting a book removes ALL of
+// its chunks; the native player is what actually plays the ContentIterator's set.
 class DownloadedMenu extends WatchUi.Menu2 {
 
     function initialize() {
@@ -29,14 +31,18 @@ class DownloadedMenu extends WatchUi.Menu2 {
             addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.clearQueue), null, "clearqueue", null));
         }
 
-        var tracks = Application.Storage.getValue(Store.TRACKS);
-        if (tracks == null) { tracks = {}; }
+        var books = groupedBooks();
+        var itemIds = books.keys();
 
-        var refIds = tracks.keys();
-        for (var i = 0; i < refIds.size(); ++i) {
-            var refId = refIds[i];
-            var name = trackTitle(refId, tracks);
-            addItem(new WatchUi.MenuItem(name, WatchUi.loadResource(Rez.Strings.tapToDelete), refId, null));
+        if (itemIds.size() > 0) {
+            addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.deleteAllDownloads), null, "deleteall", null));
+        }
+
+        for (var i = 0; i < itemIds.size(); ++i) {
+            var itemId = itemIds[i];
+            var book = books[itemId];
+            var sub = book["count"].toString() + " part" + ((book["count"] == 1) ? "" : "s");
+            addItem(new WatchUi.MenuItem(book["title"], sub, itemId, null));
         }
     }
 
@@ -47,16 +53,40 @@ class DownloadedMenu extends WatchUi.Menu2 {
             || ((deleteList != null) && (deleteList.size() > 0));
     }
 
-    // Prefer the cached media's own metadata title; fall back to stored TrackInfo.
-    function trackTitle(refId, tracks) {
+    // { itemId => { "title" => bookTitle, "count" => Number } } - one entry per
+    // book, folding every chunk that shares the same TrackInfo.ITEM_ID together.
+    function groupedBooks() {
+        var tracks = Application.Storage.getValue(Store.TRACKS);
+        if (tracks == null) { tracks = {}; }
+
+        var books = {};
+        var refIds = tracks.keys();
+        for (var i = 0; i < refIds.size(); ++i) {
+            var info = tracks[refIds[i]];
+            var itemId = info[TrackInfo.ITEM_ID];
+            if (itemId == null) { itemId = "unknown"; }
+
+            var book = books[itemId];
+            if (book == null) {
+                book = { "title" => bookTitle(refIds[i], info), "count" => 0 };
+                books[itemId] = book;
+            }
+            book["count"] = book["count"] + 1;
+        }
+        return books;
+    }
+
+    // Prefer the cached media's own metadata title (whole-file, no chunk suffix);
+    // fall back to stored BOOK_TITLE, then the per-chunk TITLE, then "Book".
+    function bookTitle(refId, info) {
         var ref = new Media.ContentRef(refId, Media.CONTENT_TYPE_AUDIO);
         var obj = Media.getCachedContentObj(ref);
         if (obj != null && obj.getMetadata() != null && obj.getMetadata().title != null) {
             return obj.getMetadata().title;
         }
-        var info = tracks[refId];
-        if (info != null && info[TrackInfo.TITLE] != null) { return info[TrackInfo.TITLE]; }
-        return "Track";
+        if (info[TrackInfo.BOOK_TITLE] != null) { return info[TrackInfo.BOOK_TITLE]; }
+        if (info[TrackInfo.TITLE] != null) { return info[TrackInfo.TITLE]; }
+        return "Book";
     }
 
     // Show used cache space in the menu title. CacheStatistics exposes `size`

--- a/source/DownloadedMenuDelegate.mc
+++ b/source/DownloadedMenuDelegate.mc
@@ -3,21 +3,20 @@ using Toybox.Communications;
 using Toybox.Media;
 using Toybox.WatchUi;
 
-// This is a management screen. Tapping a track queues it for deletion and runs a
-// sync; "Done" starts playback of the downloaded set.
+// This is a management screen. Tapping a book queues ALL of its chunks for
+// deletion and runs a sync; "Done" starts playback of the downloaded set.
 class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
 
     function initialize() {
         Menu2InputDelegate.initialize();
     }
 
-    // Tap a track = delete it (queued, then a sync performs Media.deleteCachedItem).
     function onSelect(item) {
-        var refId = item.getId();
+        var id = item.getId();
 
         // The "Browse library" row -> open the library (LibraryView logs in first
         // if we're not configured yet, otherwise it lists books to download).
-        if ((refId instanceof Toybox.Lang.String) && refId.equals("browse")) {
+        if ((id instanceof Toybox.Lang.String) && id.equals("browse")) {
             WatchUi.pushView(new LibraryView(), new LibraryViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }
@@ -25,7 +24,7 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
         // "Log out" -> clear the stored server/token and go straight to a fresh
         // on-watch login (switchToView, not push, so Back doesn't return to a
         // stale pre-logout menu - matches how LoginView.onLogin returns on success).
-        if ((refId instanceof Toybox.Lang.String) && refId.equals("logout")) {
+        if ((id instanceof Toybox.Lang.String) && id.equals("logout")) {
             AbsApi.logout();
             WatchUi.switchToView(new LoginView(), new LibraryViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
@@ -34,21 +33,50 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
         // "Clear queue" -> abandon anything pending (a crashed/interrupted sync
         // can leave entries behind, since they're only cleared as each finishes)
         // WITHOUT starting a sync - we want to drop them, not process them.
-        // Same push-a-confirmation pattern as the delete-a-track case below;
-        // re-entering this menu afterward re-evaluates hasQueued() fresh.
-        if ((refId instanceof Toybox.Lang.String) && refId.equals("clearqueue")) {
+        if ((id instanceof Toybox.Lang.String) && id.equals("clearqueue")) {
             Application.Storage.setValue(Store.SYNC_LIST, {});
             Application.Storage.setValue(Store.DELETE_LIST, []);
             WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.queueCleared)), null, WatchUi.SLIDE_LEFT);
             return;
         }
 
+        // "Delete all downloads" -> queue every downloaded chunk, across every book.
+        if ((id instanceof Toybox.Lang.String) && id.equals("deleteall")) {
+            var tracks = Application.Storage.getValue(Store.TRACKS);
+            if (tracks == null) { tracks = {}; }
+            queueDelete(tracks.keys());
+            return;
+        }
+
+        // Anything else is a BOOK's itemId (DownloadedMenu now groups chunks by
+        // book, not one row per chunk - a book can be 100+ ~3-min chunks, so
+        // showing/deleting them individually isn't usable). Find every
+        // downloaded refId that belongs to this book and queue them all.
+        var tracks = Application.Storage.getValue(Store.TRACKS);
+        if (tracks == null) { tracks = {}; }
+        var refIds = tracks.keys();
+        var toDelete = [];
+        for (var i = 0; i < refIds.size(); ++i) {
+            var info = tracks[refIds[i]];
+            if ((info != null) && (info[TrackInfo.ITEM_ID] != null) && info[TrackInfo.ITEM_ID].equals(id)) {
+                toDelete.add(refIds[i]);
+            }
+        }
+        queueDelete(toDelete);
+    }
+
+    // Add every given refId to the delete queue, then run a sync now to perform
+    // the deletions (Media.deleteCachedItem happens in SyncDelegate.deleteQueued).
+    function queueDelete(refIds) {
+        if (refIds.size() == 0) { return; }
+
         var deleteList = Application.Storage.getValue(Store.DELETE_LIST);
         if (deleteList == null) { deleteList = []; }
-        deleteList.add(refId);
+        for (var i = 0; i < refIds.size(); ++i) {
+            deleteList.add(refIds[i]);
+        }
         Application.Storage.setValue(Store.DELETE_LIST, deleteList);
 
-        // Run a sync now to perform the deletion, then confirm.
         Communications.startSync();
         WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.deleting)), null, WatchUi.SLIDE_LEFT);
     }


### PR DESCRIPTION
Dropping the chunk size to ~3 minutes (#14) turned a single audiobook into 100+ individual entries on the Downloaded screen with no bulk action - a book that used to be ~50 rows is now 500+.

- `DownloadedMenu` now groups chunks by book (`TrackInfo.ITEM_ID`) instead of listing every chunk, showing one row per book with a part count ("42 parts").
- Selecting a book queues **all** of its chunks for deletion in one sync.
- New **"Delete all downloads"** item (shown only when something's downloaded) queues every chunk across every book.

🧙 Built with [WOZCODE](https://wozcode.com)