### PR TITLE
fix(sidecar): switch mp3 encoding to 44.1kHz/96kbps

### DIFF
--- a/sidecar/server.js
+++ b/sidecar/server.js
@@ -50,7 +50,15 @@ function ffArgs(srcUrl, token, fmt, start, end) {
   // own default encoder tag, so the mp3 output carries no ID3 tag at all.
   a.push('-map_metadata', '-1', '-id3v2_version', '0');
   if (fmt === 'm4a') { a.push('-map', '0:a:0', '-c:a', 'copy', '-f', 'adts', 'pipe:1'); }
-  else { a.push('-map', '0:a:0', '-c:a', 'libmp3lame', '-b:a', '64k', '-ac', '1', '-ar', '22050', '-f', 'mp3', 'pipe:1'); }
+  // 44100Hz/96kbps instead of the original 22050Hz/64kbps: the file itself was
+  // independently verified valid, complete, standard MP3 (clean full decode,
+  // correct headers) - but 22050Hz mono is a much less common combination than
+  // typical commercial audio, a plausible edge case for Garmin's specific
+  // hardware decoder to not handle even though it's fully spec-compliant.
+  // Mono is kept (legitimate, common for spoken word, and halves file size vs
+  // stereo for no perceptual benefit on speech) - only sample rate/bitrate move
+  // to more mainstream values.
+  else { a.push('-map', '0:a:0', '-c:a', 'libmp3lame', '-b:a', '96k', '-ac', '1', '-ar', '44100', '-f', 'mp3', 'pipe:1'); }
   return a;
 }
 


### PR DESCRIPTION
## "Media Error Occurred" persisted even after playback became reachable (#18)

Confirmed via a screen recording of the actual failure on real hardware:
\`Media.startPlayback()\` now works, the native player UI loads with working
transport controls, and the error hits within ~1 second of reaching that
screen - consistent with a decode-time failure on the very first chunk, not a
download/transfer problem (everything up to that point - Content-Length,
ID3-free, correct file structure - was already independently re-verified).

The least mainstream thing left about the encoding: 22050Hz mono 64kbps,
a much less common combination than typical commercial audio. Switched to
44.1kHz/96kbps (kept mono - legitimate and space-efficient for spoken word).

**Sidecar-only change - no watch rebuild needed.** Already-downloaded chunks
used the old encoding and need deleting + re-downloading to pick this up
(the "Delete all downloads" feature from #16 makes that quick).

Verified against the live server: correct \`Content-Length\`, no ID3 tag,
clean full decode - same checks as every prior fix, now on the more standard
encoding.

🧙 Built with [WOZCODE](https://wozcode.com)