### PR TITLE
fix(storage): O(books) storage redesign — kills the fatal OOM behind "Media Error Occurred"

### DIFF
--- a/source/BookMenuDelegate.mc
+++ b/source/BookMenuDelegate.mc
@@ -2,11 +2,12 @@ using Toybox.Application;
 using Toybox.Communications;
 using Toybox.WatchUi;
 
-// Picked a book -> get its lean file list from the sidecar, split each file into
-// song-length downloadable chunks (a short one first, then ~3-min ones), queue
-// them (as small param sets, not full URLs), and run a background sync.
-// Everything goes through the sidecar because most books here are single
-// 200MB-1GB files the watch cannot download whole.
+// Picked a book -> get its lean file list from the sidecar, store ONE small
+// per-book job (file inos + durations + title + resume cursor), and run a
+// background sync. Chunk boundaries are derived by the Chunks module at
+// download time - never stored per-chunk (see Constants.mc for the OOM
+// post-mortem that forced this). Everything goes through the sidecar because
+// most books here are single 200MB-1GB files the watch cannot download whole.
 class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
 
     private var mItemId;
@@ -28,67 +29,47 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
             return;
         }
 
-        // Song-length chunks (~3 min, ~2MB at 96kbps mono) - matching how real,
-        // proven-working ACP apps like Spotify actually download audio (individual
-        // songs, a few MB each), not the originally-assumed 30-min/~14MB chunks,
-        // which failed immediately on real hardware ("Media Error Occurred").
-        // The very FIRST chunk of a book is deliberately much shorter - while
-        // this is still an open on-device debugging question, there's something
-        // to test playback with almost immediately rather than waiting for a
-        // full 3-min chunk (let alone a whole book).
-        var chunk = 180;
-        var firstChunk = 15;
         var files = data["files"];
         var title = data["title"];
         if (title == null) { title = "Book"; }
 
+        var inos = [];
+        var durs = [];
+        for (var f = 0; f < files.size(); ++f) {
+            var dur = numOr(files[f]["duration"], 0).toNumber();
+            if (dur <= 0) { continue; }
+            inos.add(files[f]["ino"]);
+            durs.add(dur);
+        }
+
+        var expected = Chunks.total(durs);
+        if (expected == 0) {
+            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errNoAudio)), new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
+            return;
+        }
+
         // Re-selecting an already-fully-downloaded book must not silently queue
-        // a full re-download of every chunk - tell the user it's already there
-        // instead of burning battery/data re-syncing the same book.
-        var expected = expectedChunkCount(files, chunk, firstChunk);
-        if ((expected > 0) && (alreadyDownloadedCount() >= expected)) {
+        // a full re-download - tell the user it's already there instead.
+        var have = BookStore.count(mItemId);
+        if (have >= expected) {
             WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.alreadyDownloaded)),
                 new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }
 
-        var syncList = Application.Storage.getValue(Store.SYNC_LIST);
-        if (syncList == null) { syncList = {}; }
+        // One small job per book. "done" starts at the already-downloaded chunk
+        // count so an interrupted book resumes where it left off (chunks always
+        // download in order, so count == next index).
+        var jobs = Application.Storage.getValue(Store.SYNC_JOBS);
+        if (jobs == null) { jobs = {}; }
+        jobs[mItemId] = {
+            "inos"  => inos,
+            "durs"  => durs,
+            "title" => title,
+            "done"  => have
+        };
+        Application.Storage.setValue(Store.SYNC_JOBS, jobs);
 
-        var bookOffset = 0;
-        var idx = 0;
-        for (var f = 0; f < files.size(); ++f) {
-            var ino = files[f]["ino"];
-            var dur = numOr(files[f]["duration"], 0).toNumber();
-            if (dur <= 0) { continue; }
-            var pos = 0;
-            while (pos < dur) {
-                var size = (idx == 0) ? firstChunk : chunk;
-                var end = pos + size;
-                if (end > dur) { end = dur; }
-                syncList[mItemId + ":" + idx] = {
-                    TrackInfo.ITEM_ID    => mItemId,
-                    TrackInfo.INO        => ino,
-                    TrackInfo.CSTART     => pos,
-                    TrackInfo.CEND       => end,
-                    TrackInfo.START      => bookOffset + pos,
-                    TrackInfo.TITLE      => title + " " + (idx + 1),
-                    TrackInfo.BOOK_TITLE => title,
-                    TrackInfo.TYPE       => "adts",
-                    TrackInfo.CAN_SKIP   => true
-                };
-                idx += 1;
-                pos = end;
-            }
-            bookOffset = bookOffset + dur;
-        }
-
-        if (idx == 0) {
-            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errNoAudio)), new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
-            return;
-        }
-
-        Application.Storage.setValue(Store.SYNC_LIST, syncList);
         WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.queued)), new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
         Communications.startSync();
     }
@@ -96,39 +77,6 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
     function numOr(v, dflt) {
         if (v == null) { return dflt; }
         return v;
-    }
-
-    // Mirrors the chunking loop above exactly (count only, no allocation) so it
-    // can never disagree with how many chunks a book actually splits into.
-    function expectedChunkCount(files, chunk, firstChunk) {
-        var count = 0;
-        for (var f = 0; f < files.size(); ++f) {
-            var dur = numOr(files[f]["duration"], 0).toNumber();
-            if (dur <= 0) { continue; }
-            var pos = 0;
-            while (pos < dur) {
-                var size = (count == 0) ? firstChunk : chunk;
-                var end = pos + size;
-                if (end > dur) { end = dur; }
-                count += 1;
-                pos = end;
-            }
-        }
-        return count;
-    }
-
-    function alreadyDownloadedCount() {
-        var tracks = Application.Storage.getValue(Store.TRACKS);
-        if (tracks == null) { return 0; }
-        var count = 0;
-        var refIds = tracks.keys();
-        for (var i = 0; i < refIds.size(); ++i) {
-            var info = tracks[refIds[i]];
-            if ((info != null) && (info[TrackInfo.ITEM_ID] != null) && info[TrackInfo.ITEM_ID].equals(mItemId)) {
-                count += 1;
-            }
-        }
-        return count;
     }
 
     function onBack() {

--- a/source/BookStore.mc
+++ b/source/BookStore.mc
@@ -1,0 +1,129 @@
+using Toybox.Application;
+using Toybox.Media;
+
+// Persistent store for DOWNLOADED books. Owns the media-cache lifecycle of
+// every recorded chunk. Layout (see Constants.mc for the OOM post-mortem that
+// forced O(books) storage):
+//
+//   "trk:"  + itemId          => { "title" => str, "durs" => [num, ...] }
+//   "trkc:" + itemId + ":" + p => [ refId, ... ]   (page p, PAGE_SIZE entries)
+//
+// Chunks are stored as ARRAYS indexed by chunk number, in pages:
+//  - position == chunk index, so re-recording a chunk after a crash/resume
+//    OVERWRITES (and evicts the superseded cached item) instead of duplicating,
+//    and "count == next chunk to download" holds by construction.
+//  - pages keep every Storage value bounded (~11KB worst case at UUID-length
+//    refIds) - a single flat per-book value would cross the documented
+//    32KB-per-value cap on 33h+ books.
+module BookStore {
+
+    const PAGE_SIZE = 256;
+
+    function key(itemId) {
+        return "trk:" + itemId;
+    }
+    function pageKey(itemId, p) {
+        return "trkc:" + itemId + ":" + p;
+    }
+
+    // Book metadata { "title", "durs" }, or null if nothing recorded yet.
+    function get(itemId) {
+        return Application.Storage.getValue(key(itemId));
+    }
+
+    function ensureMeta(itemId, title, durs) {
+        if (get(itemId) == null) {
+            Application.Storage.setValue(key(itemId), { "title" => title, "durs" => durs });
+        }
+    }
+
+    // Downloaded-chunk count for a book (0 if none). Chunks download strictly
+    // in order, so this is also the next chunk index to fetch.
+    function count(itemId) {
+        var total = 0;
+        var p = 0;
+        while (true) {
+            var arr = Application.Storage.getValue(pageKey(itemId, p));
+            if (arr == null) { return total; }
+            total += arr.size();
+            p += 1;
+        }
+        return total;
+    }
+
+    // Record chunk k's cache refId. Only page k/PAGE_SIZE is read-modified-
+    // written, so the write stays small no matter how long the book is. If a
+    // refId is already recorded at k (crash-window re-download), the OLD
+    // cached item is evicted and the slot overwritten - no duplicates, ever.
+    function saveChunk(itemId, k, refId) {
+        var p = (k / PAGE_SIZE).toNumber();
+        var idx = k - (p * PAGE_SIZE);
+        var arr = Application.Storage.getValue(pageKey(itemId, p));
+        if (arr == null) { arr = []; }
+        if (idx < arr.size()) {
+            var old = arr[idx];
+            if ((old != null) && !old.equals(refId)) {
+                Media.deleteCachedItem(new Media.ContentRef(old, Media.CONTENT_TYPE_AUDIO));
+            }
+            arr[idx] = refId;
+        } else {
+            // Defensive: pad any gap (shouldn't occur - downloads are strictly
+            // in-order) so position always equals chunk index.
+            while (arr.size() < idx) { arr.add(null); }
+            arr.add(refId);
+        }
+        Application.Storage.setValue(pageKey(itemId, p), arr);
+    }
+
+    // Delete a book: evict every recorded chunk from the media cache, then
+    // drop its pages and metadata. One page in memory at a time. Pages are
+    // deleted in DESCENDING order: every reader (count/addLookup/this probe)
+    // stops at the first missing page, so an interrupted delete must leave a
+    // contiguous 0..m prefix for its retry to find and finish - deleting
+    // ascending would strand pages >=1 forever (unreachable keys plus their
+    // cached media) the moment page 0 vanished.
+    function deleteBook(itemId) {
+        var last = -1;
+        while (Application.Storage.getValue(pageKey(itemId, last + 1)) != null) {
+            last += 1;
+        }
+        for (var p = last; p >= 0; --p) {
+            var arr = Application.Storage.getValue(pageKey(itemId, p));
+            if (arr != null) {
+                for (var i = 0; i < arr.size(); ++i) {
+                    if (arr[i] != null) {
+                        Media.deleteCachedItem(new Media.ContentRef(arr[i], Media.CONTENT_TYPE_AUDIO));
+                    }
+                }
+            }
+            Application.Storage.deleteValue(pageKey(itemId, p));
+        }
+        Application.Storage.deleteValue(key(itemId));
+    }
+
+    // Build { refId => [bookOrder, bookAbsoluteStartSeconds] } for one book
+    // into `out` (a shared lookup dict used by playback). bookOrder is the
+    // caller-supplied position of this book (its BOOK_INDEX slot) - playback
+    // sorts on it NUMERICALLY. Never sort on the title string: Monkey C
+    // String does not support relational operators at runtime (throws
+    // UnexpectedTypeException; compiles silently at typecheck=0), and equal
+    // titles would interleave two books chunk-by-chunk.
+    function addLookup(itemId, order, out) {
+        var meta = get(itemId);
+        if (meta == null) { return; }
+        var starts = Chunks.starts(meta["durs"]);
+        var k = 0;
+        var p = 0;
+        while (true) {
+            var arr = Application.Storage.getValue(pageKey(itemId, p));
+            if (arr == null) { break; }
+            for (var i = 0; i < arr.size(); ++i) {
+                if ((arr[i] != null) && (k < starts.size())) {
+                    out[arr[i]] = [order, starts[k]];
+                }
+                k += 1;
+            }
+            p += 1;
+        }
+    }
+}

--- a/source/Chunks.mc
+++ b/source/Chunks.mc
@@ -1,0 +1,85 @@
+// Chunk math shared by BookMenuDelegate (queueing) and SyncDelegate
+// (downloading). Chunk boundaries are DERIVED from the book's per-file
+// durations every time they're needed, never materialized as per-chunk
+// records - a 19h book is ~390 chunks, and storing (or even holding) one
+// dictionary per chunk is what used to blow the 512KB audioContentProvider
+// memory ceiling ("Media Error Occurred", reproduced in the simulator).
+//
+// The very FIRST chunk of a book is deliberately short so there's something
+// to test playback with almost immediately; all later chunks are song-length
+// (~3 min, ~2MB at 96kbps mono), matching how proven ACP apps like Spotify
+// download audio. Both loops below MUST stay identical to each other.
+module Chunks {
+    const FIRST = 15;    // seconds, global chunk 0 only
+    const LEN   = 180;   // seconds, every other chunk
+
+    // Total chunk count across a book's files. durs = [seconds, ...].
+    function total(durs) {
+        var n = 0;
+        for (var f = 0; f < durs.size(); ++f) {
+            var d = durs[f];
+            if (d <= 0) { continue; }
+            var pos = 0;
+            while (pos < d) {
+                var size = (n == 0) ? FIRST : LEN;
+                var end = pos + size;
+                if (end > d) { end = d; }
+                n += 1;
+                pos = end;
+            }
+        }
+        return n;
+    }
+
+    // Book-absolute start offset (seconds) of EVERY chunk, in one pass:
+    // [ start0, start1, ... ]. Used to map recorded chunk indexes back to
+    // positions for playback ordering and ABS progress sync.
+    function starts(durs) {
+        var out = [];
+        var bookOffset = 0;
+        for (var f = 0; f < durs.size(); ++f) {
+            var d = durs[f];
+            if (d <= 0) { continue; }
+            var pos = 0;
+            while (pos < d) {
+                var size = (out.size() == 0) ? FIRST : LEN;
+                var end = pos + size;
+                if (end > d) { end = d; }
+                out.add(bookOffset + pos);
+                pos = end;
+            }
+            bookOffset = bookOffset + d;
+        }
+        return out;
+    }
+
+    // Boundaries of global chunk k, or null if k is out of range. Returns
+    // { "file" => file index, "cstart"/"cend" => seconds within that file,
+    //   "start" => absolute seconds within the whole book }.
+    function at(durs, k) {
+        var n = 0;
+        var bookOffset = 0;
+        for (var f = 0; f < durs.size(); ++f) {
+            var d = durs[f];
+            if (d <= 0) { continue; }
+            var pos = 0;
+            while (pos < d) {
+                var size = (n == 0) ? FIRST : LEN;
+                var end = pos + size;
+                if (end > d) { end = d; }
+                if (n == k) {
+                    return {
+                        "file"   => f,
+                        "cstart" => pos,
+                        "cend"   => end,
+                        "start"  => bookOffset + pos
+                    };
+                }
+                n += 1;
+                pos = end;
+            }
+            bookOffset = bookOffset + d;
+        }
+        return null;
+    }
+}

--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -2,15 +2,34 @@ using Toybox.Application;
 
 // ---------------------------------------------------------------------------
 // Application.Storage keys (object store). These hold app STATE (not user
-// settings): the download queue, the delete queue, the map of downloaded
-// chapter tracks, and the app version. Storage (not Properties) because these
-// are code-managed and a sync/background process CAN write Storage but NOT
-// Properties.
+// settings). Storage (not Properties) because these are code-managed and a
+// sync/background process CAN write Storage but NOT Properties.
+//
+// SIZE MATTERS HERE - this layout exists because the first design stored one
+// dictionary entry PER CHUNK in a single Storage value ({ "itemId:idx" =>
+// 9-field dict }), and a long audiobook (The Algebraist: 19.4h = 389 chunks)
+// made that value large enough that Storage.setValue() died with a FATAL,
+// UNCATCHABLE "Out Of Memory Error" - reproduced in the simulator against
+// this exact device profile (fenix8solar51mm), which gives an
+// audioContentProvider app only 512KB. On the watch that crash surfaces as
+// the native "Media Error Occurred" dialog + app exit. Storage values are
+// also hard-limited to 32KB each (SDK-documented). So: everything below is
+// O(books), never O(chunks) - chunk boundaries are DERIVED via the Chunks
+// module, and per-chunk refIds live in one small per-book value.
 // ---------------------------------------------------------------------------
 module Store {
-    const SYNC_LIST   = "syncList";    // { trackKey => TrackInfo dict } queued to download
-    const DELETE_LIST = "deleteList";  // [ refId, ... ] queued to delete from media cache
-    const TRACKS      = "tracks";       // { refId => TrackInfo dict } already on device
+    // { itemId => { "inos" => [str], "durs" => [num], "title" => str,
+    //   "done" => num } } - one small job per QUEUED book; chunk boundaries
+    // derived on the fly, "done" is the resume cursor. ALWAYS read fresh and
+    // read-modify-written per event, never held across events: a long-lived
+    // in-memory snapshot persisted wholesale silently clobbers queue writes
+    // made while a (background) sync is running.
+    const SYNC_JOBS   = "syncJobs";
+    // [ itemId, ... ] - books queued for DELETION (whole books only; the UI
+    // has no per-chunk delete).
+    const DELETE_LIST = "deleteList";
+    // [ itemId, ... ] - books with downloaded chunks (index for the menu).
+    const BOOK_INDEX  = "bookIndex";
     const APP_VERSION = "appVersion";  // Number, see Versions
     const SERVER      = "absServer";   // server URL saved by on-watch login
     const TOKEN       = "absToken";    // bearer token saved by on-watch login
@@ -29,26 +48,11 @@ module Settings {
 // Bump `current` whenever the stored data shape changes so stale caches reset.
 module Versions {
     enum {
-        V1 = 0
+        V1 = 0,
+        V2 = 1   // per-chunk SYNC_LIST/TRACKS dicts -> per-book jobs + BookStore
     }
-    const current = V1;
+    const current = V2;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b25";
-}
-
-// Keys for a TrackInfo dict (one downloaded/queued CHAPTER = one Media track).
-module TrackInfo {
-    // We store the chunk PARAMETERS (not the full URL) so hundreds of chunks stay
-    // small in Storage - the download URL (which embeds the long token) is rebuilt
-    // at download time via AbsApi.sidecarChunkUrl().
-    const TITLE      = "title";      // display title (this CHUNK - "Book Name 7")
-    const BOOK_TITLE = "bookTitle";  // display title of the BOOK this chunk belongs to
-    const TYPE       = "type";       // "mp3" -> Media.ENCODING_*
-    const ITEM_ID    = "itemId";     // ABS libraryItemId - groups a book's chunks together
-    const INO        = "ino";        // audio file inode
-    const CSTART     = "cstart";     // chunk start within the file (seconds)
-    const CEND       = "cend";       // chunk end within the file (seconds)
-    const START      = "start";      // book-absolute start (seconds) for progress
-    const CAN_SKIP   = "canSkip";
+    const tag = "b26";
 }

--- a/source/ContentDelegate.mc
+++ b/source/ContentDelegate.mc
@@ -7,9 +7,11 @@ using Toybox.System;
 class ContentDelegate extends Media.ContentDelegate {
 
     private var mIterator;
+    private var mProgressLookup; // { refId => [itemId, start] }, lazy
 
     function initialize() {
         ContentDelegate.initialize();
+        mProgressLookup = null;
         resetContentIterator();
     }
 
@@ -23,10 +25,11 @@ class ContentDelegate extends Media.ContentDelegate {
     }
 
     // Playback events. playbackPosition is seconds WITHIN the current chapter
-    // track; ABS wants book-absolute time, so we add the chapter's start offset
-    // stored in TrackInfo. We push progress on notify/pause/stop/complete using
-    // the CONFIRMED named enum (Media.SONG_EVENT_PLAYBACK_NOTIFY=3, COMPLETE=4,
-    // STOP=5, PAUSE=6) rather than magic numbers.
+    // track; ABS wants book-absolute time, so we add the chunk's start offset
+    // from its book's BookStore record. We push progress on
+    // notify/pause/stop/complete using the CONFIRMED named enum
+    // (Media.SONG_EVENT_PLAYBACK_NOTIFY=3, COMPLETE=4, STOP=5, PAUSE=6)
+    // rather than magic numbers.
     function onSong(refId, songEvent, playbackPosition) {
         if (songEvent == Media.SONG_EVENT_PLAYBACK_NOTIFY ||
             songEvent == Media.SONG_EVENT_COMPLETE ||
@@ -37,20 +40,31 @@ class ContentDelegate extends Media.ContentDelegate {
     }
 
     function syncProgress(refId, positionInChapter) {
-        var tracks = Application.Storage.getValue(Store.TRACKS);
-        if (tracks == null) { return; }
-        var info = tracks[refId];
-        if (info == null) { return; }
-
         if (!AbsApi.isConfigured()) { return; }
 
-        var start = info[TrackInfo.START];
-        if (start == null) { start = 0; }
-        var absolute = start + positionInChapter;
+        // { refId => [itemId, start] }, built once per playback session (the
+        // downloaded set can't change while the player is running - syncs
+        // and playback are separate app modes).
+        if (mProgressLookup == null) {
+            mProgressLookup = {};
+            var index = Application.Storage.getValue(Store.BOOK_INDEX);
+            if (index == null) { index = []; }
+            for (var b = 0; b < index.size(); ++b) {
+                var perBook = {};
+                BookStore.addLookup(index[b], b, perBook);
+                var refIds = perBook.keys();
+                for (var i = 0; i < refIds.size(); ++i) {
+                    mProgressLookup[refIds[i]] = [index[b], perBook[refIds[i]][1]];
+                }
+            }
+        }
 
+        var hit = mProgressLookup[refId];
+        if (hit == null) { return; }
+        var absolute = hit[1] + positionInChapter;
         // We do not know the book's total duration here; passing null lets ABS
         // keep its stored duration and just update currentTime.
-        AbsApi.patchProgress(info[TrackInfo.ITEM_ID], absolute, null);
+        AbsApi.patchProgress(hit[0], absolute, null);
     }
 
     function onShuffle() {

--- a/source/ContentIterator.mc
+++ b/source/ContentIterator.mc
@@ -3,13 +3,18 @@ using Toybox.Math;
 using Toybox.Media;
 using Toybox.System;
 
-// Yields cached chapter tracks to the player. Order = the TRACKS map grouped by
-// book (alphabetical by BOOK_TITLE), then sorted within each book by chapter
-// START offset - so with more than one book downloaded, playback finishes one
-// book before starting the next rather than interleaving their chapters (START
-// resets to 0 for every book independently, so sorting by START alone would mix
-// different books' chapters together in lockstep). Shuffle is available but off
-// by default (nobody shuffles an audiobook).
+// Yields cached chapter tracks to the player, grouped by book (alphabetical by
+// title), sorted within each book by absolute start offset - so with more than
+// one book downloaded, playback finishes one book before starting the next.
+// Shuffle is available but off by default (nobody shuffles an audiobook).
+//
+// MEMORY: this runs in the playback context, which shares the 512KB
+// audioContentProvider ceiling with the native player itself. Everything here
+// stays O(cached chunks) in small parallel arrays - the per-book BookStore
+// values hold only { refId => startSeconds }, and sorting is done in place
+// with swaps (no per-insert array rebuilds). The old design deserialized one
+// 9-field dict per chunk here and died with an uncatchable Out Of Memory
+// Error the moment the player screen opened ("Media Error Occurred").
 class ContentIterator extends Media.ContentIterator {
 
     private var mIndex;
@@ -112,71 +117,72 @@ class ContentIterator extends Media.ContentIterator {
         return null;
     }
 
-    // Build the ordered playlist from the OS's OWN content cache, never our own
-    // Storage bookkeeping - mirrors MonkeyMusic's initializePlaylist() exactly.
-    // Store.TRACKS can drift out of sync with what the OS actually has cached
-    // (a stale/removed entry, or a key that doesn't round-trip identically
-    // through Storage's persistence layer); handing the OS back one of ITS OWN
-    // ids is the only way to guarantee Media.getCachedContentObj() resolves it.
-    // Store.TRACKS is used ONLY for sort metadata (bookTitle, chapterStart)
-    // below, never as the id source. Insertion sort by (bookTitle,
-    // chapterStart), plain statements (no fluent slice().add().addAll()
-    // chaining, which relies on Array.add/addAll returning the array - they
-    // return Void).
+    // Build the ordered playlist. Ids come from the OS's OWN content cache
+    // (Media.getContentRefIter - mirrors MonkeyMusic), never our bookkeeping;
+    // BookStore supplies only sort metadata (book order, chunk start). A
+    // cached id BookStore doesn't know is SKIPPED - it's an orphan from a
+    // crash window (cached but never recorded), not playable content we can
+    // name or order. Sorted in place by (bookOrder, start) with parallel
+    // arrays and swaps - NUMERIC keys only. Never sort on title strings:
+    // Monkey C String has no relational operators at runtime (throws
+    // UnexpectedTypeException, invisible at typecheck=0 - empirically
+    // confirmed in the simulator), and identical titles would interleave two
+    // books chunk-by-chunk.
     function buildPlaylist() {
         mPlaylist = [];
-        var tracks = Application.Storage.getValue(Store.TRACKS);
-        if (tracks == null) { tracks = {}; }
+        var orders = [];
+        var starts = [];
 
-        var refIds = [];
+        // One { refId => [bookOrder, start] } lookup across every downloaded
+        // book; bookOrder = the book's BOOK_INDEX position.
+        var lookup = {};
+        var index = Application.Storage.getValue(Store.BOOK_INDEX);
+        if (index == null) { index = []; }
+        for (var b = 0; b < index.size(); ++b) {
+            BookStore.addLookup(index[b], b, lookup);
+        }
+
         var iter = Media.getContentRefIter({ :contentType => Media.CONTENT_TYPE_AUDIO });
         if (iter != null) {
             var ref = iter.next();
             while (ref != null) {
-                refIds.add(ref.getId());
+                var refId = ref.getId();
+                var info = lookup[refId];
+                if (info != null) {
+                    mPlaylist.add(refId);
+                    orders.add(info[0]);
+                    starts.add(info[1]);
+                }
                 ref = iter.next();
             }
         }
 
-        for (var i = 0; i < refIds.size(); ++i) {
-            var refId = refIds[i];
-
-            var pos = mPlaylist.size();
-            for (var j = 0; j < mPlaylist.size(); ++j) {
-                if (before(tracks, refId, mPlaylist[j])) { pos = j; break; }
+        // In-place insertion sort on the three parallel arrays: stable, no
+        // allocations, numeric compares only. Chunks download (and cache) in
+        // playlist order, so the input is near-sorted and this stays ~O(n).
+        for (var i = 1; i < mPlaylist.size(); ++i) {
+            var j = i;
+            while (j > 0 && after(orders[j - 1], starts[j - 1], orders[j], starts[j])) {
+                swap(mPlaylist, j); swap(orders, j); swap(starts, j);
+                --j;
             }
-
-            // Insert refId at pos by rebuilding the array in one pass.
-            var rebuilt = new [mPlaylist.size() + 1];
-            for (var k = 0; k < pos; ++k) { rebuilt[k] = mPlaylist[k]; }
-            rebuilt[pos] = refId;
-            for (var k = pos; k < mPlaylist.size(); ++k) { rebuilt[k + 1] = mPlaylist[k]; }
-            mPlaylist = rebuilt;
         }
         mIndex = 0;
     }
 
-    // True if refIdA sorts before refIdB: by book title first (so one book's
-    // chapters never interleave with another's), then by chapter start.
-    function before(tracks, refIdA, refIdB) {
-        var titleA = bookTitleOf(tracks, refIdA);
-        var titleB = bookTitleOf(tracks, refIdB);
-        if (!titleA.equals(titleB)) {
-            return titleA < titleB;
+    // True if (orderA, startA) sorts AFTER (orderB, startB): by book first
+    // (one book's chapters never interleave with another's), then start.
+    function after(orderA, startA, orderB, startB) {
+        if (orderA != orderB) {
+            return orderA > orderB;
         }
-        return startOf(tracks, refIdA) < startOf(tracks, refIdB);
+        return startA > startB;
     }
 
-    function bookTitleOf(tracks, refId) {
-        var info = tracks[refId];
-        if ((info != null) && (info[TrackInfo.BOOK_TITLE] != null)) { return info[TrackInfo.BOOK_TITLE]; }
-        return "";
-    }
-
-    function startOf(tracks, refId) {
-        var info = tracks[refId];
-        if ((info != null) && (info[TrackInfo.START] != null)) { return info[TrackInfo.START]; }
-        return 0;
+    function swap(arr, j) {
+        var tmp = arr[j];
+        arr[j] = arr[j - 1];
+        arr[j - 1] = tmp;
     }
 
     function shuffle() {

--- a/source/DownloadedMenu.mc
+++ b/source/DownloadedMenu.mc
@@ -2,12 +2,11 @@ using Toybox.Application;
 using Toybox.Media;
 using Toybox.WatchUi;
 
-// Lists downloaded books (grouped from their individual chunk tracks - a book is
-// ~3-min chunks, so a long audiobook can be 100+ tracks; showing each one
-// individually would make this screen unusable). Selecting a book removes ALL of
-// its chunks; "Play downloaded" starts playback (Media.startPlayback), which
-// hands off to the native player driving ContentIterator's set. The watch's own
-// Music widget (hold the music-controls button -> Music Providers -> WatchShelf)
+// Lists downloaded books - one row per book from the BOOK_INDEX, with the
+// chunk count as the subtitle. Selecting a book removes ALL of its chunks;
+// "Play downloaded" starts playback (Media.startPlayback), which hands off to
+// the native player driving ContentIterator's set. The watch's own Music
+// widget (hold the music-controls button -> Music Providers -> WatchShelf)
 // reaches the SAME downloaded content and is the platform-standard way in too.
 class DownloadedMenu extends WatchUi.Menu2 {
 
@@ -19,8 +18,8 @@ class DownloadedMenu extends WatchUi.Menu2 {
         // logs the user in first if they aren't configured yet.
         addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.browseLibrary), null, "browse", null));
 
-        var books = groupedBooks();
-        var itemIds = books.keys();
+        var index = Application.Storage.getValue(Store.BOOK_INDEX);
+        if (index == null) { index = []; }
 
         // Explicit, direct "Play" action - a plain MenuItem calling
         // Media.startPlayback() straight from onSelect. NOT wired through
@@ -28,7 +27,7 @@ class DownloadedMenu extends WatchUi.Menu2 {
         // triggered by a WatchUi.CheckboxMenu, never a plain Menu2 like this
         // one - so a Done-based "play" action here would be silently
         // unreachable on real hardware no matter what the user pressed.
-        if (itemIds.size() > 0) {
+        if (index.size() > 0) {
             addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.playDownloaded), null, "play", null));
         }
 
@@ -38,68 +37,33 @@ class DownloadedMenu extends WatchUi.Menu2 {
             addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.logOut), null, "logout", null));
         }
 
-        // A crashed/interrupted sync can leave queued entries behind (they're
-        // only cleared as each one finishes downloading), which then get
-        // reprocessed on every future sync alongside anything new. Offer a way
-        // to wipe just the pending queue - sideloaded apps can't be cleanly
+        // A crashed/interrupted sync can leave queued jobs behind, which then
+        // get reprocessed on every future sync alongside anything new. Offer a
+        // way to wipe just the pending queue - sideloaded apps can't be cleanly
         // uninstalled to reset this, so it has to be reachable from in here.
         if (hasQueued()) {
             addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.clearQueue), null, "clearqueue", null));
         }
 
-        if (itemIds.size() > 0) {
+        if (index.size() > 0) {
             addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.deleteAllDownloads), null, "deleteall", null));
         }
 
-        for (var i = 0; i < itemIds.size(); ++i) {
-            var itemId = itemIds[i];
-            var book = books[itemId];
-            var sub = book["count"].toString() + " part" + ((book["count"] == 1) ? "" : "s");
-            addItem(new WatchUi.MenuItem(book["title"], sub, itemId, null));
+        for (var i = 0; i < index.size(); ++i) {
+            var itemId = index[i];
+            var meta = BookStore.get(itemId);
+            var title = ((meta != null) && (meta["title"] != null)) ? meta["title"] : "Book";
+            var count = BookStore.count(itemId);
+            var sub = count.toString() + " part" + ((count == 1) ? "" : "s");
+            addItem(new WatchUi.MenuItem(title, sub, itemId, null));
         }
     }
 
     function hasQueued() {
-        var syncList = Application.Storage.getValue(Store.SYNC_LIST);
+        var jobs = Application.Storage.getValue(Store.SYNC_JOBS);
         var deleteList = Application.Storage.getValue(Store.DELETE_LIST);
-        return ((syncList != null) && (syncList.size() > 0))
+        return ((jobs != null) && (jobs.size() > 0))
             || ((deleteList != null) && (deleteList.size() > 0));
-    }
-
-    // { itemId => { "title" => bookTitle, "count" => Number } } - one entry per
-    // book, folding every chunk that shares the same TrackInfo.ITEM_ID together.
-    function groupedBooks() {
-        var tracks = Application.Storage.getValue(Store.TRACKS);
-        if (tracks == null) { tracks = {}; }
-
-        var books = {};
-        var refIds = tracks.keys();
-        for (var i = 0; i < refIds.size(); ++i) {
-            var info = tracks[refIds[i]];
-            var itemId = info[TrackInfo.ITEM_ID];
-            if (itemId == null) { itemId = "unknown"; }
-
-            var book = books[itemId];
-            if (book == null) {
-                book = { "title" => bookTitle(refIds[i], info), "count" => 0 };
-                books[itemId] = book;
-            }
-            book["count"] = book["count"] + 1;
-        }
-        return books;
-    }
-
-    // Prefer the cached media's own metadata title (whole-file, no chunk suffix);
-    // fall back to stored BOOK_TITLE, then the per-chunk TITLE, then "Book".
-    function bookTitle(refId, info) {
-        var ref = new Media.ContentRef(refId, Media.CONTENT_TYPE_AUDIO);
-        var obj = Media.getCachedContentObj(ref);
-        if (obj != null && obj.getMetadata() != null && obj.getMetadata().title != null) {
-            return obj.getMetadata().title;
-        }
-        if (info[TrackInfo.BOOK_TITLE] != null) { return info[TrackInfo.BOOK_TITLE]; }
-        if (info[TrackInfo.TITLE] != null) { return info[TrackInfo.TITLE]; }
-        return "Book";
     }
 
     // Show used cache space in the menu title. CacheStatistics exposes `size`

--- a/source/DownloadedMenuDelegate.mc
+++ b/source/DownloadedMenuDelegate.mc
@@ -43,49 +43,41 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
         }
 
         // "Clear queue" -> abandon anything pending (a crashed/interrupted sync
-        // can leave entries behind, since they're only cleared as each finishes)
-        // WITHOUT starting a sync - we want to drop them, not process them.
+        // can leave queued jobs behind, since they're only cleared as each book
+        // finishes) WITHOUT starting a sync - we want to drop them, not process
+        // them.
         if ((id instanceof Toybox.Lang.String) && id.equals("clearqueue")) {
-            Application.Storage.setValue(Store.SYNC_LIST, {});
+            Application.Storage.setValue(Store.SYNC_JOBS, {});
             Application.Storage.setValue(Store.DELETE_LIST, []);
             WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.queueCleared)), new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }
 
-        // "Delete all downloads" -> queue every downloaded chunk, across every book.
+        // "Delete all downloads" -> queue every downloaded book.
         if ((id instanceof Toybox.Lang.String) && id.equals("deleteall")) {
-            var tracks = Application.Storage.getValue(Store.TRACKS);
-            if (tracks == null) { tracks = {}; }
-            queueDelete(tracks.keys());
+            var index = Application.Storage.getValue(Store.BOOK_INDEX);
+            if (index == null) { index = []; }
+            queueDelete(index);
             return;
         }
 
-        // Anything else is a BOOK's itemId (DownloadedMenu now groups chunks by
-        // book, not one row per chunk - a book can be 100+ ~3-min chunks, so
-        // showing/deleting them individually isn't usable). Find every
-        // downloaded refId that belongs to this book and queue them all.
-        var tracks = Application.Storage.getValue(Store.TRACKS);
-        if (tracks == null) { tracks = {}; }
-        var refIds = tracks.keys();
-        var toDelete = [];
-        for (var i = 0; i < refIds.size(); ++i) {
-            var info = tracks[refIds[i]];
-            if ((info != null) && (info[TrackInfo.ITEM_ID] != null) && info[TrackInfo.ITEM_ID].equals(id)) {
-                toDelete.add(refIds[i]);
-            }
-        }
-        queueDelete(toDelete);
+        // Anything else is a BOOK's itemId - queue that one book for deletion.
+        // Deletions are always whole-book (a book can be 100+ ~3-min chunks;
+        // per-chunk anything isn't usable, and per-chunk STORAGE is what used
+        // to OOM-crash the app - see Constants.mc).
+        queueDelete([id]);
     }
 
-    // Add every given refId to the delete queue, then run a sync now to perform
-    // the deletions (Media.deleteCachedItem happens in SyncDelegate.deleteQueued).
-    function queueDelete(refIds) {
-        if (refIds.size() == 0) { return; }
+    // Add every given book itemId to the delete queue, then run a sync now to
+    // perform the deletions (Media.deleteCachedItem happens per cached chunk in
+    // SyncDelegate.deleteQueued).
+    function queueDelete(itemIds) {
+        if (itemIds.size() == 0) { return; }
 
         var deleteList = Application.Storage.getValue(Store.DELETE_LIST);
         if (deleteList == null) { deleteList = []; }
-        for (var i = 0; i < refIds.size(); ++i) {
-            deleteList.add(refIds[i]);
+        for (var i = 0; i < itemIds.size(); ++i) {
+            deleteList.add(itemIds[i]);
         }
         Application.Storage.setValue(Store.DELETE_LIST, deleteList);
 

--- a/source/SyncDelegate.mc
+++ b/source/SyncDelegate.mc
@@ -2,10 +2,21 @@ using Toybox.Application;
 using Toybox.Communications;
 using Toybox.Media;
 
-// Downloads queued CHAPTER tracks to the device media cache. One chapter == one
-// Media track, so the native player gives real chapter navigation (we never
-// flatten a book into a single track). Mirrors MonkeyMusic's SyncDelegate but
-// operates on chapter tracks and reports progress via Communications.notify*.
+// Downloads queued books to the device media cache, one derived chunk at a
+// time. One chunk == one Media track, so the native player gives real chapter
+// navigation. Works from the per-book jobs in Store.SYNC_JOBS - chunk
+// boundaries come from Chunks.at(), and each downloaded refId is recorded via
+// BookStore.saveChunk (position == chunk index, overwrite-safe). Nothing here
+// is ever O(chunks) in a single Storage value (see Constants.mc for the OOM
+// post-mortem).
+//
+// STORAGE DISCIPLINE: Store.SYNC_JOBS is read FRESH at every step and only
+// read-modify-written - never held in a long-lived field and persisted
+// wholesale. A snapshot design silently clobbered any queue change made while
+// a sync was running (book queued mid-sync erased after "Queued!" was shown;
+// "Clear queue" undone seconds later) and let a deleted book's job survive
+// deletion, resurrecting the book with its head chunks permanently missing.
+//
 // Extends Communications.SyncDelegate. VERIFIED against SDK 9.2.0's api.mir
 // (the compiler's own contract, not docs or samples):
 // AudioContentProviderApp.getSyncDelegate() is declared
@@ -17,126 +28,228 @@ using Toybox.Media;
 // persisted), and was reverted.
 class SyncDelegate extends Communications.SyncDelegate {
 
-    private var mSyncList;   // { trackKey => TrackInfo }
-    private var mDeleteList; // [ refId, ... ]
-    private var mKeys;       // ordered keys of mSyncList we still need to fetch
-    private var mTotal;      // total ops (downloads + deletes) for progress math
+    private var mTotal;      // ops planned at sync start (downloads + deletes)
     private var mDone;       // ops completed
 
     function initialize() {
         SyncDelegate.initialize();
-
-        mSyncList = Application.Storage.getValue(Store.SYNC_LIST);
-        if (mSyncList == null) { mSyncList = {}; }
-
-        mDeleteList = Application.Storage.getValue(Store.DELETE_LIST);
-        if (mDeleteList == null) { mDeleteList = []; }
-
+        mTotal = 0;
         mDone = 0;
+    }
+
+    function jobs() {
+        var j = Application.Storage.getValue(Store.SYNC_JOBS);
+        return (j == null) ? {} : j;
+    }
+
+    function deletes() {
+        var d = Application.Storage.getValue(Store.DELETE_LIST);
+        return (d == null) ? [] : d;
     }
 
     // The system only starts a sync when this is true.
     function isSyncNeeded() {
-        return (mSyncList.size() != 0) || (mDeleteList.size() != 0);
+        return (jobs().size() != 0) || (deletes().size() != 0);
     }
 
     function onStartSync() {
-        mTotal = mSyncList.size() + mDeleteList.size();
+        var toDelete = deletes();
+
+        // Cancel any queued job for a book being deleted BEFORE counting or
+        // downloading anything - otherwise the very sync that deletes the book
+        // resumes its job and resurrects it missing its head chunks.
+        if (toDelete.size() > 0) {
+            var j = jobs();
+            var changed = false;
+            for (var i = 0; i < toDelete.size(); ++i) {
+                if (j[toDelete[i]] != null) {
+                    j.remove(toDelete[i]);
+                    changed = true;
+                }
+            }
+            if (changed) {
+                Application.Storage.setValue(Store.SYNC_JOBS, j);
+            }
+        }
+
+        var remaining = jobs();
+        mTotal = toDelete.size();
+        var itemIds = remaining.keys();
+        for (var i = 0; i < itemIds.size(); ++i) {
+            var job = remaining[itemIds[i]];
+            var left = Chunks.total(job["durs"]) - job["done"];
+            if (left > 0) { mTotal += left; }
+        }
         if (mTotal == 0) {
             Communications.notifySyncComplete(null);
             return;
         }
-        deleteQueued();
-        mKeys = mSyncList.keys();
+
+        deleteQueued(toDelete);
         downloadNext();
     }
 
-    // System-initiated cancel: stop cleanly. In-flight request is abandoned.
+    // System-initiated cancel: stop cleanly. In-flight request is abandoned;
+    // jobs stay in Storage with their cursor, so the next sync resumes.
     function onStopSync() {
         Communications.cancelAllRequests();
         Communications.notifySyncComplete(null);
     }
 
-    // Delete every queued refId from the media cache, then clear the queue.
-    function deleteQueued() {
-        var tracks = Application.Storage.getValue(Store.TRACKS);
-        if (tracks == null) { tracks = {}; }
-
-        for (var i = 0; i < mDeleteList.size(); ++i) {
-            var refId = mDeleteList[i];
-            Media.deleteCachedItem(new Media.ContentRef(refId, Media.CONTENT_TYPE_AUDIO));
-            tracks.remove(refId);
+    // Delete every queued BOOK: BookStore evicts its cached chunks and drops
+    // its records; then remove it from the menu index. If nothing downloaded
+    // remains at all afterwards, sweep the whole media cache too - that
+    // reclaims any orphaned cache items a crash window may have left behind
+    // (cached but never recorded), which no per-book path can reach.
+    function deleteQueued(toDelete) {
+        if (toDelete.size() == 0) { return; }
+        for (var i = 0; i < toDelete.size(); ++i) {
+            BookStore.deleteBook(toDelete[i]);
+            removeFromIndex(toDelete[i]);
             onOpDone();
         }
-        Application.Storage.setValue(Store.TRACKS, tracks);
-        Application.Storage.deleteValue(Store.DELETE_LIST);
-        mDeleteList = [];
+
+        // Remove ONLY the entries just processed - a delete the UI queued
+        // while this loop ran must survive for the next sync, not be
+        // silently dropped by a wholesale clear.
+        var fresh = deletes();
+        var remaining = [];
+        for (var i = 0; i < fresh.size(); ++i) {
+            if (!containsId(toDelete, fresh[i])) { remaining.add(fresh[i]); }
+        }
+        if (remaining.size() > 0) {
+            Application.Storage.setValue(Store.DELETE_LIST, remaining);
+        } else {
+            Application.Storage.deleteValue(Store.DELETE_LIST);
+        }
+
+        var index = Application.Storage.getValue(Store.BOOK_INDEX);
+        if (((index == null) || (index.size() == 0)) && (jobs().size() == 0)) {
+            Media.resetContentCache();
+        }
     }
 
-    // Download the next queued chapter track as audio.
+    function containsId(arr, itemId) {
+        for (var i = 0; i < arr.size(); ++i) {
+            if (arr[i].equals(itemId)) { return true; }
+        }
+        return false;
+    }
+
+    // Download the next chunk of the first queued book. Reads the queue fresh
+    // so mid-sync queue changes (new book, clear queue, delete) take effect.
     function downloadNext() {
-        if (mKeys.size() == 0) {
-            Application.Storage.setValue(Store.SYNC_LIST, {});
+        var j = jobs();
+        var itemIds = j.keys();
+        if (itemIds.size() == 0) {
             Communications.notifySyncComplete(null);
             return;
         }
 
-        var key = mKeys[0];
-        var info = mSyncList[key];
+        var itemId = itemIds[0];
 
-        // Context we want back in the callback so we can record the ContentRef.
-        var context = { "key" => key, "info" => info };
+        // Honor a delete queued mid-sync: stop downloading the doomed book
+        // now (its actual deletion runs at the next sync start) instead of
+        // pouring hundreds more chunks into a book the user already deleted.
+        if (containsId(deletes(), itemId)) {
+            j.remove(itemId);
+            Application.Storage.setValue(Store.SYNC_JOBS, j);
+            downloadNext();
+            return;
+        }
+
+        var job = j[itemId];
+        var c = Chunks.at(job["durs"], job["done"]);
+        if (c == null) {
+            // Book finished (or cursor out of range) - drop the job, move on.
+            j.remove(itemId);
+            Application.Storage.setValue(Store.SYNC_JOBS, j);
+            downloadNext();
+            return;
+        }
 
         var options = {
             :method => Communications.HTTP_REQUEST_METHOD_GET,
             // Audio download: hand bytes straight to the media cache.
             :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_AUDIO,
-            // Encoding MUST match what the server/sidecar actually returns.
-            :mediaEncoding => typeToEncoding(info[TrackInfo.TYPE])
+            // The sidecar always transcodes chunks to AAC/ADTS.
+            :mediaEncoding => Media.ENCODING_ADTS
         };
 
+        var context = { "item" => itemId };
         var delegate = new RequestDelegate(method(:onTrackDownloaded), context);
-        var url = AbsApi.sidecarChunkUrl(info[TrackInfo.ITEM_ID], info[TrackInfo.INO],
-                                        info[TrackInfo.CSTART], info[TrackInfo.CEND]);
+        var url = AbsApi.sidecarChunkUrl(itemId, job["inos"][c["file"]],
+                                        c["cstart"], c["cend"]);
         delegate.makeWebRequest(url, null, options);
     }
 
-    // mp3 -> MP3, m4a -> M4A. Anything else is invalid and the download fails.
-    function typeToEncoding(type) {
-        if (type.equals("mp3")) { return Media.ENCODING_MP3; }
-        if (type.equals("m4a")) { return Media.ENCODING_M4A; }
-        if (type.equals("adts")) { return Media.ENCODING_ADTS; }
-        if (type.equals("wav")) { return Media.ENCODING_WAV; }
-        return Media.ENCODING_INVALID;
+    // On success `data` is a Media.ContentRef (the doc's union type is loose,
+    // but ContentRef is what an audio download delivers). Record its id at the
+    // job's cursor position and advance.
+    function onTrackDownloaded(code, data, context) {
+        if ((code != 200) || (data == null)) {
+            Communications.notifySyncComplete("Download failed (" + code + ")");
+            return;
+        }
+
+        var itemId = context["item"];
+        var refId = data.getId();
+
+        var j = jobs();
+        var job = j[itemId];
+        if (job == null) {
+            // The job was cancelled (cleared/deleted) while this chunk was in
+            // flight - evict the now-ownerless cached item and carry on with
+            // whatever the queue holds now.
+            Media.deleteCachedItem(new Media.ContentRef(refId, Media.CONTENT_TYPE_AUDIO));
+            downloadNext();
+            return;
+        }
+
+        var k = job["done"];
+        BookStore.ensureMeta(itemId, job["title"], job["durs"]);
+        BookStore.saveChunk(itemId, k, refId);
+        addToIndex(itemId);
+
+        // Advance + persist the cursor so a crash won't re-fetch. saveChunk is
+        // overwrite-by-position, so even a crash between these writes can only
+        // cause a harmless re-download, never a duplicate or a skipped chunk.
+        job["done"] = k + 1;
+        if (job["done"] >= Chunks.total(job["durs"])) {
+            j.remove(itemId);
+        }
+        Application.Storage.setValue(Store.SYNC_JOBS, j);
+
+        onOpDone();
+        downloadNext();
     }
 
-    // On success `data` is a Media.ContentRef (the doc's union type is loose, but
-    // ContentRef is what an audio download delivers). Store its id -> TrackInfo.
-    function onTrackDownloaded(code, data, context) {
-        if (code == 200) {
-            var refId = data.getId();
-
-            var tracks = Application.Storage.getValue(Store.TRACKS);
-            if (tracks == null) { tracks = {}; }
-            tracks[refId] = context["info"];
-            Application.Storage.setValue(Store.TRACKS, tracks);
-
-            // Remove from the pending queue and persist so a crash won't re-fetch.
-            mSyncList.remove(context["key"]);
-            Application.Storage.setValue(Store.SYNC_LIST, mSyncList);
-
-            onOpDone();
-
-            mKeys = mKeys.slice(1, mKeys.size());
-            downloadNext();
-        } else {
-            Communications.notifySyncComplete("Download failed (" + code + ")");
+    function addToIndex(itemId) {
+        var index = Application.Storage.getValue(Store.BOOK_INDEX);
+        if (index == null) { index = []; }
+        for (var i = 0; i < index.size(); ++i) {
+            if (index[i].equals(itemId)) { return; }
         }
+        index.add(itemId);
+        Application.Storage.setValue(Store.BOOK_INDEX, index);
+    }
+
+    function removeFromIndex(itemId) {
+        var index = Application.Storage.getValue(Store.BOOK_INDEX);
+        if (index == null) { return; }
+        var out = [];
+        for (var i = 0; i < index.size(); ++i) {
+            if (!index[i].equals(itemId)) { out.add(index[i]); }
+        }
+        Application.Storage.setValue(Store.BOOK_INDEX, out);
     }
 
     function onOpDone() {
         ++mDone;
+        // Mid-sync queue changes can grow/shrink the real work vs the plan
+        // made at sync start - clamp so the bar never runs past 100%.
         var pct = ((mDone / mTotal.toFloat()) * 100).toNumber();
+        if (pct > 100) { pct = 100; }
         Communications.notifySyncProgress(pct);
     }
 }

--- a/source/WatchShelfApp.mc
+++ b/source/WatchShelfApp.mc
@@ -7,11 +7,18 @@ using Toybox.Media;
 class WatchShelfApp extends Application.AudioContentProviderApp {
 
     function initialize() {
-        // Reset caches if the stored data shape changed between versions.
+        // Reset caches if the stored data shape changed between versions -
+        // but carry the login (server/token) across: it isn't shape-versioned
+        // data, and clearValues() would otherwise silently log the user out
+        // on every upgrade.
         var version = Application.Storage.getValue(Store.APP_VERSION);
         if (version != Versions.current) {
+            var server = Application.Storage.getValue(Store.SERVER);
+            var token = Application.Storage.getValue(Store.TOKEN);
             Application.Storage.clearValues();
             Media.resetContentCache();
+            if (server != null) { Application.Storage.setValue(Store.SERVER, server); }
+            if (token != null) { Application.Storage.setValue(Store.TOKEN, token); }
             Application.Storage.setValue(Store.APP_VERSION, Versions.current);
         }
         // NOTE: MonkeyMusic hardcoded a fake auth token here. WatchShelf does NOT:


### PR DESCRIPTION
## Root cause (reproduced, not guessed)
The old design stored one 9-field dict **per chunk** in single `Application.Storage` values (`SYNC_LIST` at queue time, `TRACKS` at play time). A 19.4h book = 389 chunks made `Storage.setValue()` die with a **fatal, uncatchable Out Of Memory Error** against the 512KB `audioContentProvider` ceiling — reproduced in the simulator on the `fenix8solar51mm` profile with a stack trace. On the watch this surfaces as the native "Media Error Occurred" dialog + app exit:
- queue-time crash → The Algebraist download failure
- play-time deserialization of the same shape → the Nightingale playback failure

Audio encoding was never the problem (2 MP3 configs + AAC/ADTS all failed identically because the crash precedes any decode).

## New layout (simulator-verified at 1200-chunk / 60h scale)
- `SYNC_JOBS`: one small per-book job `{inos, durs, title, done}`; chunk boundaries derived by the new `Chunks` module, never stored.
- `BookStore` (new): paged refId arrays (`trkc:<itemId>:<page>`, 256/page) where **position == chunk index** — overwrite-by-position makes crash-window re-downloads duplicate- and skip-proof; every value stays far under the 32KB/value cap.
- `SYNC_JOBS` read fresh + RMW per event (no long-lived snapshot); deletes cancel the book's job before anything counts or downloads; mid-sync deletes stop further chunks of the doomed book.
- Playlist sorts on `(bookOrder, start)` **numerically** — Monkey C `String` has no runtime relational operators (throws `UnexpectedTypeException`, invisible at typecheck=0, empirically confirmed in the simulator), so the previous title sort would have crashed playback with 2+ books.
- `V1→V2` version bump clears all old-shape storage on first launch, preserving login across the reset.

## Verification
- Old shape at Algebraist scale (389 chunks): fatal OOM reproduced in simulator ✔
- New shapes at 60h/1200-chunk worst case (UUID-length refIds): all writes OK, count readback correct, playback lookup builds ✔
- Two adversarial multi-agent review passes: 7 confirmed defects in the first draft, all fixed and re-verified; fresh-eyes pass caught the String-compare crash + 4 more, all fixed ✔
- `make build` clean; `debug-symbols/b26.debug.xml` preserved for crash-log decoding ✔

## On-device test plan
- [ ] Sideload b26 (storage resets once; login survives; books need re-download)
- [ ] Download The Algebraist — should queue and sync without the instant error
- [ ] Play a partially-synced book — the moment of truth

🧙 Built with [WOZCODE](https://wozcode.com)