### PR TITLE
fix: switch downloaded chunks from mp3 to AAC/ADTS

### DIFF
--- a/sidecar/server.js
+++ b/sidecar/server.js
@@ -49,7 +49,15 @@ function ffArgs(srcUrl, token, fmt, start, end) {
   // error surfaced to the app. -id3v2_version 0 additionally suppresses ffmpeg's
   // own default encoder tag, so the mp3 output carries no ID3 tag at all.
   a.push('-map_metadata', '-1', '-id3v2_version', '0');
-  if (fmt === 'm4a') { a.push('-map', '0:a:0', '-c:a', 'copy', '-f', 'adts', 'pipe:1'); }
+  // Always TRANSCODE to AAC/ADTS (not stream-copy) regardless of source codec -
+  // matches the same "always re-encode to a known-good target" approach as the
+  // mp3 branch below, and lets any book (mp3-sourced or aac-sourced) test this
+  // format, not just already-AAC ones. Testing whether MP3 itself - not any
+  // particular MP3 parameter - is what a real device's decoder has trouble
+  // with, after 22050Hz/64kbps and 44100Hz/96kbps mp3 both failed identically
+  // and immediately on real hardware despite both being independently verified
+  // as valid, complete, standard MP3 files.
+  if (fmt === 'm4a') { a.push('-map', '0:a:0', '-c:a', 'aac', '-b:a', '96k', '-ac', '1', '-ar', '44100', '-f', 'adts', 'pipe:1'); }
   // 44100Hz/96kbps instead of the original 22050Hz/64kbps: the file itself was
   // independently verified valid, complete, standard MP3 (clean full decode,
   // correct headers) - but 22050Hz mono is a much less common combination than

--- a/source/AbsApi.mc
+++ b/source/AbsApi.mc
@@ -74,10 +74,12 @@ module AbsApi {
             cb);
     }
 
-    // One CHUNK of a file as a small mp3 the watch can download.
+    // One CHUNK of a file as a small AAC/ADTS chunk the watch can download.
+    // fmt=m4a on the sidecar produces ADTS, not mp3 - see BookMenuDelegate.mc
+    // for why (testing whether MP3 itself is what real hardware struggles with).
     function sidecarChunkUrl(itemId, ino, startSec, endSec) {
         return sidecarBase() + "/transcode?item=" + itemId + "&file=" + ino
-            + "&fmt=mp3&start=" + startSec.toString() + "&end=" + endSec.toString()
+            + "&fmt=m4a&start=" + startSec.toString() + "&end=" + endSec.toString()
             + "&token=" + authToken();
     }
 

--- a/source/BookMenuDelegate.mc
+++ b/source/BookMenuDelegate.mc
@@ -27,7 +27,7 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
             return;
         }
 
-        // Song-length chunks (~3 min, ~1.4MB at 64kbps mono) - matching how real,
+        // Song-length chunks (~3 min, ~2MB at 96kbps mono) - matching how real,
         // proven-working ACP apps like Spotify actually download audio (individual
         // songs, a few MB each), not the originally-assumed 30-min/~14MB chunks,
         // which failed immediately on real hardware ("Media Error Occurred").
@@ -67,7 +67,7 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
                     TrackInfo.START      => bookOffset + pos,
                     TrackInfo.TITLE      => title + " " + (idx + 1),
                     TrackInfo.BOOK_TITLE => title,
-                    TrackInfo.TYPE       => "mp3",
+                    TrackInfo.TYPE       => "adts",
                     TrackInfo.CAN_SKIP   => true
                 };
                 idx += 1;

--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -34,7 +34,7 @@ module Versions {
     const current = V1;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b20";
+    const tag = "b21";
 }
 
 // Keys for a TrackInfo dict (one downloaded/queued CHAPTER = one Media track).


### PR DESCRIPTION
## Testing whether MP3 itself is what real hardware can't play

Both mp3 encodings tried so far (22050Hz/64kbps in #19's predecessor, then
44100Hz/96kbps in #19) failed identically and immediately on real hardware -
confirmed live with the sidecar redeployed and the book freshly re-downloaded
each time. Every mp3 property has checked out valid via direct ffprobe/ffmpeg
inspection on both attempts. With sample rate, bitrate, Content-Length, and
ID3 tags all independently ruled out, the remaining candidate is the format
itself.

The sidecar already had an AAC/ADTS code path, but it only stream-copied
already-AAC source files rather than genuinely transcoding, so it was never
actually exercised for the common mp3-sourced case. Changed it to always
transcode via ffmpeg's AAC encoder, matching the same "always re-encode to a
known-good target" approach the mp3 branch already used.

**Verified against the live server with the MP3-sourced book specifically**
(exercising the new transcode path): correct \`Content-Type: audio/aac\`,
correct \`Content-Length\`, valid ADTS sync bytes, clean full decode.

**Requires all three:** sidecar redeploy (\`server.js\` changed), fresh watch
build (b21), and deleting + re-downloading any existing books - none of these
retroactively affect what the others already have in place.

🧙 Built with [WOZCODE](https://wozcode.com)