### PR TITLE
fix(app): don't re-sync a book that's already fully downloaded

### DIFF
--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -11,6 +11,7 @@
     <string id="clearQueue">Clear queue</string>
     <string id="queueCleared">Queue cleared</string>
     <string id="deleteAllDownloads">Delete all downloads</string>
+    <string id="alreadyDownloaded">Already downloaded.\nSee "Downloaded".</string>
 
     <!-- errors -->
     <string id="errLibraries">Could not load libraries</string>

--- a/source/BookMenuDelegate.mc
+++ b/source/BookMenuDelegate.mc
@@ -36,6 +36,16 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
         var title = data["title"];
         if (title == null) { title = "Book"; }
 
+        // Re-selecting an already-fully-downloaded book must not silently queue
+        // a full re-download of every chunk - tell the user it's already there
+        // instead of burning battery/data re-syncing the same book.
+        var expected = expectedChunkCount(files, chunk);
+        if ((expected > 0) && (alreadyDownloadedCount() >= expected)) {
+            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.alreadyDownloaded)),
+                null, WatchUi.SLIDE_LEFT);
+            return;
+        }
+
         var syncList = Application.Storage.getValue(Store.SYNC_LIST);
         if (syncList == null) { syncList = {}; }
 
@@ -79,6 +89,38 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
     function numOr(v, dflt) {
         if (v == null) { return dflt; }
         return v;
+    }
+
+    // Mirrors the chunking loop above exactly (count only, no allocation) so it
+    // can never disagree with how many chunks a book actually splits into.
+    function expectedChunkCount(files, chunk) {
+        var count = 0;
+        for (var f = 0; f < files.size(); ++f) {
+            var dur = numOr(files[f]["duration"], 0).toNumber();
+            if (dur <= 0) { continue; }
+            var pos = 0;
+            while (pos < dur) {
+                var end = pos + chunk;
+                if (end > dur) { end = dur; }
+                count += 1;
+                pos = end;
+            }
+        }
+        return count;
+    }
+
+    function alreadyDownloadedCount() {
+        var tracks = Application.Storage.getValue(Store.TRACKS);
+        if (tracks == null) { return 0; }
+        var count = 0;
+        var refIds = tracks.keys();
+        for (var i = 0; i < refIds.size(); ++i) {
+            var info = tracks[refIds[i]];
+            if ((info != null) && (info[TrackInfo.ITEM_ID] != null) && info[TrackInfo.ITEM_ID].equals(mItemId)) {
+                count += 1;
+            }
+        }
+        return count;
     }
 
     function onBack() {

--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -34,7 +34,7 @@ module Versions {
     const current = V1;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b16";
+    const tag = "b17";
 }
 
 // Keys for a TrackInfo dict (one downloaded/queued CHAPTER = one Media track).


### PR DESCRIPTION
Found live: re-selecting a book from the library after its sync had already completed silently queued a full re-download of every chunk instead of recognizing it was already there.

`expectedChunkCount()` mirrors the real chunking loop exactly (count-only, same iteration) so it can never disagree with it; `alreadyDownloadedCount()` counts how many of this book's chunks already exist in `Store.TRACKS`. If they match, shows "Already downloaded" instead of re-queuing.

🧙 Built with [WOZCODE](https://wozcode.com)