### PR TITLE
revert(sync): restore Communications.SyncDelegate (b24 violated the SDK contract)

### DIFF
--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -34,7 +34,7 @@ module Versions {
     const current = V1;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b24";
+    const tag = "b25";
 }
 
 // Keys for a TrackInfo dict (one downloaded/queued CHAPTER = one Media track).

--- a/source/SyncDelegate.mc
+++ b/source/SyncDelegate.mc
@@ -4,17 +4,18 @@ using Toybox.Media;
 
 // Downloads queued CHAPTER tracks to the device media cache. One chapter == one
 // Media track, so the native player gives real chapter navigation (we never
-// flatten a book into a single track). Mirrors MonkeyMusic's SyncDelegate,
-// including its base class: Media.SyncDelegate is deprecated ("may be removed
-// after System 9") but still fully present on SDK 9.2.0, and Garmin's own
-// current MonkeyMusic reference extends it, paired end-to-end with the Media.*
-// notify/cache functions - never mixed with Communications.SyncDelegate. An
-// earlier version of this file extended Communications.SyncDelegate instead
-// (an unverified claim that this was "required" on SDK 9.x, which official
-// docs do not support) while ContentIterator.mc uses Media.getContentRefIter()
-// for the content cache - an untested class-family mix no reference
-// implementation validates. Reverted to match MonkeyMusic exactly.
-class SyncDelegate extends Media.SyncDelegate {
+// flatten a book into a single track). Mirrors MonkeyMusic's SyncDelegate but
+// operates on chapter tracks and reports progress via Communications.notify*.
+// Extends Communications.SyncDelegate. VERIFIED against SDK 9.2.0's api.mir
+// (the compiler's own contract, not docs or samples):
+// AudioContentProviderApp.getSyncDelegate() is declared
+// `as Communications.SyncDelegate or Null`, and Media.SyncDelegate is a
+// SEPARATE class (not a subtype), so returning one violates the declared
+// contract. Do NOT "fix" this back to Media.SyncDelegate to match the GitHub
+// MonkeyMusic sample - that sample is 2018-era and predates the type change;
+// build b24 tried exactly that, fixed nothing (both known failures
+// persisted), and was reverted.
+class SyncDelegate extends Communications.SyncDelegate {
 
     private var mSyncList;   // { trackKey => TrackInfo }
     private var mDeleteList; // [ refId, ... ]
@@ -42,7 +43,7 @@ class SyncDelegate extends Media.SyncDelegate {
     function onStartSync() {
         mTotal = mSyncList.size() + mDeleteList.size();
         if (mTotal == 0) {
-            Media.notifySyncComplete(null);
+            Communications.notifySyncComplete(null);
             return;
         }
         deleteQueued();
@@ -53,7 +54,7 @@ class SyncDelegate extends Media.SyncDelegate {
     // System-initiated cancel: stop cleanly. In-flight request is abandoned.
     function onStopSync() {
         Communications.cancelAllRequests();
-        Media.notifySyncComplete(null);
+        Communications.notifySyncComplete(null);
     }
 
     // Delete every queued refId from the media cache, then clear the queue.
@@ -76,7 +77,7 @@ class SyncDelegate extends Media.SyncDelegate {
     function downloadNext() {
         if (mKeys.size() == 0) {
             Application.Storage.setValue(Store.SYNC_LIST, {});
-            Media.notifySyncComplete(null);
+            Communications.notifySyncComplete(null);
             return;
         }
 
@@ -129,13 +130,13 @@ class SyncDelegate extends Media.SyncDelegate {
             mKeys = mKeys.slice(1, mKeys.size());
             downloadNext();
         } else {
-            Media.notifySyncComplete("Download failed (" + code + ")");
+            Communications.notifySyncComplete("Download failed (" + code + ")");
         }
     }
 
     function onOpDone() {
         ++mDone;
         var pct = ((mDone / mTotal.toFloat()) * 100).toNumber();
-        Media.notifySyncProgress(pct);
+        Communications.notifySyncProgress(pct);
     }
 }


### PR DESCRIPTION
## Summary
- Reverts PR #25. SDK 9.2.0's `api.mir` — the compiler's own contract, checked directly on the installed SDK — declares `AudioContentProviderApp.getSyncDelegate()` as returning `Communications.SyncDelegate or Null`, and `Media.SyncDelegate` is a separate class (not a subtype). Returning a `Media.SyncDelegate` violates the declared contract.
- The 2018-era GitHub MonkeyMusic sample that PR #25 was modeled on predates this type change; the api.mir on disk is the authority for this SDK, not the sample or the doc pages.
- b24 fixed nothing on-device (playback of a downloaded book and the long-standing Algebraist download failure both persisted identically), so there is no counter-evidence in its favor.
- The class comment now records the api.mir evidence explicitly so this doesn't get "fixed" back again.
- Bumped build tag to b25.

## Test plan
- [x] `make build` succeeds for `fenix8solar51mm`; b24/b25 debug symbols preserved in `debug-symbols/` for crash-log decoding

🧙 Built with [WOZCODE](https://wozcode.com)