### PR TITLE
fix(playback): build playlist from OS content cache, not app-level Storage

### DIFF
--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -34,7 +34,7 @@ module Versions {
     const current = V1;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b22";
+    const tag = "b23";
 }
 
 // Keys for a TrackInfo dict (one downloaded/queued CHAPTER = one Media track).

--- a/source/ContentIterator.mc
+++ b/source/ContentIterator.mc
@@ -1,6 +1,7 @@
 using Toybox.Application;
 using Toybox.Math;
 using Toybox.Media;
+using Toybox.System;
 
 // Yields cached chapter tracks to the player. Order = the TRACKS map grouped by
 // book (alphabetical by BOOK_TITLE), then sorted within each book by chapter
@@ -97,22 +98,46 @@ class ContentIterator extends Media.ContentIterator {
 
     function objAt(idx) {
         if ((idx >= 0) && (idx < mPlaylist.size())) {
-            return Media.getCachedContentObj(new Media.ContentRef(mPlaylist[idx], Media.CONTENT_TYPE_AUDIO));
+            try {
+                return Media.getCachedContentObj(new Media.ContentRef(mPlaylist[idx], Media.CONTENT_TYPE_AUDIO));
+            } catch (e) {
+                // Media.getCachedContentObj is documented to throw if the id
+                // isn't a Lang.String the OS recognizes - fall back to null
+                // (a sanctioned return value) instead of an uncaught exception
+                // reaching the native player.
+                System.println("objAt failed for " + mPlaylist[idx] + ": " + e.getErrorMessage());
+                return null;
+            }
         }
         return null;
     }
 
-    // Build the ordered playlist from Storage TRACKS: insertion sort by
-    // (bookTitle, chapterStart) so every book's chapters stay contiguous and in
-    // order, and different books don't interleave. Uses plain statements (no
-    // fluent slice().add().addAll() chaining, which relies on Array.add/addAll
-    // returning the array - they return Void).
+    // Build the ordered playlist from the OS's OWN content cache, never our own
+    // Storage bookkeeping - mirrors MonkeyMusic's initializePlaylist() exactly.
+    // Store.TRACKS can drift out of sync with what the OS actually has cached
+    // (a stale/removed entry, or a key that doesn't round-trip identically
+    // through Storage's persistence layer); handing the OS back one of ITS OWN
+    // ids is the only way to guarantee Media.getCachedContentObj() resolves it.
+    // Store.TRACKS is used ONLY for sort metadata (bookTitle, chapterStart)
+    // below, never as the id source. Insertion sort by (bookTitle,
+    // chapterStart), plain statements (no fluent slice().add().addAll()
+    // chaining, which relies on Array.add/addAll returning the array - they
+    // return Void).
     function buildPlaylist() {
         mPlaylist = [];
         var tracks = Application.Storage.getValue(Store.TRACKS);
-        if (tracks == null) { mIndex = 0; return; }
+        if (tracks == null) { tracks = {}; }
 
-        var refIds = tracks.keys();
+        var refIds = [];
+        var iter = Media.getContentRefIter({ :contentType => Media.CONTENT_TYPE_AUDIO });
+        if (iter != null) {
+            var ref = iter.next();
+            while (ref != null) {
+                refIds.add(ref.getId());
+                ref = iter.next();
+            }
+        }
+
         for (var i = 0; i < refIds.size(); ++i) {
             var refId = refIds[i];
 


### PR DESCRIPTION
## Summary
- `ContentIterator.buildPlaylist()` was sourcing `mPlaylist` from `Store.TRACKS.keys()` (our own `Application.Storage` bookkeeping) instead of `Media.getContentRefIter({:contentType => Media.CONTENT_TYPE_AUDIO})` — the OS's own authoritative view of what's actually cached, which is exactly what Garmin's real MonkeyMusic reference sample uses.
- This is the one thing genuinely common across every "Media Error Occurred" attempt so far (MP3 at two different bitrate/sample-rate configs, then AAC/ADTS — all independently verified valid server-side, all failing identically and immediately before play is even pressed). A real published Connect IQ audio app (SubMusic, GH issue #25) traced the identical error message to this exact bug class — trusting app-level playlist bookkeeping instead of the OS's authoritative content cache.
- `objAt()` now also wraps `Media.getCachedContentObj()` in try/catch — it's documented to throw if the id isn't a recognized `Lang.String`, and falls back to `null` (a sanctioned return value) instead of letting an uncaught exception reach the native player.
- `Store.TRACKS` is still used, but only for sort metadata (book title, chapter start) — never as the source of ids themselves.
- Bumped build tag to b23.

## Test plan
- [x] `make build` succeeds for `fenix8solar51mm`
- [ ] Sideload b23, download a chapter fresh, confirm "Media Error Occurred" no longer appears on entering the player screen

🧙 Built with [WOZCODE](https://wozcode.com)