### PR TITLE
fix(app): status/error screens had no Back handler - hung forever

### DIFF
--- a/source/BookMenuDelegate.mc
+++ b/source/BookMenuDelegate.mc
@@ -23,7 +23,7 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
     function onFiles(code, data) {
         if (code != 200 || data == null || data["files"] == null || data["files"].size() == 0) {
             WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errDetail) + "\n(" + code + ")"),
-                null, WatchUi.SLIDE_LEFT);
+                new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }
 
@@ -42,7 +42,7 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
         var expected = expectedChunkCount(files, chunk);
         if ((expected > 0) && (alreadyDownloadedCount() >= expected)) {
             WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.alreadyDownloaded)),
-                null, WatchUi.SLIDE_LEFT);
+                new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }
 
@@ -77,12 +77,12 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
         }
 
         if (idx == 0) {
-            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errNoAudio)), null, WatchUi.SLIDE_LEFT);
+            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errNoAudio)), new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }
 
         Application.Storage.setValue(Store.SYNC_LIST, syncList);
-        WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.queued)), null, WatchUi.SLIDE_LEFT);
+        WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.queued)), new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
         Communications.startSync();
     }
 

--- a/source/Browse.mc
+++ b/source/Browse.mc
@@ -17,7 +17,7 @@ module Browse {
     function showBooks(code, data) {
         if (code != 200 || data == null || data["books"] == null || data["books"].size() == 0) {
             WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errItems) + "\n(" + code + ")"),
-                null, WatchUi.SLIDE_LEFT);
+                new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }
         var books = data["books"];
@@ -47,7 +47,7 @@ class BrowseDelegate extends WatchUi.Menu2InputDelegate {
 
     function pushGroups(code, data, key, filterType) {
         if (code != 200 || data == null || data[key] == null || data[key].size() == 0) {
-            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errNone)), null, WatchUi.SLIDE_LEFT);
+            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errNone)), new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }
         var groups = data[key];

--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -34,7 +34,7 @@ module Versions {
     const current = V1;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b18";
+    const tag = "b19";
 }
 
 // Keys for a TrackInfo dict (one downloaded/queued CHAPTER = one Media track).

--- a/source/DownloadedMenuDelegate.mc
+++ b/source/DownloadedMenuDelegate.mc
@@ -48,7 +48,7 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
         if ((id instanceof Toybox.Lang.String) && id.equals("clearqueue")) {
             Application.Storage.setValue(Store.SYNC_LIST, {});
             Application.Storage.setValue(Store.DELETE_LIST, []);
-            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.queueCleared)), null, WatchUi.SLIDE_LEFT);
+            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.queueCleared)), new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }
 
@@ -90,7 +90,7 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
         Application.Storage.setValue(Store.DELETE_LIST, deleteList);
 
         Communications.startSync();
-        WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.deleting)), null, WatchUi.SLIDE_LEFT);
+        WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.deleting)), new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
     }
 
     function onBack() {

--- a/source/ErrorViewDelegate.mc
+++ b/source/ErrorViewDelegate.mc
@@ -1,0 +1,18 @@
+using Toybox.WatchUi;
+
+// Back handler for ErrorView (a plain WatchUi.View with no delegate of its own).
+// Without this, pressing Back on ANY error/status message screen (queued,
+// removing, already downloaded, queue cleared, etc.) has no handler at all and
+// hangs instead of dismissing - same bug class already documented and fixed on
+// LibraryViewDelegate, just never applied to ErrorView's many call sites.
+class ErrorViewDelegate extends WatchUi.BehaviorDelegate {
+
+    function initialize() {
+        BehaviorDelegate.initialize();
+    }
+
+    function onBack() {
+        WatchUi.popView(WatchUi.SLIDE_RIGHT);
+        return true;
+    }
+}


### PR DESCRIPTION
## Root cause of the "Removing..." freeze

Every status/error screen (\`ErrorView\` - "Queued. Syncing...", "Removing...",
"Already downloaded", "Queue cleared", "No audio in this book", library
errors) is a plain \`WatchUi.View\` with no delegate of its own, and **every**
call site pushed it with \`null\` as the delegate. Pressing Back had no
app-level handler at all and hung instead of dismissing.

This is the exact bug class the project already hit once (documented in
\`LibraryViewDelegate.mc\`'s own comments) and fixed there - it was just never
applied to \`ErrorView\`'s other 8 call sites.

Found live: user hit "Delete all downloads" mid-sync, backed out and
confirmed the OS's "cancel sync?" dialog, and was left frozen on
"Removing..." for 5+ minutes - not a hang in the sync itself, but in the UI
screen left on top of it with nothing wired to dismiss it.

**Fix:** added \`ErrorViewDelegate\` (\`onBack -> popView\`, same pattern as
\`LibraryViewDelegate\`) and wired it into all 8 \`ErrorView\` push sites across
\`BookMenuDelegate.mc\`, \`DownloadedMenuDelegate.mc\`, and \`Browse.mc\`.

🧙 Built with [WOZCODE](https://wozcode.com)