### PR TITLE
fix(sync): revert SyncDelegate to Media.SyncDelegate, matching MonkeyMusic exactly

### DIFF
--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -34,7 +34,7 @@ module Versions {
     const current = V1;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b23";
+    const tag = "b24";
 }
 
 // Keys for a TrackInfo dict (one downloaded/queued CHAPTER = one Media track).

--- a/source/SyncDelegate.mc
+++ b/source/SyncDelegate.mc
@@ -4,11 +4,17 @@ using Toybox.Media;
 
 // Downloads queued CHAPTER tracks to the device media cache. One chapter == one
 // Media track, so the native player gives real chapter navigation (we never
-// flatten a book into a single track). Mirrors MonkeyMusic's SyncDelegate but
-// operates on chapter tracks and reports progress via Communications.notify*.
-// Extends Communications.SyncDelegate (Media.SyncDelegate is deprecated on SDK 9.x,
-// and getSyncDelegate() must now return a Communications.SyncDelegate).
-class SyncDelegate extends Communications.SyncDelegate {
+// flatten a book into a single track). Mirrors MonkeyMusic's SyncDelegate,
+// including its base class: Media.SyncDelegate is deprecated ("may be removed
+// after System 9") but still fully present on SDK 9.2.0, and Garmin's own
+// current MonkeyMusic reference extends it, paired end-to-end with the Media.*
+// notify/cache functions - never mixed with Communications.SyncDelegate. An
+// earlier version of this file extended Communications.SyncDelegate instead
+// (an unverified claim that this was "required" on SDK 9.x, which official
+// docs do not support) while ContentIterator.mc uses Media.getContentRefIter()
+// for the content cache - an untested class-family mix no reference
+// implementation validates. Reverted to match MonkeyMusic exactly.
+class SyncDelegate extends Media.SyncDelegate {
 
     private var mSyncList;   // { trackKey => TrackInfo }
     private var mDeleteList; // [ refId, ... ]
@@ -36,7 +42,7 @@ class SyncDelegate extends Communications.SyncDelegate {
     function onStartSync() {
         mTotal = mSyncList.size() + mDeleteList.size();
         if (mTotal == 0) {
-            Communications.notifySyncComplete(null);
+            Media.notifySyncComplete(null);
             return;
         }
         deleteQueued();
@@ -47,7 +53,7 @@ class SyncDelegate extends Communications.SyncDelegate {
     // System-initiated cancel: stop cleanly. In-flight request is abandoned.
     function onStopSync() {
         Communications.cancelAllRequests();
-        Communications.notifySyncComplete(null);
+        Media.notifySyncComplete(null);
     }
 
     // Delete every queued refId from the media cache, then clear the queue.
@@ -70,7 +76,7 @@ class SyncDelegate extends Communications.SyncDelegate {
     function downloadNext() {
         if (mKeys.size() == 0) {
             Application.Storage.setValue(Store.SYNC_LIST, {});
-            Communications.notifySyncComplete(null);
+            Media.notifySyncComplete(null);
             return;
         }
 
@@ -123,13 +129,13 @@ class SyncDelegate extends Communications.SyncDelegate {
             mKeys = mKeys.slice(1, mKeys.size());
             downloadNext();
         } else {
-            Communications.notifySyncComplete("Download failed (" + code + ")");
+            Media.notifySyncComplete("Download failed (" + code + ")");
         }
     }
 
     function onOpDone() {
         ++mDone;
         var pct = ((mDone / mTotal.toFloat()) * 100).toNumber();
-        Communications.notifySyncProgress(pct);
+        Media.notifySyncProgress(pct);
     }
 }


### PR DESCRIPTION
## Summary
- `SyncDelegate.mc` extended `Communications.SyncDelegate` on the strength of a code comment claiming this was "required" on SDK 9.x — that claim was never independently verified and is contradicted by official docs (`Media.SyncDelegate` is deprecated, "may be removed after System 9", but still fully present/functional on SDK 9.2.0) and by Garmin's own MonkeyMusic reference source (fetched verbatim), which extends `Media.SyncDelegate` end-to-end, paired consistently with `Media.notifySyncComplete`/`Media.notifySyncProgress` — never mixed with the `Communications.*` equivalents.
- WatchShelf's `ContentIterator.mc` (prior fix, PR #24) already uses `Media.getContentRefIter()` for the content cache — pairing that with a `Communications.SyncDelegate`-based downloader was an untested class-family mix no reference implementation validates.
- Reverted the base class and all four `notifySyncComplete`/`notifySyncProgress` call sites to the `Media.*` family, matching MonkeyMusic exactly. `Communications.cancelAllRequests()` / `HTTP_REQUEST_METHOD_GET` / `HTTP_RESPONSE_CONTENT_TYPE_AUDIO` stay as-is — those are shared module-level constants MonkeyMusic's own `Media.SyncDelegate`-based sample also uses for the web request itself.
- Bumped build tag to b24.

## Test plan
- [x] `make build` succeeds for `fenix8solar51mm`, `.prg.debug.xml` regenerated
- [ ] Sideload b24, download a chapter fresh, confirm "Media Error Occurred" no longer appears
- [ ] If it still fails: pull `GARMIN/APPS/LOGS/CIQ_LOG.YAML` via MTP (OpenMTP) for a real stack trace, since a matching `.debug.xml` now exists in `bin/`

🧙 Built with [WOZCODE](https://wozcode.com)