### PR TITLE
fix(app): "Play downloaded" was completely unreachable

### DIFF
--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -11,6 +11,7 @@
     <string id="clearQueue">Clear queue</string>
     <string id="queueCleared">Queue cleared</string>
     <string id="deleteAllDownloads">Delete all downloads</string>
+    <string id="playDownloaded">Play downloaded</string>
     <string id="alreadyDownloaded">Already downloaded.\nSee "Downloaded".</string>
 
     <!-- errors -->

--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -34,7 +34,7 @@ module Versions {
     const current = V1;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b17";
+    const tag = "b18";
 }
 
 // Keys for a TrackInfo dict (one downloaded/queued CHAPTER = one Media track).

--- a/source/DownloadedMenu.mc
+++ b/source/DownloadedMenu.mc
@@ -5,7 +5,10 @@ using Toybox.WatchUi;
 // Lists downloaded books (grouped from their individual chunk tracks - a book is
 // ~3-min chunks, so a long audiobook can be 100+ tracks; showing each one
 // individually would make this screen unusable). Selecting a book removes ALL of
-// its chunks; the native player is what actually plays the ContentIterator's set.
+// its chunks; "Play downloaded" starts playback (Media.startPlayback), which
+// hands off to the native player driving ContentIterator's set. The watch's own
+// Music widget (hold the music-controls button -> Music Providers -> WatchShelf)
+// reaches the SAME downloaded content and is the platform-standard way in too.
 class DownloadedMenu extends WatchUi.Menu2 {
 
     function initialize() {
@@ -15,6 +18,19 @@ class DownloadedMenu extends WatchUi.Menu2 {
         // MUST lead to the books. Always show a way into the library; LibraryView
         // logs the user in first if they aren't configured yet.
         addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.browseLibrary), null, "browse", null));
+
+        var books = groupedBooks();
+        var itemIds = books.keys();
+
+        // Explicit, direct "Play" action - a plain MenuItem calling
+        // Media.startPlayback() straight from onSelect. NOT wired through
+        // Menu2's onDone(): per Garmin's own API docs, onDone() is only ever
+        // triggered by a WatchUi.CheckboxMenu, never a plain Menu2 like this
+        // one - so a Done-based "play" action here would be silently
+        // unreachable on real hardware no matter what the user pressed.
+        if (itemIds.size() > 0) {
+            addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.playDownloaded), null, "play", null));
+        }
 
         // Only offer to log out if actually logged in - avoids a pointless item
         // on a fresh, unconfigured install.
@@ -30,9 +46,6 @@ class DownloadedMenu extends WatchUi.Menu2 {
         if (hasQueued()) {
             addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.clearQueue), null, "clearqueue", null));
         }
-
-        var books = groupedBooks();
-        var itemIds = books.keys();
 
         if (itemIds.size() > 0) {
             addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.deleteAllDownloads), null, "deleteall", null));

--- a/source/DownloadedMenuDelegate.mc
+++ b/source/DownloadedMenuDelegate.mc
@@ -4,7 +4,9 @@ using Toybox.Media;
 using Toybox.WatchUi;
 
 // This is a management screen. Tapping a book queues ALL of its chunks for
-// deletion and runs a sync; "Done" starts playback of the downloaded set.
+// deletion and runs a sync; "Play downloaded" starts playback directly (see
+// the note on that branch below for why this isn't wired through Menu2's
+// onDone() the way Garmin's own MonkeyMusic sample does it).
 class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
 
     function initialize() {
@@ -18,6 +20,16 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
         // if we're not configured yet, otherwise it lists books to download).
         if ((id instanceof Toybox.Lang.String) && id.equals("browse")) {
             WatchUi.pushView(new LibraryView(), new LibraryViewDelegate(), WatchUi.SLIDE_LEFT);
+            return;
+        }
+
+        // "Play downloaded" -> start playback directly. NOT wired through
+        // Menu2's onDone() (see class comment) - onDone() never fires on a
+        // plain Menu2 like this one, only on a WatchUi.CheckboxMenu, so a
+        // Done-triggered "play" was unreachable on real hardware no matter
+        // what the user pressed. This is a normal, always-reachable tap.
+        if ((id instanceof Toybox.Lang.String) && id.equals("play")) {
+            Media.startPlayback(null);
             return;
         }
 
@@ -79,11 +91,6 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
 
         Communications.startSync();
         WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.deleting)), null, WatchUi.SLIDE_LEFT);
-    }
-
-    // "Done" (menu action) = start playing the downloaded set.
-    function onDone() {
-        Media.startPlayback(null);
     }
 
     function onBack() {


### PR DESCRIPTION
## Root cause of "there was no way to play it"

\`DownloadedMenu\`'s \`onDone()\` called \`Media.startPlayback(null)\`, but per
Garmin's own \`WatchUi.Menu2InputDelegate\` API docs, \`onDone()\` is **only**
ever triggered by a \`WatchUi.CheckboxMenu\` - never a plain \`Menu2\` like
\`DownloadedMenu\`. There was no button or gesture on real hardware that could
ever reach it. The only playback trigger anywhere in the app was dead code.

Confirmed against Garmin's own MonkeyMusic reference sample (this project's
class hierarchy already claims to mirror it): its playback-config screen
extends \`WatchUi.CheckboxMenu\` specifically so \`onDone()\` is reachable.

Converting \`DownloadedMenu\` to a \`CheckboxMenu\` would mean redesigning its
whole interaction model for no real benefit - \`ContentIterator\` already plays
everything in \`Store.TRACKS\` regardless of selection state, so there'd be
nothing for a checkbox to actually filter.

**Fix:** added a **"Play downloaded"** \`MenuItem\` (shown whenever anything's
downloaded) whose \`onSelect\` calls \`Media.startPlayback(null)\` directly -
same as any other menu action, always reachable, no special gesture. Removed
\`onDone()\` since it's now confirmed dead on this class.

Also documented the platform-standard alternative: the watch's own Music
widget (hold the music-controls button -> Music Providers -> WatchShelf)
reaches the same downloaded content independently, confirmed via the tactix 8
Owner's Manual.

🧙 Built with [WOZCODE](https://wozcode.com)