### PR TITLE
fix(storage): b27 hardening — per-key jobs, chunk cap, orphan sweep, drift wipe, toasts

### DIFF
--- a/debug-symbols/b24.debug.xml
+++ b/debug-symbols/b24.debug.xml
@@ -1,0 +1,1757 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<debugInfo>
+    <manifest filename="/Users/cbrooker/Code/ABS-Garmin/manifest.xml"/>
+    <pcToLineNum>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="1" lineNum="33" parent="globals/BrowseDelegate" pc="268435460" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="2" lineNum="17" parent="globals/SyncDelegate" pc="268435472" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/bin/gen/006-B4533-00/source/Rez.mcgen" id="3" lineNum="7" parent="globals/Rez" pc="268435484" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="4" lineNum="65" parent="globals/GroupDelegate" pc="268435504" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="5" lineNum="4" parent="globals/LibraryMenuDelegate" pc="268435516" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="6" lineNum="7" parent="globals/WatchShelfApp" pc="268435528" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="7" lineNum="7" parent="globals/ContentDelegate" pc="268435540" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="8" lineNum="13" parent="globals/ContentIterator" pc="268435552" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="9" lineNum="115" parent="globals/FieldDelegate" pc="268435564" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="10" lineNum="8" parent="globals/LibraryView" pc="268435576" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="11" lineNum="6" parent="globals/LibraryViewDelegate" pc="268435588" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="12" lineNum="10" parent="globals/BookMenuDelegate" pc="268435600" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="13" lineNum="27" parent="globals/LoginView" pc="268435612" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="14" lineNum="10" parent="globals/DownloadedMenuDelegate" pc="268435624" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="15" lineNum="8" parent="globals/ErrorViewDelegate" pc="268435636" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="16" lineNum="5" parent="globals/ErrorView" pc="268435648" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="17" lineNum="12" parent="globals/DownloadedMenu" pc="268435660" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="18" lineNum="45" parent="globals/BrowseDelegate" pc="268435672" symbol="onSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="18" lineNum="45" parent="globals/BrowseDelegate" pc="268435674" symbol="onSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="19" lineNum="62" parent="globals/BrowseDelegate" pc="268435698" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="19" lineNum="62" parent="globals/BrowseDelegate" pc="268435700" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="20" lineNum="44" parent="globals/BrowseDelegate" pc="268435716" symbol="onAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="20" lineNum="44" parent="globals/BrowseDelegate" pc="268435718" symbol="onAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="48" parent="globals/BrowseDelegate" pc="268435742" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="49" parent="globals/BrowseDelegate" pc="268435745" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="50" parent="globals/BrowseDelegate" pc="268435785" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="51" parent="globals/BrowseDelegate" pc="268435867" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="53" parent="globals/BrowseDelegate" pc="268435871" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="54" parent="globals/BrowseDelegate" pc="268435878" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="55" parent="globals/BrowseDelegate" pc="268435944" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="56" parent="globals/BrowseDelegate" pc="268435960" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="57" parent="globals/BrowseDelegate" pc="268435967" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="58" parent="globals/BrowseDelegate" pc="268436005" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="60" parent="globals/BrowseDelegate" pc="268436066" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="22" lineNum="43" parent="globals/BrowseDelegate" pc="268436109" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="22" lineNum="43" parent="globals/BrowseDelegate" pc="268436111" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="23" lineNum="46" parent="globals/BrowseDelegate" pc="268436129" symbol="onCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="23" lineNum="46" parent="globals/BrowseDelegate" pc="268436131" symbol="onCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="35" parent="globals/BrowseDelegate" pc="268436155" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="35" parent="globals/BrowseDelegate" pc="268436157" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="35" parent="globals/BrowseDelegate" pc="268436169" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="36" parent="globals/BrowseDelegate" pc="268436179" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="37" parent="globals/BrowseDelegate" pc="268436182" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="38" parent="globals/BrowseDelegate" pc="268436191" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="38" parent="globals/BrowseDelegate" pc="268436208" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="39" parent="globals/BrowseDelegate" pc="268436244" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="39" parent="globals/BrowseDelegate" pc="268436261" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="40" parent="globals/BrowseDelegate" pc="268436295" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="40" parent="globals/BrowseDelegate" pc="268436312" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="41" parent="globals/BrowseDelegate" pc="268436346" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="42" parent="globals/SyncDelegate" pc="268436378" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="43" parent="globals/SyncDelegate" pc="268436380" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="44" parent="globals/SyncDelegate" pc="268436410" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="45" parent="globals/SyncDelegate" pc="268436420" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="46" parent="globals/SyncDelegate" pc="268436434" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="48" parent="globals/SyncDelegate" pc="268436438" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="49" parent="globals/SyncDelegate" pc="268436445" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="50" parent="globals/SyncDelegate" pc="268436463" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="76" parent="globals/SyncDelegate" pc="268436471" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="77" parent="globals/SyncDelegate" pc="268436474" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="78" parent="globals/SyncDelegate" pc="268436490" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="79" parent="globals/SyncDelegate" pc="268436510" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="80" parent="globals/SyncDelegate" pc="268436524" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="83" parent="globals/SyncDelegate" pc="268436528" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="84" parent="globals/SyncDelegate" pc="268436537" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="87" parent="globals/SyncDelegate" pc="268436547" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="89" parent="globals/SyncDelegate" pc="268436570" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="97" parent="globals/SyncDelegate" pc="268436615" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="98" parent="globals/SyncDelegate" pc="268436650" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="100" parent="globals/SyncDelegate" pc="268436696" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="28" lineNum="136" parent="globals/SyncDelegate" pc="268436712" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="28" lineNum="137" parent="globals/SyncDelegate" pc="268436715" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="28" lineNum="138" parent="globals/SyncDelegate" pc="268436730" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="28" lineNum="139" parent="globals/SyncDelegate" pc="268436758" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="60" parent="globals/SyncDelegate" pc="268436774" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="61" parent="globals/SyncDelegate" pc="268436777" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="62" parent="globals/SyncDelegate" pc="268436796" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="62" parent="globals/SyncDelegate" pc="268436802" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="64" parent="globals/SyncDelegate" pc="268436809" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="65" parent="globals/SyncDelegate" pc="268436829" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="66" parent="globals/SyncDelegate" pc="268436839" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="67" parent="globals/SyncDelegate" pc="268436878" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="68" parent="globals/SyncDelegate" pc="268436890" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="70" parent="globals/SyncDelegate" pc="268436907" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="71" parent="globals/SyncDelegate" pc="268436927" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="72" parent="globals/SyncDelegate" pc="268436945" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="114" parent="globals/SyncDelegate" pc="268436955" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="115" parent="globals/SyncDelegate" pc="268436958" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="116" parent="globals/SyncDelegate" pc="268436967" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="118" parent="globals/SyncDelegate" pc="268436976" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="119" parent="globals/SyncDelegate" pc="268436995" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="119" parent="globals/SyncDelegate" pc="268437001" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="120" parent="globals/SyncDelegate" pc="268437008" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="121" parent="globals/SyncDelegate" pc="268437021" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="124" parent="globals/SyncDelegate" pc="268437041" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="125" parent="globals/SyncDelegate" pc="268437063" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="127" parent="globals/SyncDelegate" pc="268437086" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="129" parent="globals/SyncDelegate" pc="268437093" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="130" parent="globals/SyncDelegate" pc="268437126" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="132" parent="globals/SyncDelegate" pc="268437136" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="54" parent="globals/SyncDelegate" pc="268437164" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="55" parent="globals/SyncDelegate" pc="268437166" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="56" parent="globals/SyncDelegate" pc="268437177" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="104" parent="globals/SyncDelegate" pc="268437192" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="105" parent="globals/SyncDelegate" pc="268437194" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="105" parent="globals/SyncDelegate" pc="268437211" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="106" parent="globals/SyncDelegate" pc="268437217" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="106" parent="globals/SyncDelegate" pc="268437234" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="107" parent="globals/SyncDelegate" pc="268437240" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="107" parent="globals/SyncDelegate" pc="268437257" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="108" parent="globals/SyncDelegate" pc="268437263" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="108" parent="globals/SyncDelegate" pc="268437280" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="109" parent="globals/SyncDelegate" pc="268437286" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="25" parent="globals/SyncDelegate" pc="268437288" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="26" parent="globals/SyncDelegate" pc="268437290" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="28" parent="globals/SyncDelegate" pc="268437302" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="29" parent="globals/SyncDelegate" pc="268437326" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="29" parent="globals/SyncDelegate" pc="268437335" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="31" parent="globals/SyncDelegate" pc="268437347" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="32" parent="globals/SyncDelegate" pc="268437371" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="32" parent="globals/SyncDelegate" pc="268437380" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="34" parent="globals/SyncDelegate" pc="268437392" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="38" parent="globals/SyncDelegate" pc="268437401" symbol="isSyncNeeded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="39" parent="globals/SyncDelegate" pc="268437403" symbol="isSyncNeeded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="35" lineNum="18" parent="globals/LoginCreds" pc="268437436" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="35" lineNum="18" parent="globals/LoginCreds" pc="268437438" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="35" lineNum="18" parent="globals/LoginCreds" pc="268437450" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="35" lineNum="18" parent="globals/LoginCreds" pc="268437462" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="36" lineNum="71" parent="globals/GroupDelegate" pc="268437475" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="36" lineNum="71" parent="globals/GroupDelegate" pc="268437477" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="37" lineNum="70" parent="globals/GroupDelegate" pc="268437493" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="37" lineNum="70" parent="globals/GroupDelegate" pc="268437495" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="38" lineNum="68" parent="globals/GroupDelegate" pc="268437513" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="38" lineNum="68" parent="globals/GroupDelegate" pc="268437515" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="38" lineNum="68" parent="globals/GroupDelegate" pc="268437527" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="38" lineNum="68" parent="globals/GroupDelegate" pc="268437536" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="39" lineNum="69" parent="globals/GroupDelegate" pc="268437546" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="39" lineNum="69" parent="globals/GroupDelegate" pc="268437548" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="40" lineNum="168" parent="globals/AbsProgressListener" pc="268437592" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="40" lineNum="169" parent="globals/AbsProgressListener" pc="268437594" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="40" lineNum="170" parent="globals/AbsProgressListener" pc="268437603" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="42" lineNum="7" parent="globals/LibraryMenuDelegate" pc="268437628" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="42" lineNum="7" parent="globals/LibraryMenuDelegate" pc="268437630" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="43" lineNum="5" parent="globals/LibraryMenuDelegate" pc="268437646" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="43" lineNum="5" parent="globals/LibraryMenuDelegate" pc="268437648" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="44" lineNum="6" parent="globals/LibraryMenuDelegate" pc="268437661" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="44" lineNum="6" parent="globals/LibraryMenuDelegate" pc="268437663" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="45" lineNum="50" parent="globals/WatchShelfApp" pc="268437684" symbol="getProviderIconInfo"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="45" lineNum="51" parent="globals/WatchShelfApp" pc="268437686" symbol="getProviderIconInfo"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="46" lineNum="38" parent="globals/WatchShelfApp" pc="268437733" symbol="getPlaybackConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="46" lineNum="39" parent="globals/WatchShelfApp" pc="268437735" symbol="getPlaybackConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="47" lineNum="23" parent="globals/WatchShelfApp" pc="268437782" symbol="getContentDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="47" lineNum="24" parent="globals/WatchShelfApp" pc="268437784" symbol="getContentDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="48" lineNum="31" parent="globals/WatchShelfApp" pc="268437803" symbol="getSyncDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="48" lineNum="32" parent="globals/WatchShelfApp" pc="268437805" symbol="getSyncDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="9" parent="globals/WatchShelfApp" pc="268437824" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="11" parent="globals/WatchShelfApp" pc="268437827" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="12" parent="globals/WatchShelfApp" pc="268437846" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="13" parent="globals/WatchShelfApp" pc="268437853" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="14" parent="globals/WatchShelfApp" pc="268437864" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="15" parent="globals/WatchShelfApp" pc="268437875" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="19" parent="globals/WatchShelfApp" pc="268437897" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="50" lineNum="45" parent="globals/WatchShelfApp" pc="268437910" symbol="getSyncConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="50" lineNum="46" parent="globals/WatchShelfApp" pc="268437912" symbol="getSyncConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="51" lineNum="56" parent="globals/ContentDelegate" pc="268437959" symbol="onShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="51" lineNum="57" parent="globals/ContentDelegate" pc="268437961" symbol="onShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="52" lineNum="16" parent="globals/ContentDelegate" pc="268437974" symbol="getContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="52" lineNum="17" parent="globals/ContentDelegate" pc="268437976" symbol="getContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="39" parent="globals/ContentDelegate" pc="268437982" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="40" parent="globals/ContentDelegate" pc="268437985" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="41" parent="globals/ContentDelegate" pc="268438004" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="41" parent="globals/ContentDelegate" pc="268438010" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="42" parent="globals/ContentDelegate" pc="268438014" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="43" parent="globals/ContentDelegate" pc="268438021" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="43" parent="globals/ContentDelegate" pc="268438027" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="45" parent="globals/ContentDelegate" pc="268438031" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="45" parent="globals/ContentDelegate" pc="268438045" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="47" parent="globals/ContentDelegate" pc="268438049" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="48" parent="globals/ContentDelegate" pc="268438059" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="48" parent="globals/ContentDelegate" pc="268438065" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="49" parent="globals/ContentDelegate" pc="268438071" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="53" parent="globals/ContentDelegate" pc="268438078" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="54" lineNum="61" parent="globals/ContentDelegate" pc="268438103" symbol="onThumbsUp"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="55" lineNum="11" parent="globals/ContentDelegate" pc="268438106" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="55" lineNum="12" parent="globals/ContentDelegate" pc="268438108" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="55" lineNum="13" parent="globals/ContentDelegate" pc="268438120" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="56" lineNum="30" parent="globals/ContentDelegate" pc="268438128" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="56" lineNum="31" parent="globals/ContentDelegate" pc="268438130" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="56" lineNum="35" parent="globals/ContentDelegate" pc="268438162" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="58" lineNum="20" parent="globals/ContentDelegate" pc="268438179" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="58" lineNum="21" parent="globals/ContentDelegate" pc="268438181" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="58" lineNum="22" parent="globals/ContentDelegate" pc="268438206" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="59" lineNum="62" parent="globals/ContentDelegate" pc="268438212" symbol="onThumbsDown"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="60" lineNum="55" parent="globals/ContentIterator" pc="268438215" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="60" lineNum="56" parent="globals/ContentIterator" pc="268438217" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="60" lineNum="57" parent="globals/ContentIterator" pc="268438240" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="60" lineNum="58" parent="globals/ContentIterator" pc="268438255" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="60" lineNum="60" parent="globals/ContentIterator" pc="268438272" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="99" parent="globals/ContentIterator" pc="268438274" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="100" parent="globals/ContentIterator" pc="268438277" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="102" parent="globals/ContentIterator" pc="268438301" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="103" parent="globals/ContentIterator" pc="268438355" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="108" parent="globals/ContentIterator" pc="268438359" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="109" parent="globals/ContentIterator" pc="268438400" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="112" parent="globals/ContentIterator" pc="268438421" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="62" lineNum="63" parent="globals/ContentIterator" pc="268438423" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="62" lineNum="64" parent="globals/ContentIterator" pc="268438425" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="62" lineNum="65" parent="globals/ContentIterator" pc="268438435" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="62" lineNum="66" parent="globals/ContentIterator" pc="268438450" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="62" lineNum="68" parent="globals/ContentIterator" pc="268438467" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="63" lineNum="161" parent="globals/ContentIterator" pc="268438469" symbol="before"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="63" lineNum="162" parent="globals/ContentIterator" pc="268438472" symbol="before"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="63" lineNum="163" parent="globals/ContentIterator" pc="268438486" symbol="before"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="63" lineNum="164" parent="globals/ContentIterator" pc="268438500" symbol="before"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="63" lineNum="165" parent="globals/ContentIterator" pc="268438515" symbol="before"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="63" lineNum="167" parent="globals/ContentIterator" pc="268438524" symbol="before"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="64" lineNum="75" parent="globals/ContentIterator" pc="268438550" symbol="peekPrevious"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="64" lineNum="76" parent="globals/ContentIterator" pc="268438552" symbol="peekPrevious"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="65" lineNum="79" parent="globals/ContentIterator" pc="268438569" symbol="canSkip"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="65" lineNum="80" parent="globals/ContentIterator" pc="268438571" symbol="canSkip"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="66" lineNum="87" parent="globals/ContentIterator" pc="268438573" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="66" lineNum="88" parent="globals/ContentIterator" pc="268438575" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="66" lineNum="89" parent="globals/ContentIterator" pc="268438583" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="66" lineNum="90" parent="globals/ContentIterator" pc="268438591" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="66" lineNum="92" parent="globals/ContentIterator" pc="268438601" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="66" lineNum="93" parent="globals/ContentIterator" pc="268438608" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="27" parent="globals/ContentIterator" pc="268438617" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="28" parent="globals/ContentIterator" pc="268438620" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="29" parent="globals/ContentIterator" pc="268438644" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="36" parent="globals/ContentIterator" pc="268438657" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="37" parent="globals/ContentIterator" pc="268438666" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="38" parent="globals/ContentIterator" pc="268438675" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="39" parent="globals/ContentIterator" pc="268438685" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="42" parent="globals/ContentIterator" pc="268438695" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="43" parent="globals/ContentIterator" pc="268438706" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="45" parent="globals/ContentIterator" pc="268438719" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="46" parent="globals/ContentIterator" pc="268438730" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="48" parent="globals/ContentIterator" pc="268438743" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="68" lineNum="176" parent="globals/ContentIterator" pc="268438746" symbol="startOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="68" lineNum="177" parent="globals/ContentIterator" pc="268438749" symbol="startOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="68" lineNum="178" parent="globals/ContentIterator" pc="268438756" symbol="startOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="68" lineNum="178" parent="globals/ContentIterator" pc="268438774" symbol="startOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="68" lineNum="179" parent="globals/ContentIterator" pc="268438786" symbol="startOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="69" lineNum="71" parent="globals/ContentIterator" pc="268438788" symbol="peekNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="69" lineNum="72" parent="globals/ContentIterator" pc="268438790" symbol="peekNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="70" lineNum="51" parent="globals/ContentIterator" pc="268438807" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="70" lineNum="52" parent="globals/ContentIterator" pc="268438809" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="71" lineNum="83" parent="globals/ContentIterator" pc="268438823" symbol="shuffling"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="71" lineNum="84" parent="globals/ContentIterator" pc="268438825" symbol="shuffling"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="72" lineNum="19" parent="globals/ContentIterator" pc="268438831" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="72" lineNum="20" parent="globals/ContentIterator" pc="268438833" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="72" lineNum="21" parent="globals/ContentIterator" pc="268438845" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="72" lineNum="22" parent="globals/ContentIterator" pc="268438853" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="72" lineNum="23" parent="globals/ContentIterator" pc="268438861" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="182" parent="globals/ContentIterator" pc="268438869" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="183" parent="globals/ContentIterator" pc="268438872" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="184" parent="globals/ContentIterator" pc="268438895" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="185" parent="globals/ContentIterator" pc="268438913" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="186" parent="globals/ContentIterator" pc="268438923" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="187" parent="globals/ContentIterator" pc="268438939" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="189" parent="globals/ContentIterator" pc="268438959" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="74" lineNum="170" parent="globals/ContentIterator" pc="268438968" symbol="bookTitleOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="74" lineNum="171" parent="globals/ContentIterator" pc="268438971" symbol="bookTitleOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="74" lineNum="172" parent="globals/ContentIterator" pc="268438978" symbol="bookTitleOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="74" lineNum="172" parent="globals/ContentIterator" pc="268438996" symbol="bookTitleOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="74" lineNum="173" parent="globals/ContentIterator" pc="268439008" symbol="bookTitleOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="126" parent="globals/ContentIterator" pc="268439014" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="127" parent="globals/ContentIterator" pc="268439017" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="128" parent="globals/ContentIterator" pc="268439026" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="129" parent="globals/ContentIterator" pc="268439045" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="129" parent="globals/ContentIterator" pc="268439051" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="131" parent="globals/ContentIterator" pc="268439058" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="132" parent="globals/ContentIterator" pc="268439062" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="133" parent="globals/ContentIterator" pc="268439089" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="134" parent="globals/ContentIterator" pc="268439095" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="135" parent="globals/ContentIterator" pc="268439105" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="136" parent="globals/ContentIterator" pc="268439111" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="137" parent="globals/ContentIterator" pc="268439129" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="141" parent="globals/ContentIterator" pc="268439145" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="142" parent="globals/ContentIterator" pc="268439161" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="144" parent="globals/ContentIterator" pc="268439168" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="145" parent="globals/ContentIterator" pc="268439181" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="146" parent="globals/ContentIterator" pc="268439201" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="146" parent="globals/ContentIterator" pc="268439224" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="146" parent="globals/ContentIterator" pc="268439228" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="150" parent="globals/ContentIterator" pc="268439244" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="151" parent="globals/ContentIterator" pc="268439261" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="151" parent="globals/ContentIterator" pc="268439272" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="152" parent="globals/ContentIterator" pc="268439295" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="153" parent="globals/ContentIterator" pc="268439302" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="153" parent="globals/ContentIterator" pc="268439323" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="154" parent="globals/ContentIterator" pc="268439349" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="156" parent="globals/ContentIterator" pc="268439368" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="76" lineNum="22" parent="globals/Login" pc="268439377" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="76" lineNum="23" parent="globals/Login" pc="268439387" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="77" lineNum="94" parent="globals/AbsApi" pc="268439447" symbol="isConfigured"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="77" lineNum="95" parent="globals/AbsApi" pc="268439457" symbol="isConfigured"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="78" lineNum="29" parent="globals/AbsApi" pc="268439478" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="78" lineNum="30" parent="globals/AbsApi" pc="268439489" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="78" lineNum="31" parent="globals/AbsApi" pc="268439508" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="78" lineNum="31" parent="globals/AbsApi" pc="268439514" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="78" lineNum="32" parent="globals/AbsApi" pc="268439532" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="79" lineNum="146" parent="globals/AbsApi" pc="268439535" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="79" lineNum="147" parent="globals/AbsApi" pc="268439545" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="79" lineNum="148" parent="globals/AbsApi" pc="268439573" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="80" lineNum="65" parent="globals/AbsApi" pc="268439594" symbol="getCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="80" lineNum="65" parent="globals/AbsApi" pc="268439604" symbol="getCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="81" lineNum="40" parent="globals/AbsApi" pc="268439623" symbol="sidecarBase"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="81" lineNum="40" parent="globals/AbsApi" pc="268439633" symbol="sidecarBase"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="82" lineNum="137" parent="globals/AbsApi" pc="268439640" symbol="login"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="82" lineNum="138" parent="globals/AbsApi" pc="268439650" symbol="login"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="83" lineNum="68" parent="globals/AbsApi" pc="268439734" symbol="getFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="83" lineNum="69" parent="globals/AbsApi" pc="268439744" symbol="getFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="84" lineNum="86" parent="globals/AbsApi" pc="268439817" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="84" lineNum="89" parent="globals/AbsApi" pc="268439828" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="84" lineNum="90" parent="globals/AbsApi" pc="268439844" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="84" lineNum="90" parent="globals/AbsApi" pc="268439878" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="84" lineNum="91" parent="globals/AbsApi" pc="268439883" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="85" lineNum="44" parent="globals/AbsApi" pc="268439886" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="85" lineNum="45" parent="globals/AbsApi" pc="268439897" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="85" lineNum="46" parent="globals/AbsApi" pc="268439924" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="85" lineNum="46" parent="globals/AbsApi" pc="268439936" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="85" lineNum="47" parent="globals/AbsApi" pc="268439946" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="86" lineNum="150" parent="globals/AbsApi" pc="268439996" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="86" lineNum="151" parent="globals/AbsApi" pc="268440006" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="86" lineNum="152" parent="globals/AbsApi" pc="268440024" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="87" lineNum="124" parent="globals/AbsApi" pc="268440043" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="87" lineNum="125" parent="globals/AbsApi" pc="268440054" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="87" lineNum="126" parent="globals/AbsApi" pc="268440077" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="87" lineNum="126" parent="globals/AbsApi" pc="268440083" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="87" lineNum="127" parent="globals/AbsApi" pc="268440096" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="88" lineNum="64" parent="globals/AbsApi" pc="268440197" symbol="getSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="88" lineNum="64" parent="globals/AbsApi" pc="268440207" symbol="getSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="89" lineNum="113" parent="globals/AbsApi" pc="268440226" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="89" lineNum="114" parent="globals/AbsApi" pc="268440237" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="89" lineNum="115" parent="globals/AbsApi" pc="268440247" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="89" lineNum="116" parent="globals/AbsApi" pc="268440265" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="89" lineNum="118" parent="globals/AbsApi" pc="268440277" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="90" lineNum="63" parent="globals/AbsApi" pc="268440279" symbol="getAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="90" lineNum="63" parent="globals/AbsApi" pc="268440289" symbol="getAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="91" lineNum="80" parent="globals/AbsApi" pc="268440308" symbol="sidecarChunkUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="91" lineNum="81" parent="globals/AbsApi" pc="268440318" symbol="sidecarChunkUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="92" lineNum="154" parent="globals/AbsApi" pc="268440384" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="92" lineNum="155" parent="globals/AbsApi" pc="268440394" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="92" lineNum="156" parent="globals/AbsApi" pc="268440458" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="92" lineNum="158" parent="globals/AbsApi" pc="268440484" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="19" parent="globals/AbsApi" pc="268440487" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="20" parent="globals/AbsApi" pc="268440498" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="21" parent="globals/AbsApi" pc="268440517" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="21" parent="globals/AbsApi" pc="268440523" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="22" parent="globals/AbsApi" pc="268440541" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="22" parent="globals/AbsApi" pc="268440547" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="23" parent="globals/AbsApi" pc="268440552" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="24" parent="globals/AbsApi" pc="268440606" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="26" parent="globals/AbsApi" pc="268440631" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="94" lineNum="101" parent="globals/AbsApi" pc="268440634" symbol="getLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="94" lineNum="102" parent="globals/AbsApi" pc="268440644" symbol="getLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="95" lineNum="55" parent="globals/AbsApi" pc="268440709" symbol="getGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="95" lineNum="56" parent="globals/AbsApi" pc="268440719" symbol="getGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="96" lineNum="125" parent="globals/FieldDelegate" pc="268440789" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="96" lineNum="126" parent="globals/FieldDelegate" pc="268440791" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="96" lineNum="127" parent="globals/FieldDelegate" pc="268440812" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="97" lineNum="129" parent="globals/FieldDelegate" pc="268440814" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="97" lineNum="130" parent="globals/FieldDelegate" pc="268440816" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="97" lineNum="131" parent="globals/FieldDelegate" pc="268440828" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="98" lineNum="118" parent="globals/FieldDelegate" pc="268440830" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="98" lineNum="119" parent="globals/FieldDelegate" pc="268440832" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="98" lineNum="120" parent="globals/FieldDelegate" pc="268440844" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="98" lineNum="121" parent="globals/FieldDelegate" pc="268440853" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="99" lineNum="14" parent="globals/RequestDelegate" pc="268440863" symbol="makeWebRequest"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="99" lineNum="15" parent="globals/RequestDelegate" pc="268440865" symbol="makeWebRequest"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="100" lineNum="9" parent="globals/RequestDelegate" pc="268440898" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="100" lineNum="10" parent="globals/RequestDelegate" pc="268440900" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="100" lineNum="11" parent="globals/RequestDelegate" pc="268440909" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="101" lineNum="18" parent="globals/RequestDelegate" pc="268440919" symbol="onWebResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="101" lineNum="19" parent="globals/RequestDelegate" pc="268440921" symbol="onWebResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="7" parent="globals/Browse" pc="268440945" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="8" parent="globals/Browse" pc="268440956" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="9" parent="globals/Browse" pc="268441022" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="10" parent="globals/Browse" pc="268441092" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="11" parent="globals/Browse" pc="268441162" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="12" parent="globals/Browse" pc="268441232" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="13" parent="globals/Browse" pc="268441302" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="17" parent="globals/Browse" pc="268441344" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="18" parent="globals/Browse" pc="268441355" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="19" parent="globals/Browse" pc="268441401" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="21" parent="globals/Browse" pc="268441506" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="23" parent="globals/Browse" pc="268441510" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="24" parent="globals/Browse" pc="268441520" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="25" parent="globals/Browse" pc="268441586" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="26" parent="globals/Browse" pc="268441602" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="27" parent="globals/Browse" pc="268441609" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="29" parent="globals/Browse" pc="268441676" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="43" parent="globals/LibraryView" pc="268441716" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="44" parent="globals/LibraryView" pc="268441719" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="45" parent="globals/LibraryView" pc="268441746" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="46" parent="globals/LibraryView" pc="268441756" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="47" parent="globals/LibraryView" pc="268441822" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="48" parent="globals/LibraryView" pc="268441838" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="50" parent="globals/LibraryView" pc="268441845" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="51" parent="globals/LibraryView" pc="268441881" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="54" parent="globals/LibraryView" pc="268441944" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="56" parent="globals/LibraryView" pc="268441982" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="57" parent="globals/LibraryView" pc="268442035" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="19" parent="globals/LibraryView" pc="268442047" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="23" parent="globals/LibraryView" pc="268442049" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="23" parent="globals/LibraryView" pc="268442057" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="24" parent="globals/LibraryView" pc="268442061" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="26" parent="globals/LibraryView" pc="268442069" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="28" parent="globals/LibraryView" pc="268442083" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="29" parent="globals/LibraryView" pc="268442094" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="31" parent="globals/LibraryView" pc="268442098" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="106" lineNum="13" parent="globals/LibraryView" pc="268442125" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="106" lineNum="14" parent="globals/LibraryView" pc="268442127" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="106" lineNum="15" parent="globals/LibraryView" pc="268442139" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="106" lineNum="16" parent="globals/LibraryView" pc="268442177" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="107" lineNum="34" parent="globals/LibraryView" pc="268442186" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="107" lineNum="35" parent="globals/LibraryView" pc="268442188" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="107" lineNum="36" parent="globals/LibraryView" pc="268442200" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="107" lineNum="37" parent="globals/LibraryView" pc="268442208" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="107" lineNum="38" parent="globals/LibraryView" pc="268442224" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="108" lineNum="13" parent="globals/LibraryViewDelegate" pc="268442264" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="108" lineNum="14" parent="globals/LibraryViewDelegate" pc="268442266" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="108" lineNum="15" parent="globals/LibraryViewDelegate" pc="268442281" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="109" lineNum="8" parent="globals/LibraryViewDelegate" pc="268442283" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="109" lineNum="9" parent="globals/LibraryViewDelegate" pc="268442285" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="110" lineNum="134" parent="globals/BookMenuDelegate" pc="268442298" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="110" lineNum="135" parent="globals/BookMenuDelegate" pc="268442300" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="120" parent="globals/BookMenuDelegate" pc="268442316" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="121" parent="globals/BookMenuDelegate" pc="268442319" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="122" parent="globals/BookMenuDelegate" pc="268442338" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="122" parent="globals/BookMenuDelegate" pc="268442344" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="123" parent="globals/BookMenuDelegate" pc="268442349" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="124" parent="globals/BookMenuDelegate" pc="268442352" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="125" parent="globals/BookMenuDelegate" pc="268442361" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="126" parent="globals/BookMenuDelegate" pc="268442377" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="127" parent="globals/BookMenuDelegate" pc="268442387" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="128" parent="globals/BookMenuDelegate" pc="268442429" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="131" parent="globals/BookMenuDelegate" pc="268442449" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="112" lineNum="14" parent="globals/BookMenuDelegate" pc="268442452" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="112" lineNum="15" parent="globals/BookMenuDelegate" pc="268442454" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="112" lineNum="16" parent="globals/BookMenuDelegate" pc="268442466" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="24" parent="globals/BookMenuDelegate" pc="268442475" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="25" parent="globals/BookMenuDelegate" pc="268442478" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="26" parent="globals/BookMenuDelegate" pc="268442524" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="28" parent="globals/BookMenuDelegate" pc="268442621" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="39" parent="globals/BookMenuDelegate" pc="268442625" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="40" parent="globals/BookMenuDelegate" pc="268442630" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="41" parent="globals/BookMenuDelegate" pc="268442634" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="42" parent="globals/BookMenuDelegate" pc="268442644" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="43" parent="globals/BookMenuDelegate" pc="268442654" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="43" parent="globals/BookMenuDelegate" pc="268442660" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="48" parent="globals/BookMenuDelegate" pc="268442670" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="49" parent="globals/BookMenuDelegate" pc="268442686" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="50" parent="globals/BookMenuDelegate" pc="268442705" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="52" parent="globals/BookMenuDelegate" pc="268442787" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="55" parent="globals/BookMenuDelegate" pc="268442791" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="56" parent="globals/BookMenuDelegate" pc="268442810" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="56" parent="globals/BookMenuDelegate" pc="268442816" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="58" parent="globals/BookMenuDelegate" pc="268442823" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="59" parent="globals/BookMenuDelegate" pc="268442826" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="60" parent="globals/BookMenuDelegate" pc="268442829" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="61" parent="globals/BookMenuDelegate" pc="268442845" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="62" parent="globals/BookMenuDelegate" pc="268442858" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="63" parent="globals/BookMenuDelegate" pc="268442886" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="63" parent="globals/BookMenuDelegate" pc="268442893" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="64" parent="globals/BookMenuDelegate" pc="268442899" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="65" parent="globals/BookMenuDelegate" pc="268442902" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="66" parent="globals/BookMenuDelegate" pc="268442910" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="67" parent="globals/BookMenuDelegate" pc="268442926" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="68" parent="globals/BookMenuDelegate" pc="268442933" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="68" parent="globals/BookMenuDelegate" pc="268442941" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="69" parent="globals/BookMenuDelegate" pc="268442948" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="80" parent="globals/BookMenuDelegate" pc="268443046" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="81" parent="globals/BookMenuDelegate" pc="268443053" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="83" parent="globals/BookMenuDelegate" pc="268443060" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="86" parent="globals/BookMenuDelegate" pc="268443077" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="87" parent="globals/BookMenuDelegate" pc="268443084" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="88" parent="globals/BookMenuDelegate" pc="268443166" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="91" parent="globals/BookMenuDelegate" pc="268443170" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="92" parent="globals/BookMenuDelegate" pc="268443190" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="93" parent="globals/BookMenuDelegate" pc="268443272" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="114" lineNum="96" parent="globals/BookMenuDelegate" pc="268443284" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="114" lineNum="97" parent="globals/BookMenuDelegate" pc="268443286" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="114" lineNum="97" parent="globals/BookMenuDelegate" pc="268443292" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="114" lineNum="98" parent="globals/BookMenuDelegate" pc="268443298" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="103" parent="globals/BookMenuDelegate" pc="268443301" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="104" parent="globals/BookMenuDelegate" pc="268443304" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="105" parent="globals/BookMenuDelegate" pc="268443307" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="106" parent="globals/BookMenuDelegate" pc="268443323" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="107" parent="globals/BookMenuDelegate" pc="268443351" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="107" parent="globals/BookMenuDelegate" pc="268443358" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="108" parent="globals/BookMenuDelegate" pc="268443364" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="109" parent="globals/BookMenuDelegate" pc="268443367" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="110" parent="globals/BookMenuDelegate" pc="268443375" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="111" parent="globals/BookMenuDelegate" pc="268443391" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="112" parent="globals/BookMenuDelegate" pc="268443398" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="112" parent="globals/BookMenuDelegate" pc="268443406" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="113" parent="globals/BookMenuDelegate" pc="268443413" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="114" parent="globals/BookMenuDelegate" pc="268443420" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="117" parent="globals/BookMenuDelegate" pc="268443437" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="116" lineNum="19" parent="globals/BookMenuDelegate" pc="268443440" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="116" lineNum="20" parent="globals/BookMenuDelegate" pc="268443442" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="116" lineNum="21" parent="globals/BookMenuDelegate" pc="268443456" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="103" parent="globals/LoginView" pc="268443488" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="104" parent="globals/LoginView" pc="268443490" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="105" parent="globals/LoginView" pc="268443535" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="106" parent="globals/LoginView" pc="268443572" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="108" parent="globals/LoginView" pc="268443626" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="109" parent="globals/LoginView" pc="268443635" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="110" parent="globals/LoginView" pc="268443688" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="118" lineNum="63" parent="globals/LoginView" pc="268443700" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="118" lineNum="64" parent="globals/LoginView" pc="268443702" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="118" lineNum="64" parent="globals/LoginView" pc="268443709" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="118" lineNum="65" parent="globals/LoginView" pc="268443744" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="118" lineNum="65" parent="globals/LoginView" pc="268443752" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="118" lineNum="66" parent="globals/LoginView" pc="268443787" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="90" parent="globals/LoginView" pc="268443819" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="91" parent="globals/LoginView" pc="268443821" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="91" parent="globals/LoginView" pc="268443828" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="92" parent="globals/LoginView" pc="268443844" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="92" parent="globals/LoginView" pc="268443852" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="93" parent="globals/LoginView" pc="268443868" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="93" parent="globals/LoginView" pc="268443876" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="94" parent="globals/LoginView" pc="268443892" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="44" parent="globals/LoginView" pc="268443905" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="45" parent="globals/LoginView" pc="268443907" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="46" parent="globals/LoginView" pc="268443918" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="47" parent="globals/LoginView" pc="268443938" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="48" parent="globals/LoginView" pc="268443949" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="49" parent="globals/LoginView" pc="268443978" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="50" parent="globals/LoginView" pc="268444012" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="51" parent="globals/LoginView" pc="268444023" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="52" parent="globals/LoginView" pc="268444032" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="53" parent="globals/LoginView" pc="268444070" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="54" parent="globals/LoginView" pc="268444081" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="97" parent="globals/LoginView" pc="268444141" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="98" parent="globals/LoginView" pc="268444143" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="99" parent="globals/LoginView" pc="268444152" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="100" parent="globals/LoginView" pc="268444190" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="70" parent="globals/LoginView" pc="268444202" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="71" parent="globals/LoginView" pc="268444204" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="72" parent="globals/LoginView" pc="268444212" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="73" parent="globals/LoginView" pc="268444222" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="74" parent="globals/LoginView" pc="268444292" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="75" parent="globals/LoginView" pc="268444303" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="76" parent="globals/LoginView" pc="268444374" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="77" parent="globals/LoginView" pc="268444385" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="33" parent="globals/LoginView" pc="268444452" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="34" parent="globals/LoginView" pc="268444455" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="35" parent="globals/LoginView" pc="268444467" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="36" parent="globals/LoginView" pc="268444475" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="37" parent="globals/LoginView" pc="268444500" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="38" parent="globals/LoginView" pc="268444512" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="39" parent="globals/LoginView" pc="268444539" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="40" parent="globals/LoginView" pc="268444551" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="124" lineNum="59" parent="globals/LoginView" pc="268444560" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="124" lineNum="60" parent="globals/LoginView" pc="268444562" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="124" lineNum="60" parent="globals/LoginView" pc="268444571" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="124" lineNum="60" parent="globals/LoginView" pc="268444583" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="125" lineNum="81" parent="globals/LoginView" pc="268444595" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="125" lineNum="82" parent="globals/LoginView" pc="268444597" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="125" lineNum="83" parent="globals/LoginView" pc="268444609" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="125" lineNum="84" parent="globals/LoginView" pc="268444617" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="125" lineNum="85" parent="globals/LoginView" pc="268444633" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="82" parent="globals/DownloadedMenuDelegate" pc="268444673" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="83" parent="globals/DownloadedMenuDelegate" pc="268444676" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="83" parent="globals/DownloadedMenuDelegate" pc="268444688" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="85" parent="globals/DownloadedMenuDelegate" pc="268444692" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="86" parent="globals/DownloadedMenuDelegate" pc="268444711" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="86" parent="globals/DownloadedMenuDelegate" pc="268444717" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="87" parent="globals/DownloadedMenuDelegate" pc="268444724" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="88" parent="globals/DownloadedMenuDelegate" pc="268444740" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="90" parent="globals/DownloadedMenuDelegate" pc="268444765" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="92" parent="globals/DownloadedMenuDelegate" pc="268444785" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="93" parent="globals/DownloadedMenuDelegate" pc="268444796" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="127" lineNum="96" parent="globals/DownloadedMenuDelegate" pc="268444879" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="127" lineNum="97" parent="globals/DownloadedMenuDelegate" pc="268444881" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="128" lineNum="12" parent="globals/DownloadedMenuDelegate" pc="268444897" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="128" lineNum="13" parent="globals/DownloadedMenuDelegate" pc="268444899" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="16" parent="globals/DownloadedMenuDelegate" pc="268444912" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="17" parent="globals/DownloadedMenuDelegate" pc="268444915" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="21" parent="globals/DownloadedMenuDelegate" pc="268444924" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="22" parent="globals/DownloadedMenuDelegate" pc="268444957" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="23" parent="globals/DownloadedMenuDelegate" pc="268445008" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="31" parent="globals/DownloadedMenuDelegate" pc="268445012" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="32" parent="globals/DownloadedMenuDelegate" pc="268445045" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="33" parent="globals/DownloadedMenuDelegate" pc="268445059" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="39" parent="globals/DownloadedMenuDelegate" pc="268445063" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="40" parent="globals/DownloadedMenuDelegate" pc="268445096" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="41" parent="globals/DownloadedMenuDelegate" pc="268445107" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="42" parent="globals/DownloadedMenuDelegate" pc="268445158" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="48" parent="globals/DownloadedMenuDelegate" pc="268445162" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="49" parent="globals/DownloadedMenuDelegate" pc="268445195" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="50" parent="globals/DownloadedMenuDelegate" pc="268445215" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="51" parent="globals/DownloadedMenuDelegate" pc="268445235" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="52" parent="globals/DownloadedMenuDelegate" pc="268445317" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="56" parent="globals/DownloadedMenuDelegate" pc="268445321" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="57" parent="globals/DownloadedMenuDelegate" pc="268445354" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="58" parent="globals/DownloadedMenuDelegate" pc="268445373" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="58" parent="globals/DownloadedMenuDelegate" pc="268445379" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="59" parent="globals/DownloadedMenuDelegate" pc="268445386" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="60" parent="globals/DownloadedMenuDelegate" pc="268445402" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="67" parent="globals/DownloadedMenuDelegate" pc="268445406" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="68" parent="globals/DownloadedMenuDelegate" pc="268445425" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="68" parent="globals/DownloadedMenuDelegate" pc="268445431" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="69" parent="globals/DownloadedMenuDelegate" pc="268445438" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="70" parent="globals/DownloadedMenuDelegate" pc="268445447" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="71" parent="globals/DownloadedMenuDelegate" pc="268445451" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="72" parent="globals/DownloadedMenuDelegate" pc="268445467" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="73" parent="globals/DownloadedMenuDelegate" pc="268445477" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="74" parent="globals/DownloadedMenuDelegate" pc="268445516" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="77" parent="globals/DownloadedMenuDelegate" pc="268445544" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="130" lineNum="14" parent="globals/ErrorViewDelegate" pc="268445556" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="130" lineNum="15" parent="globals/ErrorViewDelegate" pc="268445558" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="130" lineNum="16" parent="globals/ErrorViewDelegate" pc="268445573" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="131" lineNum="10" parent="globals/ErrorViewDelegate" pc="268445575" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="131" lineNum="11" parent="globals/ErrorViewDelegate" pc="268445577" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="132" lineNum="9" parent="globals/ErrorView" pc="268445590" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="132" lineNum="10" parent="globals/ErrorView" pc="268445592" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="132" lineNum="11" parent="globals/ErrorView" pc="268445604" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="133" lineNum="14" parent="globals/ErrorView" pc="268445614" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="133" lineNum="15" parent="globals/ErrorView" pc="268445616" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="133" lineNum="16" parent="globals/ErrorView" pc="268445628" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="133" lineNum="17" parent="globals/ErrorView" pc="268445636" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="133" lineNum="18" parent="globals/ErrorView" pc="268445652" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="108" parent="globals/DownloadedMenu" pc="268445692" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="109" parent="globals/DownloadedMenu" pc="268445695" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="110" parent="globals/DownloadedMenu" pc="268445707" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="111" parent="globals/DownloadedMenu" pc="268445710" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="111" parent="globals/DownloadedMenu" pc="268445727" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="112" parent="globals/DownloadedMenu" pc="268445739" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="113" parent="globals/DownloadedMenu" pc="268445754" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="135" lineNum="62" parent="globals/DownloadedMenu" pc="268445813" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="135" lineNum="63" parent="globals/DownloadedMenu" pc="268445816" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="135" lineNum="64" parent="globals/DownloadedMenu" pc="268445835" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="135" lineNum="65" parent="globals/DownloadedMenu" pc="268445854" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="14" parent="globals/DownloadedMenu" pc="268445899" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="15" parent="globals/DownloadedMenu" pc="268445902" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="20" parent="globals/DownloadedMenu" pc="268445933" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="22" parent="globals/DownloadedMenu" pc="268446002" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="23" parent="globals/DownloadedMenu" pc="268446010" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="31" parent="globals/DownloadedMenu" pc="268446019" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="32" parent="globals/DownloadedMenu" pc="268446031" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="37" parent="globals/DownloadedMenu" pc="268446103" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="38" parent="globals/DownloadedMenu" pc="268446116" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="46" parent="globals/DownloadedMenu" pc="268446188" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="47" parent="globals/DownloadedMenu" pc="268446197" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="50" parent="globals/DownloadedMenu" pc="268446269" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="51" parent="globals/DownloadedMenu" pc="268446281" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="54" parent="globals/DownloadedMenu" pc="268446353" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="55" parent="globals/DownloadedMenu" pc="268446369" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="56" parent="globals/DownloadedMenu" pc="268446376" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="57" parent="globals/DownloadedMenu" pc="268446383" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="58" parent="globals/DownloadedMenu" pc="268446433" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="71" parent="globals/DownloadedMenu" pc="268446488" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="72" parent="globals/DownloadedMenu" pc="268446491" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="73" parent="globals/DownloadedMenu" pc="268446510" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="73" parent="globals/DownloadedMenu" pc="268446516" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="75" parent="globals/DownloadedMenu" pc="268446523" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="76" parent="globals/DownloadedMenu" pc="268446527" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="77" parent="globals/DownloadedMenu" pc="268446536" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="78" parent="globals/DownloadedMenu" pc="268446552" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="79" parent="globals/DownloadedMenu" pc="268446562" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="80" parent="globals/DownloadedMenu" pc="268446572" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="80" parent="globals/DownloadedMenu" pc="268446578" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="82" parent="globals/DownloadedMenu" pc="268446588" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="83" parent="globals/DownloadedMenu" pc="268446595" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="84" parent="globals/DownloadedMenu" pc="268446601" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="85" parent="globals/DownloadedMenu" pc="268446631" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="87" parent="globals/DownloadedMenu" pc="268446641" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="89" parent="globals/DownloadedMenu" pc="268446670" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="94" parent="globals/DownloadedMenu" pc="268446673" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="95" parent="globals/DownloadedMenu" pc="268446676" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="96" parent="globals/DownloadedMenu" pc="268446704" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="97" parent="globals/DownloadedMenu" pc="268446720" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="98" parent="globals/DownloadedMenu" pc="268446755" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="100" parent="globals/DownloadedMenu" pc="268446772" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="100" parent="globals/DownloadedMenu" pc="268446784" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="101" parent="globals/DownloadedMenu" pc="268446796" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="101" parent="globals/DownloadedMenu" pc="268446808" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="102" parent="globals/DownloadedMenu" pc="268446820" symbol="bookTitle"/>
+    </pcToLineNum>
+    <symbolTable>
+        <entry id="8388639" module="true" symbol="Graphics"/>
+        <entry id="8390434" method="true" symbol="getSyncConfigurationView"/>
+        <entry id="49" method="true" symbol="typeToEncoding"/>
+        <entry id="17" object="true" symbol="DownloadedMenu"/>
+        <entry field="true" id="54" symbol="&lt;globals/GroupDelegate/&lt;&gt;mType&gt;"/>
+        <entry id="8390557" method="true" symbol="resetContentIterator"/>
+        <entry id="76" method="true" symbol="isConfigured"/>
+        <entry id="112" method="true" symbol="titleWithSize"/>
+        <entry id="8390211" module="true" symbol="Media"/>
+        <entry id="96" method="true" symbol="numOr"/>
+        <entry field="true" id="127" symbol="errItems"/>
+        <entry id="39" method="true" symbol="pushGroups"/>
+        <entry id="13" object="true" symbol="AbsProgressListener"/>
+        <entry id="28" object="true" symbol="LoginView"/>
+        <entry id="8388632" method="true" symbol="&lt;init&gt;"/>
+        <entry id="8390379" method="true" symbol="onThumbsUp"/>
+        <entry id="8390380" method="true" symbol="onThumbsDown"/>
+        <entry id="59" method="true" symbol="buildPlaylist"/>
+        <entry field="true" id="119" symbol="byAuthor"/>
+        <entry id="81" method="true" symbol="saveLogin"/>
+        <entry field="true" id="128" symbol="errLibraries"/>
+        <entry id="58" method="true" symbol="bookTitleOf"/>
+        <entry id="47" method="true" symbol="onOpDone"/>
+        <entry id="8390335" object="true" symbol="ContentIterator"/>
+        <entry field="true" id="144" symbol="settingApiKey"/>
+        <entry id="8388826" method="true" symbol="next"/>
+        <entry field="true" id="141" symbol="playDownloaded"/>
+        <entry field="true" id="87" symbol="mCallback"/>
+        <entry id="23" object="true" symbol="LibraryMenuDelegate"/>
+        <entry field="true" id="53" symbol="&lt;globals/GroupDelegate/&lt;&gt;mLib&gt;"/>
+        <entry id="94" method="true" symbol="expectedChunkCount"/>
+        <entry field="true" id="132" symbol="fieldServer"/>
+        <entry id="14" object="true" symbol="BookMenuDelegate"/>
+        <entry id="37" method="true" symbol="onCollections"/>
+        <entry field="true" id="61" symbol="&lt;globals/ContentIterator/&lt;&gt;mPlaylist&gt;"/>
+        <entry field="true" id="116" symbol="allBooks"/>
+        <entry field="true" id="143" symbol="queued"/>
+        <entry id="8390336" object="true" symbol="ContentDelegate"/>
+        <entry id="12" module="true" symbol="AbsApi"/>
+        <entry field="true" id="142" symbol="queueCleared"/>
+        <entry id="32" module="true" symbol="Versions"/>
+        <entry field="true" id="8388611" module="true" symbol="Toybox"/>
+        <entry field="true" id="45" symbol="&lt;globals/SyncDelegate/&lt;&gt;mSyncList&gt;"/>
+        <entry id="107" method="true" symbol="queueDelete"/>
+        <entry id="8390377" method="true" symbol="getContentIterator"/>
+        <entry id="8389108" method="true" symbol="onResponse"/>
+        <entry id="80" method="true" symbol="progressSeconds"/>
+        <entry id="74" method="true" symbol="getLibraries"/>
+        <entry field="true" id="137" symbol="loggingIn"/>
+        <entry field="true" id="42" symbol="&lt;globals/SyncDelegate/&lt;&gt;mDeleteList&gt;"/>
+        <entry id="8390373" method="true" symbol="shuffling"/>
+        <entry id="66" method="true" symbol="_noSlash"/>
+        <entry id="33" object="true" symbol="WatchShelfApp"/>
+        <entry field="true" id="115" symbol="AppName"/>
+        <entry id="8390440" symbol="contentType"/>
+        <entry id="8390459" method="true" symbol="onStopSync"/>
+        <entry id="7" module="true" symbol="globals/Rez/Strings"/>
+        <entry id="15" module="true" symbol="Browse"/>
+        <entry id="8389594" symbol="headers"/>
+        <entry field="true" id="108" symbol="&lt;globals/ErrorView/&lt;&gt;mMessage&gt;"/>
+        <entry field="true" id="138" symbol="loginFailed"/>
+        <entry field="true" id="100" symbol="&lt;globals/LoginView/&lt;&gt;mCreds&gt;"/>
+        <entry id="8390430" method="true" symbol="getContentDelegate"/>
+        <entry field="true" id="43" symbol="&lt;globals/SyncDelegate/&lt;&gt;mDone&gt;"/>
+        <entry id="92" method="true" symbol="onLibraries"/>
+        <entry field="true" id="131" symbol="fieldPass"/>
+        <entry id="8388648" module="true" symbol="WatchUi"/>
+        <entry id="8389081" method="true" symbol="onBack"/>
+        <entry field="true" id="133" symbol="fieldUser"/>
+        <entry field="true" id="55" symbol="&lt;globals/ContentDelegate/&lt;&gt;mIterator&gt;"/>
+        <entry id="11" module="true" symbol="globals/Versions"/>
+        <entry id="73" method="true" symbol="getGroups"/>
+        <entry id="5" module="true" symbol="globals/Rez"/>
+        <entry id="35" method="true" symbol="onAuthors"/>
+        <entry id="68" method="true" symbol="authToken"/>
+        <entry id="8388789" method="true" symbol="get"/>
+        <entry id="8390342" method="true" symbol="isSyncNeeded"/>
+        <entry field="true" id="126" symbol="errDetail"/>
+        <entry id="57" method="true" symbol="before"/>
+        <entry field="true" id="118" symbol="browseLibrary"/>
+        <entry id="8389124" method="true" symbol="onUpdate"/>
+        <entry field="true" id="102" symbol="&lt;globals/LoginView/&lt;&gt;mState&gt;"/>
+        <entry id="8390431" method="true" symbol="getSyncDelegate"/>
+        <entry id="24" object="true" symbol="LibraryView"/>
+        <entry id="65" method="true" symbol="toggleShuffle"/>
+        <entry field="true" id="8390516" symbol="mContext"/>
+        <entry id="63" method="true" symbol="objAt"/>
+        <entry id="8388771" module="true" object="true" symbol="Drawables"/>
+        <entry field="true" id="147" symbol="settingServerUrlPrompt"/>
+        <entry id="67" method="true" symbol="_prop"/>
+        <entry id="26" module="true" symbol="Login"/>
+        <entry id="8390433" method="true" symbol="getProviderIconInfo"/>
+        <entry id="48" method="true" symbol="onTrackDownloaded"/>
+        <entry id="4" module="true" symbol="globals/Login"/>
+        <entry field="true" id="139" symbol="pickBook"/>
+        <entry field="true" id="117" symbol="alreadyDownloaded"/>
+        <entry field="true" id="52" symbol="username"/>
+        <entry field="true" id="145" symbol="settingApiKeyPrompt"/>
+        <entry field="true" id="51" symbol="server"/>
+        <entry id="8390442" method="true" symbol="shuffle"/>
+        <entry field="true" id="62" symbol="&lt;globals/ContentIterator/&lt;&gt;mShuffling&gt;"/>
+        <entry id="8390337" object="true" symbol="SyncDelegate"/>
+        <entry id="104" method="true" symbol="onLogin"/>
+        <entry field="true" id="125" symbol="downloaded"/>
+        <entry id="30" module="true" symbol="Store"/>
+        <entry id="93" method="true" symbol="alreadyDownloadedCount"/>
+        <entry id="9" module="true" symbol="globals/Store"/>
+        <entry id="8388637" module="true" symbol="Communications"/>
+        <entry id="82" method="true" symbol="serverUrl"/>
+        <entry id="19" object="true" symbol="ErrorView"/>
+        <entry id="27" object="true" symbol="LoginCreds"/>
+        <entry id="6" module="true" symbol="globals/Rez/Drawables"/>
+        <entry id="8390371" method="true" symbol="peekNext"/>
+        <entry id="10" module="true" symbol="globals/TrackInfo"/>
+        <entry field="true" id="130" symbol="errNone"/>
+        <entry field="true" id="120" symbol="byCollection"/>
+        <entry id="8390372" method="true" symbol="peekPrevious"/>
+        <entry id="8389844" symbol="responseType"/>
+        <entry field="true" id="90" symbol="&lt;globals/LibraryView/&lt;&gt;mMessage&gt;"/>
+        <entry field="true" id="8392276" symbol="skipForwardTimeDelta"/>
+        <entry id="8392335" module="true" object="true" symbol="Settings"/>
+        <entry field="true" id="140" symbol="pickLibrary"/>
+        <entry id="36" method="true" symbol="onBooks"/>
+        <entry id="78" method="true" symbol="logout"/>
+        <entry id="8388786" method="true" symbol="method"/>
+        <entry id="105" method="true" symbol="openField"/>
+        <entry field="true" id="136" symbol="logOut"/>
+        <entry id="31" module="true" symbol="TrackInfo"/>
+        <entry id="8388644" module="true" symbol="System"/>
+        <entry id="8390382" method="true" symbol="onSong"/>
+        <entry id="77" method="true" symbol="login"/>
+        <entry field="true" id="101" symbol="&lt;globals/LoginView/&lt;&gt;mMessage&gt;"/>
+        <entry id="8389619" method="true" symbol="onSelect"/>
+        <entry id="8388769" module="true" object="true" symbol="Rez"/>
+        <entry field="true" id="34" symbol="&lt;globals/BrowseDelegate/&lt;&gt;mLib&gt;"/>
+        <entry field="true" id="50" symbol="password"/>
+        <entry field="true" id="44" symbol="&lt;globals/SyncDelegate/&lt;&gt;mKeys&gt;"/>
+        <entry id="20" object="true" symbol="ErrorViewDelegate"/>
+        <entry id="79" method="true" symbol="patchProgress"/>
+        <entry id="8389540" method="true" symbol="onTextEntered"/>
+        <entry id="8390432" method="true" symbol="getPlaybackConfigurationView"/>
+        <entry id="75" method="true" symbol="getSeries"/>
+        <entry id="89" method="true" symbol="showBooks"/>
+        <entry field="true" id="8392277" symbol="skipBackwardTimeDelta"/>
+        <entry field="true" id="86" symbol="&lt;globals/FieldDelegate/&lt;&gt;mView&gt;"/>
+        <entry id="8388640" module="true" symbol="Lang"/>
+        <entry field="true" id="146" symbol="settingServerUrl"/>
+        <entry id="98" method="true" symbol="cancelFlow"/>
+        <entry field="true" id="134" symbol="loading"/>
+        <entry id="18" object="true" symbol="DownloadedMenuDelegate"/>
+        <entry id="8390784" method="true" symbol="onRepeat"/>
+        <entry id="8390374" method="true" symbol="canSkip"/>
+        <entry field="true" id="103" symbol="&lt;globals/LoginView/&lt;&gt;mTimer&gt;"/>
+        <entry id="106" method="true" symbol="setField"/>
+        <entry id="8388610" symbol="statics"/>
+        <entry id="70" method="true" symbol="getBookList"/>
+        <entry id="8389123" method="true" symbol="onShow"/>
+        <entry id="8" module="true" symbol="globals/Settings"/>
+        <entry id="25" object="true" symbol="LibraryViewDelegate"/>
+        <entry id="21" object="true" symbol="FieldDelegate"/>
+        <entry id="8390369" method="true" symbol="getPlaybackProfile"/>
+        <entry id="8389835" method="true" symbol="makeWebRequest"/>
+        <entry id="8390370" method="true" symbol="previous"/>
+        <entry field="true" id="113" symbol="launcher"/>
+        <entry field="true" id="91" symbol="&lt;globals/LibraryView/&lt;&gt;mStarted&gt;"/>
+        <entry id="8389350" module="true" symbol="globals"/>
+        <entry field="true" id="122" symbol="clearQueue"/>
+        <entry id="8388770" module="true" object="true" symbol="Strings"/>
+        <entry id="16" object="true" symbol="BrowseDelegate"/>
+        <entry id="8388702" method="true" symbol="initialize"/>
+        <entry field="true" id="95" symbol="&lt;globals/BookMenuDelegate/&lt;&gt;mItemId&gt;"/>
+        <entry id="40" method="true" symbol="deleteQueued"/>
+        <entry field="true" id="135" symbol="logIn"/>
+        <entry id="64" method="true" symbol="startOf"/>
+        <entry field="true" id="124" symbol="deleting"/>
+        <entry id="29" object="true" symbol="RequestDelegate"/>
+        <entry id="41" method="true" symbol="downloadNext"/>
+        <entry id="2" module="true" symbol="globals/AbsApi"/>
+        <entry id="8388641" module="true" symbol="Math"/>
+        <entry id="8389541" method="true" symbol="onCancel"/>
+        <entry id="56" method="true" symbol="syncProgress"/>
+        <entry id="8390341" method="true" symbol="onStartSync"/>
+        <entry id="88" method="true" symbol="onWebResponse"/>
+        <entry id="69" method="true" symbol="getAuthors"/>
+        <entry field="true" id="46" symbol="&lt;globals/SyncDelegate/&lt;&gt;mTotal&gt;"/>
+        <entry id="97" method="true" symbol="onFiles"/>
+        <entry id="72" method="true" symbol="getFiles"/>
+        <entry id="84" method="true" symbol="sidecarChunkUrl"/>
+        <entry id="8388646" module="true" object="true" symbol="Timer"/>
+        <entry id="3" module="true" symbol="globals/Browse"/>
+        <entry id="83" method="true" symbol="sidecarBase"/>
+        <entry id="38" method="true" symbol="onSeries"/>
+        <entry field="true" id="129" symbol="errNoAudio"/>
+        <entry id="8388698" method="true" symbol="start"/>
+        <entry id="8390381" method="true" symbol="onShuffle"/>
+        <entry id="109" method="true" symbol="bookTitle"/>
+        <entry id="22" object="true" symbol="GroupDelegate"/>
+        <entry field="true" id="60" symbol="&lt;globals/ContentIterator/&lt;&gt;mIndex&gt;"/>
+        <entry id="8390441" object="true" symbol="mediaEncoding"/>
+        <entry id="111" method="true" symbol="hasQueued"/>
+        <entry field="true" id="121" symbol="bySeries"/>
+        <entry field="true" id="123" symbol="deleteAllDownloads"/>
+        <entry id="8389125" method="true" symbol="onHide"/>
+        <entry field="true" id="114" symbol="providerIcon"/>
+        <entry id="99" method="true" symbol="labelFor"/>
+        <entry id="110" method="true" symbol="groupedBooks"/>
+        <entry id="8388635" module="true" symbol="Application"/>
+        <entry field="true" id="8389642" symbol="title"/>
+        <entry field="true" id="85" symbol="&lt;globals/FieldDelegate/&lt;&gt;mField&gt;"/>
+        <entry id="71" method="true" symbol="getCollections"/>
+    </symbolTable>
+    <localVars>
+        <entry arg="true" endPc="268435697" name="code" stackId="1" startPc="268435672"/>
+        <entry arg="true" endPc="268435697" name="data" stackId="2" startPc="268435672"/>
+        <entry arg="true" endPc="268435741" name="code" stackId="1" startPc="268435716"/>
+        <entry arg="true" endPc="268435741" name="data" stackId="2" startPc="268435716"/>
+        <entry arg="true" endPc="268436108" name="code" stackId="1" startPc="268435742"/>
+        <entry arg="true" endPc="268436108" name="data" stackId="2" startPc="268435742"/>
+        <entry arg="true" endPc="268436108" name="key" stackId="3" startPc="268435742"/>
+        <entry arg="true" endPc="268436108" name="filterType" stackId="4" startPc="268435742"/>
+        <entry endPc="268436107" name="groups" stackId="5" startPc="268435745"/>
+        <entry endPc="268436107" name="m" stackId="6" startPc="268435745"/>
+        <entry endPc="268436065" name="i" stackId="7" startPc="268435960"/>
+        <entry endPc="268436055" name="g" stackId="8" startPc="268435960"/>
+        <entry endPc="268436055" name="sub" stackId="9" startPc="268435960"/>
+        <entry arg="true" endPc="268436128" name="code" stackId="1" startPc="268436109"/>
+        <entry arg="true" endPc="268436128" name="data" stackId="2" startPc="268436109"/>
+        <entry arg="true" endPc="268436154" name="code" stackId="1" startPc="268436129"/>
+        <entry arg="true" endPc="268436154" name="data" stackId="2" startPc="268436129"/>
+        <entry arg="true" endPc="268436178" name="libId" stackId="1" startPc="268436155"/>
+        <entry arg="true" endPc="268436377" name="item" stackId="1" startPc="268436179"/>
+        <entry endPc="268436376" name="mode" stackId="2" startPc="268436182"/>
+        <entry endPc="268436710" name="key" stackId="1" startPc="268436474"/>
+        <entry endPc="268436710" name="info" stackId="2" startPc="268436474"/>
+        <entry endPc="268436710" name="context" stackId="3" startPc="268436474"/>
+        <entry endPc="268436710" name="options" stackId="4" startPc="268436474"/>
+        <entry endPc="268436710" name="delegate" stackId="5" startPc="268436474"/>
+        <entry endPc="268436710" name="url" stackId="6" startPc="268436474"/>
+        <entry endPc="268436772" name="pct" stackId="1" startPc="268436715"/>
+        <entry endPc="268436953" name="tracks" stackId="1" startPc="268436777"/>
+        <entry endPc="268436906" name="i" stackId="2" startPc="268436829"/>
+        <entry endPc="268436896" name="refId" stackId="3" startPc="268436829"/>
+        <entry arg="true" endPc="268437163" name="code" stackId="1" startPc="268436955"/>
+        <entry arg="true" endPc="268437163" name="data" stackId="2" startPc="268436955"/>
+        <entry arg="true" endPc="268437163" name="context" stackId="3" startPc="268436955"/>
+        <entry endPc="268437132" name="refId" stackId="4" startPc="268436967"/>
+        <entry endPc="268437132" name="tracks" stackId="5" startPc="268436967"/>
+        <entry arg="true" endPc="268437287" name="type" stackId="1" startPc="268437192"/>
+        <entry arg="true" endPc="268437512" name="code" stackId="1" startPc="268437493"/>
+        <entry arg="true" endPc="268437512" name="data" stackId="2" startPc="268437493"/>
+        <entry arg="true" endPc="268437545" name="libId" stackId="1" startPc="268437513"/>
+        <entry arg="true" endPc="268437545" name="filterType" stackId="2" startPc="268437513"/>
+        <entry arg="true" endPc="268437591" name="item" stackId="1" startPc="268437546"/>
+        <entry arg="true" endPc="268437627" name="code" stackId="1" startPc="268437592"/>
+        <entry arg="true" endPc="268437627" name="data" stackId="2" startPc="268437592"/>
+        <entry arg="true" endPc="268437683" name="item" stackId="1" startPc="268437661"/>
+        <entry arg="true" endPc="268437802" name="args" stackId="1" startPc="268437782"/>
+        <entry endPc="268437908" name="version" stackId="1" startPc="268437827"/>
+        <entry arg="true" endPc="268438102" name="refId" stackId="1" startPc="268437982"/>
+        <entry arg="true" endPc="268438102" name="positionInChapter" stackId="2" startPc="268437982"/>
+        <entry endPc="268438101" name="tracks" stackId="3" startPc="268437985"/>
+        <entry endPc="268438101" name="info" stackId="4" startPc="268437985"/>
+        <entry endPc="268438101" name="start" stackId="5" startPc="268437985"/>
+        <entry endPc="268438101" name="absolute" stackId="6" startPc="268437985"/>
+        <entry arg="true" endPc="268438178" name="refId" stackId="1" startPc="268438128"/>
+        <entry arg="true" endPc="268438178" name="songEvent" stackId="2" startPc="268438128"/>
+        <entry arg="true" endPc="268438178" name="playbackPosition" stackId="3" startPc="268438128"/>
+        <entry arg="true" endPc="268438422" name="idx" stackId="1" startPc="268438274"/>
+        <entry endPc="268438412" name="e" stackId="2" startPc="268438355"/>
+        <entry arg="true" endPc="268438549" name="tracks" stackId="1" startPc="268438469"/>
+        <entry arg="true" endPc="268438549" name="refIdA" stackId="2" startPc="268438469"/>
+        <entry arg="true" endPc="268438549" name="refIdB" stackId="3" startPc="268438469"/>
+        <entry endPc="268438549" name="titleA" stackId="4" startPc="268438472"/>
+        <entry endPc="268438549" name="titleB" stackId="5" startPc="268438472"/>
+        <entry endPc="268438745" name="profile" stackId="1" startPc="268438620"/>
+        <entry arg="true" endPc="268438787" name="tracks" stackId="1" startPc="268438746"/>
+        <entry arg="true" endPc="268438787" name="refId" stackId="2" startPc="268438746"/>
+        <entry endPc="268438787" name="info" stackId="3" startPc="268438749"/>
+        <entry endPc="268438958" name="i" stackId="1" startPc="268438895"/>
+        <entry endPc="268438948" name="j" stackId="2" startPc="268438895"/>
+        <entry endPc="268438948" name="tmp" stackId="3" startPc="268438895"/>
+        <entry arg="true" endPc="268439013" name="tracks" stackId="1" startPc="268438968"/>
+        <entry arg="true" endPc="268439013" name="refId" stackId="2" startPc="268438968"/>
+        <entry endPc="268439013" name="info" stackId="3" startPc="268438971"/>
+        <entry endPc="268439375" name="tracks" stackId="1" startPc="268439017"/>
+        <entry endPc="268439375" name="refIds" stackId="2" startPc="268439017"/>
+        <entry endPc="268439375" name="iter" stackId="3" startPc="268439017"/>
+        <entry endPc="268439141" name="ref" stackId="4" startPc="268439095"/>
+        <entry endPc="268439367" name="i" stackId="5" startPc="268439161"/>
+        <entry endPc="268439357" name="refId" stackId="6" startPc="268439161"/>
+        <entry endPc="268439357" name="pos" stackId="7" startPc="268439161"/>
+        <entry endPc="268439243" name="j" stackId="8" startPc="268439201"/>
+        <entry endPc="268439357" name="rebuilt" stackId="9" startPc="268439161"/>
+        <entry endPc="268439294" name="k" stackId="10" startPc="268439272"/>
+        <entry endPc="268439348" name="k" stackId="11" startPc="268439323"/>
+        <entry endPc="268439534" name="v" stackId="1" startPc="268439489"/>
+        <entry arg="true" endPc="268439593" name="server" stackId="1" startPc="268439535"/>
+        <entry arg="true" endPc="268439593" name="token" stackId="2" startPc="268439535"/>
+        <entry arg="true" endPc="268439622" name="libId" stackId="1" startPc="268439594"/>
+        <entry arg="true" endPc="268439622" name="cb" stackId="2" startPc="268439594"/>
+        <entry arg="true" endPc="268439733" name="server" stackId="1" startPc="268439640"/>
+        <entry arg="true" endPc="268439733" name="username" stackId="2" startPc="268439640"/>
+        <entry arg="true" endPc="268439733" name="password" stackId="3" startPc="268439640"/>
+        <entry arg="true" endPc="268439733" name="cb" stackId="4" startPc="268439640"/>
+        <entry arg="true" endPc="268439816" name="itemId" stackId="1" startPc="268439734"/>
+        <entry arg="true" endPc="268439816" name="cb" stackId="2" startPc="268439734"/>
+        <entry arg="true" endPc="268439885" name="key" stackId="1" startPc="268439817"/>
+        <entry endPc="268439885" name="v" stackId="2" startPc="268439828"/>
+        <entry arg="true" endPc="268439995" name="libId" stackId="1" startPc="268439886"/>
+        <entry arg="true" endPc="268439995" name="filterType" stackId="2" startPc="268439886"/>
+        <entry arg="true" endPc="268439995" name="filterId" stackId="3" startPc="268439886"/>
+        <entry arg="true" endPc="268439995" name="cb" stackId="4" startPc="268439886"/>
+        <entry endPc="268439994" name="params" stackId="5" startPc="268439897"/>
+        <entry arg="true" endPc="268440196" name="itemId" stackId="1" startPc="268440043"/>
+        <entry arg="true" endPc="268440196" name="currentTimeSec" stackId="2" startPc="268440043"/>
+        <entry arg="true" endPc="268440196" name="durationSec" stackId="3" startPc="268440043"/>
+        <entry endPc="268440195" name="params" stackId="4" startPc="268440054"/>
+        <entry arg="true" endPc="268440225" name="libId" stackId="1" startPc="268440197"/>
+        <entry arg="true" endPc="268440225" name="cb" stackId="2" startPc="268440197"/>
+        <entry arg="true" endPc="268440278" name="detail" stackId="1" startPc="268440226"/>
+        <entry endPc="268440278" name="p" stackId="2" startPc="268440237"/>
+        <entry arg="true" endPc="268440307" name="libId" stackId="1" startPc="268440279"/>
+        <entry arg="true" endPc="268440307" name="cb" stackId="2" startPc="268440279"/>
+        <entry arg="true" endPc="268440383" name="itemId" stackId="1" startPc="268440308"/>
+        <entry arg="true" endPc="268440383" name="ino" stackId="2" startPc="268440308"/>
+        <entry arg="true" endPc="268440383" name="startSec" stackId="3" startPc="268440308"/>
+        <entry arg="true" endPc="268440383" name="endSec" stackId="4" startPc="268440308"/>
+        <entry arg="true" endPc="268440486" name="url" stackId="1" startPc="268440384"/>
+        <entry endPc="268440633" name="v" stackId="1" startPc="268440498"/>
+        <entry arg="true" endPc="268440708" name="callback" stackId="1" startPc="268440634"/>
+        <entry arg="true" endPc="268440788" name="path" stackId="1" startPc="268440709"/>
+        <entry arg="true" endPc="268440788" name="libId" stackId="2" startPc="268440709"/>
+        <entry arg="true" endPc="268440788" name="cb" stackId="3" startPc="268440709"/>
+        <entry arg="true" endPc="268440813" name="text" stackId="1" startPc="268440789"/>
+        <entry arg="true" endPc="268440813" name="changed" stackId="2" startPc="268440789"/>
+        <entry arg="true" endPc="268440862" name="view" stackId="1" startPc="268440830"/>
+        <entry arg="true" endPc="268440862" name="field" stackId="2" startPc="268440830"/>
+        <entry arg="true" endPc="268440897" name="url" stackId="1" startPc="268440863"/>
+        <entry arg="true" endPc="268440897" name="params" stackId="2" startPc="268440863"/>
+        <entry arg="true" endPc="268440897" name="options" stackId="3" startPc="268440863"/>
+        <entry arg="true" endPc="268440918" name="callback" stackId="1" startPc="268440898"/>
+        <entry arg="true" endPc="268440918" name="context" stackId="2" startPc="268440898"/>
+        <entry arg="true" endPc="268440944" name="code" stackId="1" startPc="268440919"/>
+        <entry arg="true" endPc="268440944" name="data" stackId="2" startPc="268440919"/>
+        <entry arg="true" endPc="268441343" name="libId" stackId="1" startPc="268440945"/>
+        <entry endPc="268441342" name="m" stackId="2" startPc="268440956"/>
+        <entry arg="true" endPc="268441715" name="code" stackId="1" startPc="268441344"/>
+        <entry arg="true" endPc="268441715" name="data" stackId="2" startPc="268441344"/>
+        <entry endPc="268441714" name="books" stackId="3" startPc="268441355"/>
+        <entry endPc="268441714" name="m" stackId="4" startPc="268441355"/>
+        <entry endPc="268441675" name="i" stackId="5" startPc="268441602"/>
+        <entry endPc="268441665" name="b" stackId="6" startPc="268441602"/>
+        <entry arg="true" endPc="268442046" name="code" stackId="1" startPc="268441716"/>
+        <entry arg="true" endPc="268442046" name="data" stackId="2" startPc="268441716"/>
+        <entry endPc="268441978" name="libs" stackId="3" startPc="268441746"/>
+        <entry endPc="268441978" name="menu" stackId="4" startPc="268441746"/>
+        <entry endPc="268441943" name="i" stackId="5" startPc="268441838"/>
+        <entry endPc="268441933" name="lib" stackId="6" startPc="268441838"/>
+        <entry arg="true" endPc="268442263" name="dc" stackId="1" startPc="268442186"/>
+        <entry endPc="268442451" name="tracks" stackId="1" startPc="268442319"/>
+        <entry endPc="268442451" name="count" stackId="2" startPc="268442319"/>
+        <entry endPc="268442451" name="refIds" stackId="3" startPc="268442319"/>
+        <entry endPc="268442448" name="i" stackId="4" startPc="268442377"/>
+        <entry endPc="268442438" name="info" stackId="5" startPc="268442377"/>
+        <entry arg="true" endPc="268443283" name="code" stackId="1" startPc="268442475"/>
+        <entry arg="true" endPc="268443283" name="data" stackId="2" startPc="268442475"/>
+        <entry endPc="268443282" name="chunk" stackId="3" startPc="268442478"/>
+        <entry endPc="268443282" name="firstChunk" stackId="4" startPc="268442478"/>
+        <entry endPc="268443282" name="files" stackId="5" startPc="268442478"/>
+        <entry endPc="268443282" name="title" stackId="6" startPc="268442478"/>
+        <entry endPc="268443282" name="expected" stackId="7" startPc="268442478"/>
+        <entry endPc="268443282" name="syncList" stackId="8" startPc="268442478"/>
+        <entry endPc="268443282" name="bookOffset" stackId="9" startPc="268442478"/>
+        <entry endPc="268443282" name="idx" stackId="10" startPc="268442478"/>
+        <entry endPc="268443076" name="f" stackId="11" startPc="268442845"/>
+        <entry endPc="268443066" name="ino" stackId="12" startPc="268442845"/>
+        <entry endPc="268443066" name="dur" stackId="13" startPc="268442845"/>
+        <entry endPc="268443066" name="pos" stackId="14" startPc="268442845"/>
+        <entry endPc="268443056" name="size" stackId="15" startPc="268442910"/>
+        <entry endPc="268443056" name="end" stackId="16" startPc="268442910"/>
+        <entry arg="true" endPc="268443300" name="v" stackId="1" startPc="268443284"/>
+        <entry arg="true" endPc="268443300" name="dflt" stackId="2" startPc="268443284"/>
+        <entry arg="true" endPc="268443439" name="files" stackId="1" startPc="268443301"/>
+        <entry arg="true" endPc="268443439" name="chunk" stackId="2" startPc="268443301"/>
+        <entry arg="true" endPc="268443439" name="firstChunk" stackId="3" startPc="268443301"/>
+        <entry endPc="268443439" name="count" stackId="4" startPc="268443304"/>
+        <entry endPc="268443436" name="f" stackId="5" startPc="268443323"/>
+        <entry endPc="268443426" name="dur" stackId="6" startPc="268443323"/>
+        <entry endPc="268443426" name="pos" stackId="7" startPc="268443323"/>
+        <entry endPc="268443423" name="size" stackId="8" startPc="268443375"/>
+        <entry endPc="268443423" name="end" stackId="9" startPc="268443375"/>
+        <entry arg="true" endPc="268443487" name="item" stackId="1" startPc="268443440"/>
+        <entry arg="true" endPc="268443699" name="code" stackId="1" startPc="268443488"/>
+        <entry arg="true" endPc="268443699" name="data" stackId="2" startPc="268443488"/>
+        <entry arg="true" endPc="268443818" name="state" stackId="1" startPc="268443700"/>
+        <entry arg="true" endPc="268443904" name="field" stackId="1" startPc="268443819"/>
+        <entry arg="true" endPc="268443904" name="text" stackId="2" startPc="268443819"/>
+        <entry endPc="268444558" name="s" stackId="1" startPc="268444455"/>
+        <entry arg="true" endPc="268444672" name="dc" stackId="1" startPc="268444595"/>
+        <entry arg="true" endPc="268444878" name="refIds" stackId="1" startPc="268444673"/>
+        <entry endPc="268444877" name="deleteList" stackId="2" startPc="268444676"/>
+        <entry endPc="268444764" name="i" stackId="3" startPc="268444740"/>
+        <entry arg="true" endPc="268445555" name="item" stackId="1" startPc="268444912"/>
+        <entry endPc="268445554" name="id" stackId="2" startPc="268444915"/>
+        <entry endPc="268445402" name="tracks" stackId="3" startPc="268445354"/>
+        <entry endPc="268445554" name="tracks" stackId="4" startPc="268444915"/>
+        <entry endPc="268445554" name="refIds" stackId="5" startPc="268444915"/>
+        <entry endPc="268445554" name="toDelete" stackId="6" startPc="268444915"/>
+        <entry endPc="268445543" name="i" stackId="7" startPc="268445467"/>
+        <entry endPc="268445533" name="info" stackId="8" startPc="268445467"/>
+        <entry arg="true" endPc="268445613" name="message" stackId="1" startPc="268445590"/>
+        <entry arg="true" endPc="268445691" name="dc" stackId="1" startPc="268445614"/>
+        <entry endPc="268445812" name="stats" stackId="1" startPc="268445695"/>
+        <entry endPc="268445812" name="used" stackId="2" startPc="268445695"/>
+        <entry endPc="268445812" name="mb" stackId="3" startPc="268445695"/>
+        <entry endPc="268445898" name="syncList" stackId="1" startPc="268445816"/>
+        <entry endPc="268445898" name="deleteList" stackId="2" startPc="268445816"/>
+        <entry endPc="268446486" name="books" stackId="1" startPc="268445902"/>
+        <entry endPc="268446486" name="itemIds" stackId="2" startPc="268445902"/>
+        <entry endPc="268446486" name="i" stackId="3" startPc="268446369"/>
+        <entry endPc="268446476" name="itemId" stackId="4" startPc="268446369"/>
+        <entry endPc="268446476" name="book" stackId="5" startPc="268446369"/>
+        <entry endPc="268446476" name="sub" stackId="6" startPc="268446369"/>
+        <entry endPc="268446672" name="tracks" stackId="1" startPc="268446491"/>
+        <entry endPc="268446672" name="books" stackId="2" startPc="268446491"/>
+        <entry endPc="268446672" name="refIds" stackId="3" startPc="268446491"/>
+        <entry endPc="268446669" name="i" stackId="4" startPc="268446552"/>
+        <entry endPc="268446659" name="info" stackId="5" startPc="268446552"/>
+        <entry endPc="268446659" name="itemId" stackId="6" startPc="268446552"/>
+        <entry endPc="268446659" name="book" stackId="7" startPc="268446552"/>
+        <entry arg="true" endPc="268446825" name="refId" stackId="1" startPc="268446673"/>
+        <entry arg="true" endPc="268446825" name="info" stackId="2" startPc="268446673"/>
+        <entry endPc="268446825" name="ref" stackId="3" startPc="268446676"/>
+        <entry endPc="268446825" name="obj" stackId="4" startPc="268446676"/>
+    </localVars>
+    <deviceInfo deviceVersion="e6263c2a80ff43933f83afa71f1f6645dc2cb4a3" partNumber="006-B4533-00"/>
+    <annotations>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="queued"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldServer"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="byAuthor"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errNone"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="AppName"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errNoAudio"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="deleteAllDownloads"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingApiKeyPrompt"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldUser"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingServerUrlPrompt"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loggingIn"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingServerUrl"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="deleting"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errItems"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldPass"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingApiKey"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="clearQueue"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="logIn"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="browseLibrary"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="pickBook"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="alreadyDownloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="bySeries"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loginFailed"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="byCollection"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errLibraries"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="pickLibrary"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="playDownloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loading"/>
+        <annotationEntry annotation="initialized" class="Drawables" module="globals/Rez" symbol="providerIcon"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errDetail"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="allBooks"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="logOut"/>
+        <annotationEntry annotation="initialized" class="Drawables" module="globals/Rez" symbol="launcher"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="downloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="queueCleared"/>
+    </annotations>
+    <dataEntryOffsetMappings>
+        <dataEntry label="globals" offset="112" parentId="" symbolId="globals" type="module"/>
+        <dataEntry label="globals/BrowseDelegate" offset="386" parentId="globals" symbolId="BrowseDelegate" type="class"/>
+        <dataEntry label="globals/SyncDelegate" offset="502" parentId="globals" symbolId="SyncDelegate" type="class"/>
+        <dataEntry label="globals/Rez" offset="663" parentId="globals" symbolId="Rez" type="module"/>
+        <dataEntry label="globals/LoginCreds" offset="707" parentId="globals" symbolId="LoginCreds" type="class"/>
+        <dataEntry label="globals/GroupDelegate" offset="778" parentId="globals" symbolId="GroupDelegate" type="class"/>
+        <dataEntry label="globals/Store" offset="867" parentId="globals" symbolId="Store" type="module"/>
+        <dataEntry label="globals/AbsProgressListener" offset="893" parentId="globals" symbolId="AbsProgressListener" type="class"/>
+        <dataEntry label="globals/TrackInfo" offset="946" parentId="globals" symbolId="TrackInfo" type="module"/>
+        <dataEntry label="globals/LibraryMenuDelegate" offset="972" parentId="globals" symbolId="LibraryMenuDelegate" type="class"/>
+        <dataEntry label="globals/WatchShelfApp" offset="1034" parentId="globals" symbolId="WatchShelfApp" type="class"/>
+        <dataEntry label="globals/Settings" offset="1123" parentId="globals" symbolId="Settings" type="module"/>
+        <dataEntry label="globals/ContentDelegate" offset="1149" parentId="globals" symbolId="ContentDelegate" type="class"/>
+        <dataEntry label="globals/ContentIterator" offset="1274" parentId="globals" symbolId="ContentIterator" type="class"/>
+        <dataEntry label="globals/Login" offset="1480" parentId="globals" symbolId="Login" type="module"/>
+        <dataEntry label="globals/AbsApi" offset="1515" parentId="globals" symbolId="AbsApi" type="module"/>
+        <dataEntry label="globals/FieldDelegate" offset="1712" parentId="globals" symbolId="FieldDelegate" type="class"/>
+        <dataEntry label="globals/RequestDelegate" offset="1792" parentId="globals" symbolId="RequestDelegate" type="class"/>
+        <dataEntry label="globals/Browse" offset="1872" parentId="globals" symbolId="Browse" type="module"/>
+        <dataEntry label="globals/Versions" offset="1916" parentId="globals" symbolId="Versions" type="module"/>
+        <dataEntry label="globals/LibraryView" offset="1942" parentId="globals" symbolId="LibraryView" type="class"/>
+        <dataEntry label="globals/LibraryViewDelegate" offset="2031" parentId="globals" symbolId="LibraryViewDelegate" type="class"/>
+        <dataEntry label="globals/BookMenuDelegate" offset="2084" parentId="globals" symbolId="BookMenuDelegate" type="class"/>
+        <dataEntry label="globals/LoginView" offset="2191" parentId="globals" symbolId="LoginView" type="class"/>
+        <dataEntry label="globals/DownloadedMenuDelegate" offset="2343" parentId="globals" symbolId="DownloadedMenuDelegate" type="class"/>
+        <dataEntry label="globals/ErrorViewDelegate" offset="2414" parentId="globals" symbolId="ErrorViewDelegate" type="class"/>
+        <dataEntry label="globals/ErrorView" offset="2467" parentId="globals" symbolId="ErrorView" type="class"/>
+        <dataEntry label="globals/DownloadedMenu" offset="2529" parentId="globals" symbolId="DownloadedMenu" type="class"/>
+        <dataEntry label="globals/Rez/Drawables" offset="2609" parentId="Rez" symbolId="Drawables" type="module"/>
+        <dataEntry label="globals/Rez/Strings" offset="2653" parentId="Rez" symbolId="Strings" type="module"/>
+    </dataEntryOffsetMappings>
+    <functions>
+        <functionEntry accessMode="public" endPc="268435471" name="&lt;init&gt;" parent="BrowseDelegate" startPc="268435460">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435483" name="&lt;init&gt;" parent="SyncDelegate" startPc="268435472">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435503" name="&lt;init&gt;" parent="Rez" startPc="268435484">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="LoginCreds">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435515" name="&lt;init&gt;" parent="GroupDelegate" startPc="268435504">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Store">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="AbsProgressListener">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="TrackInfo">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435527" name="&lt;init&gt;" parent="LibraryMenuDelegate" startPc="268435516">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435539" name="&lt;init&gt;" parent="WatchShelfApp" startPc="268435528">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Settings">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435551" name="&lt;init&gt;" parent="ContentDelegate" startPc="268435540">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435563" name="&lt;init&gt;" parent="ContentIterator" startPc="268435552">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Login">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="AbsApi">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435575" name="&lt;init&gt;" parent="FieldDelegate" startPc="268435564">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="RequestDelegate">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Browse">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Versions">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435587" name="&lt;init&gt;" parent="LibraryView" startPc="268435576">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435599" name="&lt;init&gt;" parent="LibraryViewDelegate" startPc="268435588">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435611" name="&lt;init&gt;" parent="BookMenuDelegate" startPc="268435600">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435623" name="&lt;init&gt;" parent="LoginView" startPc="268435612">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435635" name="&lt;init&gt;" parent="DownloadedMenuDelegate" startPc="268435624">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435647" name="&lt;init&gt;" parent="ErrorViewDelegate" startPc="268435636">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435659" name="&lt;init&gt;" parent="ErrorView" startPc="268435648">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435671" name="&lt;init&gt;" parent="DownloadedMenu" startPc="268435660">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435697" name="onSeries" parent="BrowseDelegate" startPc="268435672">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435715" name="onBack" parent="BrowseDelegate" startPc="268435698">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435741" name="onAuthors" parent="BrowseDelegate" startPc="268435716">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436108" name="pushGroups" parent="BrowseDelegate" startPc="268435742">
+            <param id="code"/>
+            <param id="data"/>
+            <param id="key"/>
+            <param id="filterType"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436128" name="onBooks" parent="BrowseDelegate" startPc="268436109">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436154" name="onCollections" parent="BrowseDelegate" startPc="268436129">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436178" name="initialize" parent="BrowseDelegate" startPc="268436155">
+            <param id="libId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436377" name="onSelect" parent="BrowseDelegate" startPc="268436179">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436470" name="onStartSync" parent="SyncDelegate" startPc="268436378">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436711" name="downloadNext" parent="SyncDelegate" startPc="268436471">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436773" name="onOpDone" parent="SyncDelegate" startPc="268436712">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436954" name="deleteQueued" parent="SyncDelegate" startPc="268436774">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437163" name="onTrackDownloaded" parent="SyncDelegate" startPc="268436955">
+            <param id="code"/>
+            <param id="data"/>
+            <param id="context"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437191" name="onStopSync" parent="SyncDelegate" startPc="268437164">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437287" name="typeToEncoding" parent="SyncDelegate" startPc="268437192">
+            <param id="type"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437400" name="initialize" parent="SyncDelegate" startPc="268437288">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437435" name="isSyncNeeded" parent="SyncDelegate" startPc="268437401">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Drawables">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Strings">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437474" name="initialize" parent="LoginCreds" startPc="268437436">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437492" name="onBack" parent="GroupDelegate" startPc="268437475">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437512" name="onBooks" parent="GroupDelegate" startPc="268437493">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437545" name="initialize" parent="GroupDelegate" startPc="268437513">
+            <param id="libId"/>
+            <param id="filterType"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437591" name="onSelect" parent="GroupDelegate" startPc="268437546">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437627" name="onResponse" parent="AbsProgressListener" startPc="268437592">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="initialize" parent="AbsProgressListener">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437645" name="onBack" parent="LibraryMenuDelegate" startPc="268437628">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437660" name="initialize" parent="LibraryMenuDelegate" startPc="268437646">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437683" name="onSelect" parent="LibraryMenuDelegate" startPc="268437661">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437732" name="getProviderIconInfo" parent="WatchShelfApp" startPc="268437684">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437781" name="getPlaybackConfigurationView" parent="WatchShelfApp" startPc="268437733">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437802" name="getContentDelegate" parent="WatchShelfApp" startPc="268437782">
+            <param id="args"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437823" name="getSyncDelegate" parent="WatchShelfApp" startPc="268437803">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437909" name="initialize" parent="WatchShelfApp" startPc="268437824">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437958" name="getSyncConfigurationView" parent="WatchShelfApp" startPc="268437910">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437973" name="onShuffle" parent="ContentDelegate" startPc="268437959">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437981" name="getContentIterator" parent="ContentDelegate" startPc="268437974">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438102" name="syncProgress" parent="ContentDelegate" startPc="268437982">
+            <param id="refId"/>
+            <param id="positionInChapter"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438105" name="onThumbsUp" parent="ContentDelegate" startPc="268438103">
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438127" name="initialize" parent="ContentDelegate" startPc="268438106">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438178" name="onSong" parent="ContentDelegate" startPc="268438128">
+            <param id="refId"/>
+            <param id="songEvent"/>
+            <param id="playbackPosition"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="onRepeat" parent="ContentDelegate">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438211" name="resetContentIterator" parent="ContentDelegate" startPc="268438179">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438214" name="onThumbsDown" parent="ContentDelegate" startPc="268438212">
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438273" name="next" parent="ContentIterator" startPc="268438215">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438422" name="objAt" parent="ContentIterator" startPc="268438274">
+            <param id="idx"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438468" name="previous" parent="ContentIterator" startPc="268438423">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438549" name="before" parent="ContentIterator" startPc="268438469">
+            <param id="tracks"/>
+            <param id="refIdA"/>
+            <param id="refIdB"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438568" name="peekPrevious" parent="ContentIterator" startPc="268438550">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438572" name="canSkip" parent="ContentIterator" startPc="268438569">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438616" name="toggleShuffle" parent="ContentIterator" startPc="268438573">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438745" name="getPlaybackProfile" parent="ContentIterator" startPc="268438617">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438787" name="startOf" parent="ContentIterator" startPc="268438746">
+            <param id="tracks"/>
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438806" name="peekNext" parent="ContentIterator" startPc="268438788">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438822" name="get" parent="ContentIterator" startPc="268438807">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438830" name="shuffling" parent="ContentIterator" startPc="268438823">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438868" name="initialize" parent="ContentIterator" startPc="268438831">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438967" name="shuffle" parent="ContentIterator" startPc="268438869">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439013" name="bookTitleOf" parent="ContentIterator" startPc="268438968">
+            <param id="tracks"/>
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439376" name="buildPlaylist" parent="ContentIterator" startPc="268439014">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439446" name="start" parent="Login" startPc="268439377">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439477" name="isConfigured" parent="AbsApi" startPc="268439447">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439534" name="authToken" parent="AbsApi" startPc="268439478">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439593" name="saveLogin" parent="AbsApi" startPc="268439535">
+            <param id="server"/>
+            <param id="token"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439622" name="getCollections" parent="AbsApi" startPc="268439594">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439639" name="sidecarBase" parent="AbsApi" startPc="268439623">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439733" name="login" parent="AbsApi" startPc="268439640">
+            <param id="server"/>
+            <param id="username"/>
+            <param id="password"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439816" name="getFiles" parent="AbsApi" startPc="268439734">
+            <param id="itemId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439885" name="_prop" parent="AbsApi" startPc="268439817">
+            <param id="key"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439995" name="getBookList" parent="AbsApi" startPc="268439886">
+            <param id="libId"/>
+            <param id="filterType"/>
+            <param id="filterId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440042" name="logout" parent="AbsApi" startPc="268439996">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440196" name="patchProgress" parent="AbsApi" startPc="268440043">
+            <param id="itemId"/>
+            <param id="currentTimeSec"/>
+            <param id="durationSec"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440225" name="getSeries" parent="AbsApi" startPc="268440197">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440278" name="progressSeconds" parent="AbsApi" startPc="268440226">
+            <param id="detail"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440307" name="getAuthors" parent="AbsApi" startPc="268440279">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440383" name="sidecarChunkUrl" parent="AbsApi" startPc="268440308">
+            <param id="itemId"/>
+            <param id="ino"/>
+            <param id="startSec"/>
+            <param id="endSec"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440486" name="_noSlash" parent="AbsApi" startPc="268440384">
+            <param id="url"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440633" name="serverUrl" parent="AbsApi" startPc="268440487">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440708" name="getLibraries" parent="AbsApi" startPc="268440634">
+            <param id="callback"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440788" name="getGroups" parent="AbsApi" startPc="268440709">
+            <param id="path"/>
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440813" name="onTextEntered" parent="FieldDelegate" startPc="268440789">
+            <param id="text"/>
+            <param id="changed"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440829" name="onCancel" parent="FieldDelegate" startPc="268440814">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440862" name="initialize" parent="FieldDelegate" startPc="268440830">
+            <param id="view"/>
+            <param id="field"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440897" name="makeWebRequest" parent="RequestDelegate" startPc="268440863">
+            <param id="url"/>
+            <param id="params"/>
+            <param id="options"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440918" name="initialize" parent="RequestDelegate" startPc="268440898">
+            <param id="callback"/>
+            <param id="context"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440944" name="onWebResponse" parent="RequestDelegate" startPc="268440919">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441343" name="start" parent="Browse" startPc="268440945">
+            <param id="libId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441715" name="showBooks" parent="Browse" startPc="268441344">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442046" name="onLibraries" parent="LibraryView" startPc="268441716">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442124" name="onShow" parent="LibraryView" startPc="268442047">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442185" name="initialize" parent="LibraryView" startPc="268442125">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442263" name="onUpdate" parent="LibraryView" startPc="268442186">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442282" name="onBack" parent="LibraryViewDelegate" startPc="268442264">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442297" name="initialize" parent="LibraryViewDelegate" startPc="268442283">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442315" name="onBack" parent="BookMenuDelegate" startPc="268442298">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442451" name="alreadyDownloadedCount" parent="BookMenuDelegate" startPc="268442316">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442474" name="initialize" parent="BookMenuDelegate" startPc="268442452">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443283" name="onFiles" parent="BookMenuDelegate" startPc="268442475">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443300" name="numOr" parent="BookMenuDelegate" startPc="268443284">
+            <param id="v"/>
+            <param id="dflt"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443439" name="expectedChunkCount" parent="BookMenuDelegate" startPc="268443301">
+            <param id="files"/>
+            <param id="chunk"/>
+            <param id="firstChunk"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443487" name="onSelect" parent="BookMenuDelegate" startPc="268443440">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443699" name="onLogin" parent="LoginView" startPc="268443488">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443818" name="labelFor" parent="LoginView" startPc="268443700">
+            <param id="state"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443904" name="setField" parent="LoginView" startPc="268443819">
+            <param id="field"/>
+            <param id="text"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444140" name="onShow" parent="LoginView" startPc="268443905">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444201" name="cancelFlow" parent="LoginView" startPc="268444141">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444451" name="openField" parent="LoginView" startPc="268444202">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444559" name="initialize" parent="LoginView" startPc="268444452">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444594" name="onHide" parent="LoginView" startPc="268444560">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444672" name="onUpdate" parent="LoginView" startPc="268444595">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444878" name="queueDelete" parent="DownloadedMenuDelegate" startPc="268444673">
+            <param id="refIds"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444896" name="onBack" parent="DownloadedMenuDelegate" startPc="268444879">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444911" name="initialize" parent="DownloadedMenuDelegate" startPc="268444897">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445555" name="onSelect" parent="DownloadedMenuDelegate" startPc="268444912">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445574" name="onBack" parent="ErrorViewDelegate" startPc="268445556">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445589" name="initialize" parent="ErrorViewDelegate" startPc="268445575">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445613" name="initialize" parent="ErrorView" startPc="268445590">
+            <param id="message"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445691" name="onUpdate" parent="ErrorView" startPc="268445614">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445812" name="titleWithSize" parent="DownloadedMenu" startPc="268445692">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445898" name="hasQueued" parent="DownloadedMenu" startPc="268445813">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446487" name="initialize" parent="DownloadedMenu" startPc="268445899">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446672" name="groupedBooks" parent="DownloadedMenu" startPc="268446488">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446825" name="bookTitle" parent="DownloadedMenu" startPc="268446673">
+            <param id="refId"/>
+            <param id="info"/>
+            <documentation/>
+        </functionEntry>
+    </functions>
+</debugInfo>

--- a/debug-symbols/b25.debug.xml
+++ b/debug-symbols/b25.debug.xml
@@ -1,0 +1,1757 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<debugInfo>
+    <manifest filename="/Users/cbrooker/Code/ABS-Garmin/manifest.xml"/>
+    <pcToLineNum>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="1" lineNum="33" parent="globals/BrowseDelegate" pc="268435460" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="2" lineNum="18" parent="globals/SyncDelegate" pc="268435472" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/bin/gen/006-B4533-00/source/Rez.mcgen" id="3" lineNum="7" parent="globals/Rez" pc="268435484" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="4" lineNum="65" parent="globals/GroupDelegate" pc="268435504" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="5" lineNum="4" parent="globals/LibraryMenuDelegate" pc="268435516" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="6" lineNum="7" parent="globals/WatchShelfApp" pc="268435528" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="7" lineNum="7" parent="globals/ContentDelegate" pc="268435540" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="8" lineNum="13" parent="globals/ContentIterator" pc="268435552" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="9" lineNum="115" parent="globals/FieldDelegate" pc="268435564" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="10" lineNum="8" parent="globals/LibraryView" pc="268435576" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="11" lineNum="6" parent="globals/LibraryViewDelegate" pc="268435588" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="12" lineNum="10" parent="globals/BookMenuDelegate" pc="268435600" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="13" lineNum="27" parent="globals/LoginView" pc="268435612" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="14" lineNum="10" parent="globals/DownloadedMenuDelegate" pc="268435624" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="15" lineNum="8" parent="globals/ErrorViewDelegate" pc="268435636" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="16" lineNum="5" parent="globals/ErrorView" pc="268435648" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="17" lineNum="12" parent="globals/DownloadedMenu" pc="268435660" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="18" lineNum="45" parent="globals/BrowseDelegate" pc="268435672" symbol="onSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="18" lineNum="45" parent="globals/BrowseDelegate" pc="268435674" symbol="onSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="19" lineNum="62" parent="globals/BrowseDelegate" pc="268435698" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="19" lineNum="62" parent="globals/BrowseDelegate" pc="268435700" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="20" lineNum="44" parent="globals/BrowseDelegate" pc="268435716" symbol="onAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="20" lineNum="44" parent="globals/BrowseDelegate" pc="268435718" symbol="onAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="48" parent="globals/BrowseDelegate" pc="268435742" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="49" parent="globals/BrowseDelegate" pc="268435745" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="50" parent="globals/BrowseDelegate" pc="268435785" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="51" parent="globals/BrowseDelegate" pc="268435867" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="53" parent="globals/BrowseDelegate" pc="268435871" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="54" parent="globals/BrowseDelegate" pc="268435878" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="55" parent="globals/BrowseDelegate" pc="268435944" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="56" parent="globals/BrowseDelegate" pc="268435960" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="57" parent="globals/BrowseDelegate" pc="268435967" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="58" parent="globals/BrowseDelegate" pc="268436005" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="60" parent="globals/BrowseDelegate" pc="268436066" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="22" lineNum="43" parent="globals/BrowseDelegate" pc="268436109" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="22" lineNum="43" parent="globals/BrowseDelegate" pc="268436111" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="23" lineNum="46" parent="globals/BrowseDelegate" pc="268436129" symbol="onCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="23" lineNum="46" parent="globals/BrowseDelegate" pc="268436131" symbol="onCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="35" parent="globals/BrowseDelegate" pc="268436155" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="35" parent="globals/BrowseDelegate" pc="268436157" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="35" parent="globals/BrowseDelegate" pc="268436169" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="36" parent="globals/BrowseDelegate" pc="268436179" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="37" parent="globals/BrowseDelegate" pc="268436182" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="38" parent="globals/BrowseDelegate" pc="268436191" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="38" parent="globals/BrowseDelegate" pc="268436208" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="39" parent="globals/BrowseDelegate" pc="268436244" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="39" parent="globals/BrowseDelegate" pc="268436261" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="40" parent="globals/BrowseDelegate" pc="268436295" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="40" parent="globals/BrowseDelegate" pc="268436312" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="41" parent="globals/BrowseDelegate" pc="268436346" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="43" parent="globals/SyncDelegate" pc="268436378" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="44" parent="globals/SyncDelegate" pc="268436380" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="45" parent="globals/SyncDelegate" pc="268436410" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="46" parent="globals/SyncDelegate" pc="268436420" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="47" parent="globals/SyncDelegate" pc="268436434" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="49" parent="globals/SyncDelegate" pc="268436438" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="50" parent="globals/SyncDelegate" pc="268436445" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="26" lineNum="51" parent="globals/SyncDelegate" pc="268436463" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="77" parent="globals/SyncDelegate" pc="268436471" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="78" parent="globals/SyncDelegate" pc="268436474" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="79" parent="globals/SyncDelegate" pc="268436490" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="80" parent="globals/SyncDelegate" pc="268436510" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="81" parent="globals/SyncDelegate" pc="268436524" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="84" parent="globals/SyncDelegate" pc="268436528" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="85" parent="globals/SyncDelegate" pc="268436537" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="88" parent="globals/SyncDelegate" pc="268436547" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="90" parent="globals/SyncDelegate" pc="268436570" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="98" parent="globals/SyncDelegate" pc="268436615" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="99" parent="globals/SyncDelegate" pc="268436650" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="27" lineNum="101" parent="globals/SyncDelegate" pc="268436696" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="28" lineNum="137" parent="globals/SyncDelegate" pc="268436712" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="28" lineNum="138" parent="globals/SyncDelegate" pc="268436715" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="28" lineNum="139" parent="globals/SyncDelegate" pc="268436730" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="28" lineNum="140" parent="globals/SyncDelegate" pc="268436758" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="61" parent="globals/SyncDelegate" pc="268436774" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="62" parent="globals/SyncDelegate" pc="268436777" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="63" parent="globals/SyncDelegate" pc="268436796" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="63" parent="globals/SyncDelegate" pc="268436802" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="65" parent="globals/SyncDelegate" pc="268436809" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="66" parent="globals/SyncDelegate" pc="268436829" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="67" parent="globals/SyncDelegate" pc="268436839" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="68" parent="globals/SyncDelegate" pc="268436878" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="69" parent="globals/SyncDelegate" pc="268436890" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="71" parent="globals/SyncDelegate" pc="268436907" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="72" parent="globals/SyncDelegate" pc="268436927" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="73" parent="globals/SyncDelegate" pc="268436945" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="115" parent="globals/SyncDelegate" pc="268436955" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="116" parent="globals/SyncDelegate" pc="268436958" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="117" parent="globals/SyncDelegate" pc="268436967" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="119" parent="globals/SyncDelegate" pc="268436976" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="120" parent="globals/SyncDelegate" pc="268436995" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="120" parent="globals/SyncDelegate" pc="268437001" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="121" parent="globals/SyncDelegate" pc="268437008" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="122" parent="globals/SyncDelegate" pc="268437021" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="125" parent="globals/SyncDelegate" pc="268437041" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="126" parent="globals/SyncDelegate" pc="268437063" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="128" parent="globals/SyncDelegate" pc="268437086" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="130" parent="globals/SyncDelegate" pc="268437093" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="131" parent="globals/SyncDelegate" pc="268437126" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="133" parent="globals/SyncDelegate" pc="268437136" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="55" parent="globals/SyncDelegate" pc="268437164" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="56" parent="globals/SyncDelegate" pc="268437166" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="57" parent="globals/SyncDelegate" pc="268437177" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="105" parent="globals/SyncDelegate" pc="268437192" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="106" parent="globals/SyncDelegate" pc="268437194" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="106" parent="globals/SyncDelegate" pc="268437211" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="107" parent="globals/SyncDelegate" pc="268437217" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="107" parent="globals/SyncDelegate" pc="268437234" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="108" parent="globals/SyncDelegate" pc="268437240" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="108" parent="globals/SyncDelegate" pc="268437257" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="109" parent="globals/SyncDelegate" pc="268437263" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="109" parent="globals/SyncDelegate" pc="268437280" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="110" parent="globals/SyncDelegate" pc="268437286" symbol="typeToEncoding"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="26" parent="globals/SyncDelegate" pc="268437288" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="27" parent="globals/SyncDelegate" pc="268437290" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="29" parent="globals/SyncDelegate" pc="268437302" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="30" parent="globals/SyncDelegate" pc="268437326" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="30" parent="globals/SyncDelegate" pc="268437335" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="32" parent="globals/SyncDelegate" pc="268437347" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="33" parent="globals/SyncDelegate" pc="268437371" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="33" parent="globals/SyncDelegate" pc="268437380" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="35" parent="globals/SyncDelegate" pc="268437392" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="39" parent="globals/SyncDelegate" pc="268437401" symbol="isSyncNeeded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="40" parent="globals/SyncDelegate" pc="268437403" symbol="isSyncNeeded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="35" lineNum="18" parent="globals/LoginCreds" pc="268437436" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="35" lineNum="18" parent="globals/LoginCreds" pc="268437438" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="35" lineNum="18" parent="globals/LoginCreds" pc="268437450" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="35" lineNum="18" parent="globals/LoginCreds" pc="268437462" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="36" lineNum="71" parent="globals/GroupDelegate" pc="268437475" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="36" lineNum="71" parent="globals/GroupDelegate" pc="268437477" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="37" lineNum="70" parent="globals/GroupDelegate" pc="268437493" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="37" lineNum="70" parent="globals/GroupDelegate" pc="268437495" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="38" lineNum="68" parent="globals/GroupDelegate" pc="268437513" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="38" lineNum="68" parent="globals/GroupDelegate" pc="268437515" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="38" lineNum="68" parent="globals/GroupDelegate" pc="268437527" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="38" lineNum="68" parent="globals/GroupDelegate" pc="268437536" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="39" lineNum="69" parent="globals/GroupDelegate" pc="268437546" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="39" lineNum="69" parent="globals/GroupDelegate" pc="268437548" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="40" lineNum="168" parent="globals/AbsProgressListener" pc="268437592" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="40" lineNum="169" parent="globals/AbsProgressListener" pc="268437594" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="40" lineNum="170" parent="globals/AbsProgressListener" pc="268437603" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="42" lineNum="7" parent="globals/LibraryMenuDelegate" pc="268437628" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="42" lineNum="7" parent="globals/LibraryMenuDelegate" pc="268437630" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="43" lineNum="5" parent="globals/LibraryMenuDelegate" pc="268437646" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="43" lineNum="5" parent="globals/LibraryMenuDelegate" pc="268437648" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="44" lineNum="6" parent="globals/LibraryMenuDelegate" pc="268437661" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="44" lineNum="6" parent="globals/LibraryMenuDelegate" pc="268437663" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="45" lineNum="50" parent="globals/WatchShelfApp" pc="268437684" symbol="getProviderIconInfo"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="45" lineNum="51" parent="globals/WatchShelfApp" pc="268437686" symbol="getProviderIconInfo"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="46" lineNum="38" parent="globals/WatchShelfApp" pc="268437733" symbol="getPlaybackConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="46" lineNum="39" parent="globals/WatchShelfApp" pc="268437735" symbol="getPlaybackConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="47" lineNum="23" parent="globals/WatchShelfApp" pc="268437782" symbol="getContentDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="47" lineNum="24" parent="globals/WatchShelfApp" pc="268437784" symbol="getContentDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="48" lineNum="31" parent="globals/WatchShelfApp" pc="268437803" symbol="getSyncDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="48" lineNum="32" parent="globals/WatchShelfApp" pc="268437805" symbol="getSyncDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="9" parent="globals/WatchShelfApp" pc="268437824" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="11" parent="globals/WatchShelfApp" pc="268437827" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="12" parent="globals/WatchShelfApp" pc="268437846" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="13" parent="globals/WatchShelfApp" pc="268437853" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="14" parent="globals/WatchShelfApp" pc="268437864" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="15" parent="globals/WatchShelfApp" pc="268437875" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="49" lineNum="19" parent="globals/WatchShelfApp" pc="268437897" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="50" lineNum="45" parent="globals/WatchShelfApp" pc="268437910" symbol="getSyncConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="50" lineNum="46" parent="globals/WatchShelfApp" pc="268437912" symbol="getSyncConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="51" lineNum="56" parent="globals/ContentDelegate" pc="268437959" symbol="onShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="51" lineNum="57" parent="globals/ContentDelegate" pc="268437961" symbol="onShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="52" lineNum="16" parent="globals/ContentDelegate" pc="268437974" symbol="getContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="52" lineNum="17" parent="globals/ContentDelegate" pc="268437976" symbol="getContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="39" parent="globals/ContentDelegate" pc="268437982" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="40" parent="globals/ContentDelegate" pc="268437985" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="41" parent="globals/ContentDelegate" pc="268438004" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="41" parent="globals/ContentDelegate" pc="268438010" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="42" parent="globals/ContentDelegate" pc="268438014" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="43" parent="globals/ContentDelegate" pc="268438021" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="43" parent="globals/ContentDelegate" pc="268438027" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="45" parent="globals/ContentDelegate" pc="268438031" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="45" parent="globals/ContentDelegate" pc="268438045" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="47" parent="globals/ContentDelegate" pc="268438049" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="48" parent="globals/ContentDelegate" pc="268438059" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="48" parent="globals/ContentDelegate" pc="268438065" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="49" parent="globals/ContentDelegate" pc="268438071" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="53" lineNum="53" parent="globals/ContentDelegate" pc="268438078" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="54" lineNum="61" parent="globals/ContentDelegate" pc="268438103" symbol="onThumbsUp"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="55" lineNum="11" parent="globals/ContentDelegate" pc="268438106" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="55" lineNum="12" parent="globals/ContentDelegate" pc="268438108" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="55" lineNum="13" parent="globals/ContentDelegate" pc="268438120" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="56" lineNum="30" parent="globals/ContentDelegate" pc="268438128" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="56" lineNum="31" parent="globals/ContentDelegate" pc="268438130" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="56" lineNum="35" parent="globals/ContentDelegate" pc="268438162" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="58" lineNum="20" parent="globals/ContentDelegate" pc="268438179" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="58" lineNum="21" parent="globals/ContentDelegate" pc="268438181" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="58" lineNum="22" parent="globals/ContentDelegate" pc="268438206" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="59" lineNum="62" parent="globals/ContentDelegate" pc="268438212" symbol="onThumbsDown"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="60" lineNum="55" parent="globals/ContentIterator" pc="268438215" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="60" lineNum="56" parent="globals/ContentIterator" pc="268438217" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="60" lineNum="57" parent="globals/ContentIterator" pc="268438240" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="60" lineNum="58" parent="globals/ContentIterator" pc="268438255" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="60" lineNum="60" parent="globals/ContentIterator" pc="268438272" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="99" parent="globals/ContentIterator" pc="268438274" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="100" parent="globals/ContentIterator" pc="268438277" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="102" parent="globals/ContentIterator" pc="268438301" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="103" parent="globals/ContentIterator" pc="268438355" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="108" parent="globals/ContentIterator" pc="268438359" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="109" parent="globals/ContentIterator" pc="268438400" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="61" lineNum="112" parent="globals/ContentIterator" pc="268438421" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="62" lineNum="63" parent="globals/ContentIterator" pc="268438423" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="62" lineNum="64" parent="globals/ContentIterator" pc="268438425" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="62" lineNum="65" parent="globals/ContentIterator" pc="268438435" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="62" lineNum="66" parent="globals/ContentIterator" pc="268438450" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="62" lineNum="68" parent="globals/ContentIterator" pc="268438467" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="63" lineNum="161" parent="globals/ContentIterator" pc="268438469" symbol="before"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="63" lineNum="162" parent="globals/ContentIterator" pc="268438472" symbol="before"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="63" lineNum="163" parent="globals/ContentIterator" pc="268438486" symbol="before"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="63" lineNum="164" parent="globals/ContentIterator" pc="268438500" symbol="before"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="63" lineNum="165" parent="globals/ContentIterator" pc="268438515" symbol="before"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="63" lineNum="167" parent="globals/ContentIterator" pc="268438524" symbol="before"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="64" lineNum="75" parent="globals/ContentIterator" pc="268438550" symbol="peekPrevious"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="64" lineNum="76" parent="globals/ContentIterator" pc="268438552" symbol="peekPrevious"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="65" lineNum="79" parent="globals/ContentIterator" pc="268438569" symbol="canSkip"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="65" lineNum="80" parent="globals/ContentIterator" pc="268438571" symbol="canSkip"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="66" lineNum="87" parent="globals/ContentIterator" pc="268438573" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="66" lineNum="88" parent="globals/ContentIterator" pc="268438575" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="66" lineNum="89" parent="globals/ContentIterator" pc="268438583" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="66" lineNum="90" parent="globals/ContentIterator" pc="268438591" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="66" lineNum="92" parent="globals/ContentIterator" pc="268438601" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="66" lineNum="93" parent="globals/ContentIterator" pc="268438608" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="27" parent="globals/ContentIterator" pc="268438617" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="28" parent="globals/ContentIterator" pc="268438620" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="29" parent="globals/ContentIterator" pc="268438644" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="36" parent="globals/ContentIterator" pc="268438657" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="37" parent="globals/ContentIterator" pc="268438666" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="38" parent="globals/ContentIterator" pc="268438675" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="39" parent="globals/ContentIterator" pc="268438685" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="42" parent="globals/ContentIterator" pc="268438695" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="43" parent="globals/ContentIterator" pc="268438706" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="45" parent="globals/ContentIterator" pc="268438719" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="46" parent="globals/ContentIterator" pc="268438730" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="67" lineNum="48" parent="globals/ContentIterator" pc="268438743" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="68" lineNum="176" parent="globals/ContentIterator" pc="268438746" symbol="startOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="68" lineNum="177" parent="globals/ContentIterator" pc="268438749" symbol="startOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="68" lineNum="178" parent="globals/ContentIterator" pc="268438756" symbol="startOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="68" lineNum="178" parent="globals/ContentIterator" pc="268438774" symbol="startOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="68" lineNum="179" parent="globals/ContentIterator" pc="268438786" symbol="startOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="69" lineNum="71" parent="globals/ContentIterator" pc="268438788" symbol="peekNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="69" lineNum="72" parent="globals/ContentIterator" pc="268438790" symbol="peekNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="70" lineNum="51" parent="globals/ContentIterator" pc="268438807" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="70" lineNum="52" parent="globals/ContentIterator" pc="268438809" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="71" lineNum="83" parent="globals/ContentIterator" pc="268438823" symbol="shuffling"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="71" lineNum="84" parent="globals/ContentIterator" pc="268438825" symbol="shuffling"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="72" lineNum="19" parent="globals/ContentIterator" pc="268438831" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="72" lineNum="20" parent="globals/ContentIterator" pc="268438833" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="72" lineNum="21" parent="globals/ContentIterator" pc="268438845" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="72" lineNum="22" parent="globals/ContentIterator" pc="268438853" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="72" lineNum="23" parent="globals/ContentIterator" pc="268438861" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="182" parent="globals/ContentIterator" pc="268438869" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="183" parent="globals/ContentIterator" pc="268438872" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="184" parent="globals/ContentIterator" pc="268438895" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="185" parent="globals/ContentIterator" pc="268438913" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="186" parent="globals/ContentIterator" pc="268438923" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="187" parent="globals/ContentIterator" pc="268438939" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="73" lineNum="189" parent="globals/ContentIterator" pc="268438959" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="74" lineNum="170" parent="globals/ContentIterator" pc="268438968" symbol="bookTitleOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="74" lineNum="171" parent="globals/ContentIterator" pc="268438971" symbol="bookTitleOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="74" lineNum="172" parent="globals/ContentIterator" pc="268438978" symbol="bookTitleOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="74" lineNum="172" parent="globals/ContentIterator" pc="268438996" symbol="bookTitleOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="74" lineNum="173" parent="globals/ContentIterator" pc="268439008" symbol="bookTitleOf"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="126" parent="globals/ContentIterator" pc="268439014" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="127" parent="globals/ContentIterator" pc="268439017" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="128" parent="globals/ContentIterator" pc="268439026" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="129" parent="globals/ContentIterator" pc="268439045" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="129" parent="globals/ContentIterator" pc="268439051" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="131" parent="globals/ContentIterator" pc="268439058" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="132" parent="globals/ContentIterator" pc="268439062" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="133" parent="globals/ContentIterator" pc="268439089" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="134" parent="globals/ContentIterator" pc="268439095" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="135" parent="globals/ContentIterator" pc="268439105" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="136" parent="globals/ContentIterator" pc="268439111" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="137" parent="globals/ContentIterator" pc="268439129" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="141" parent="globals/ContentIterator" pc="268439145" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="142" parent="globals/ContentIterator" pc="268439161" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="144" parent="globals/ContentIterator" pc="268439168" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="145" parent="globals/ContentIterator" pc="268439181" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="146" parent="globals/ContentIterator" pc="268439201" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="146" parent="globals/ContentIterator" pc="268439224" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="146" parent="globals/ContentIterator" pc="268439228" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="150" parent="globals/ContentIterator" pc="268439244" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="151" parent="globals/ContentIterator" pc="268439261" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="151" parent="globals/ContentIterator" pc="268439272" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="152" parent="globals/ContentIterator" pc="268439295" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="153" parent="globals/ContentIterator" pc="268439302" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="153" parent="globals/ContentIterator" pc="268439323" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="154" parent="globals/ContentIterator" pc="268439349" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="156" parent="globals/ContentIterator" pc="268439368" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="76" lineNum="22" parent="globals/Login" pc="268439377" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="76" lineNum="23" parent="globals/Login" pc="268439387" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="77" lineNum="94" parent="globals/AbsApi" pc="268439447" symbol="isConfigured"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="77" lineNum="95" parent="globals/AbsApi" pc="268439457" symbol="isConfigured"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="78" lineNum="29" parent="globals/AbsApi" pc="268439478" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="78" lineNum="30" parent="globals/AbsApi" pc="268439489" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="78" lineNum="31" parent="globals/AbsApi" pc="268439508" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="78" lineNum="31" parent="globals/AbsApi" pc="268439514" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="78" lineNum="32" parent="globals/AbsApi" pc="268439532" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="79" lineNum="146" parent="globals/AbsApi" pc="268439535" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="79" lineNum="147" parent="globals/AbsApi" pc="268439545" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="79" lineNum="148" parent="globals/AbsApi" pc="268439573" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="80" lineNum="65" parent="globals/AbsApi" pc="268439594" symbol="getCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="80" lineNum="65" parent="globals/AbsApi" pc="268439604" symbol="getCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="81" lineNum="40" parent="globals/AbsApi" pc="268439623" symbol="sidecarBase"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="81" lineNum="40" parent="globals/AbsApi" pc="268439633" symbol="sidecarBase"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="82" lineNum="137" parent="globals/AbsApi" pc="268439640" symbol="login"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="82" lineNum="138" parent="globals/AbsApi" pc="268439650" symbol="login"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="83" lineNum="68" parent="globals/AbsApi" pc="268439734" symbol="getFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="83" lineNum="69" parent="globals/AbsApi" pc="268439744" symbol="getFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="84" lineNum="86" parent="globals/AbsApi" pc="268439817" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="84" lineNum="89" parent="globals/AbsApi" pc="268439828" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="84" lineNum="90" parent="globals/AbsApi" pc="268439844" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="84" lineNum="90" parent="globals/AbsApi" pc="268439878" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="84" lineNum="91" parent="globals/AbsApi" pc="268439883" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="85" lineNum="44" parent="globals/AbsApi" pc="268439886" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="85" lineNum="45" parent="globals/AbsApi" pc="268439897" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="85" lineNum="46" parent="globals/AbsApi" pc="268439924" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="85" lineNum="46" parent="globals/AbsApi" pc="268439936" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="85" lineNum="47" parent="globals/AbsApi" pc="268439946" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="86" lineNum="150" parent="globals/AbsApi" pc="268439996" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="86" lineNum="151" parent="globals/AbsApi" pc="268440006" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="86" lineNum="152" parent="globals/AbsApi" pc="268440024" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="87" lineNum="124" parent="globals/AbsApi" pc="268440043" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="87" lineNum="125" parent="globals/AbsApi" pc="268440054" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="87" lineNum="126" parent="globals/AbsApi" pc="268440077" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="87" lineNum="126" parent="globals/AbsApi" pc="268440083" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="87" lineNum="127" parent="globals/AbsApi" pc="268440096" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="88" lineNum="64" parent="globals/AbsApi" pc="268440197" symbol="getSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="88" lineNum="64" parent="globals/AbsApi" pc="268440207" symbol="getSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="89" lineNum="113" parent="globals/AbsApi" pc="268440226" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="89" lineNum="114" parent="globals/AbsApi" pc="268440237" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="89" lineNum="115" parent="globals/AbsApi" pc="268440247" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="89" lineNum="116" parent="globals/AbsApi" pc="268440265" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="89" lineNum="118" parent="globals/AbsApi" pc="268440277" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="90" lineNum="63" parent="globals/AbsApi" pc="268440279" symbol="getAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="90" lineNum="63" parent="globals/AbsApi" pc="268440289" symbol="getAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="91" lineNum="80" parent="globals/AbsApi" pc="268440308" symbol="sidecarChunkUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="91" lineNum="81" parent="globals/AbsApi" pc="268440318" symbol="sidecarChunkUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="92" lineNum="154" parent="globals/AbsApi" pc="268440384" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="92" lineNum="155" parent="globals/AbsApi" pc="268440394" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="92" lineNum="156" parent="globals/AbsApi" pc="268440458" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="92" lineNum="158" parent="globals/AbsApi" pc="268440484" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="19" parent="globals/AbsApi" pc="268440487" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="20" parent="globals/AbsApi" pc="268440498" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="21" parent="globals/AbsApi" pc="268440517" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="21" parent="globals/AbsApi" pc="268440523" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="22" parent="globals/AbsApi" pc="268440541" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="22" parent="globals/AbsApi" pc="268440547" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="23" parent="globals/AbsApi" pc="268440552" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="24" parent="globals/AbsApi" pc="268440606" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="26" parent="globals/AbsApi" pc="268440631" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="94" lineNum="101" parent="globals/AbsApi" pc="268440634" symbol="getLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="94" lineNum="102" parent="globals/AbsApi" pc="268440644" symbol="getLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="95" lineNum="55" parent="globals/AbsApi" pc="268440709" symbol="getGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="95" lineNum="56" parent="globals/AbsApi" pc="268440719" symbol="getGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="96" lineNum="125" parent="globals/FieldDelegate" pc="268440789" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="96" lineNum="126" parent="globals/FieldDelegate" pc="268440791" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="96" lineNum="127" parent="globals/FieldDelegate" pc="268440812" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="97" lineNum="129" parent="globals/FieldDelegate" pc="268440814" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="97" lineNum="130" parent="globals/FieldDelegate" pc="268440816" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="97" lineNum="131" parent="globals/FieldDelegate" pc="268440828" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="98" lineNum="118" parent="globals/FieldDelegate" pc="268440830" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="98" lineNum="119" parent="globals/FieldDelegate" pc="268440832" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="98" lineNum="120" parent="globals/FieldDelegate" pc="268440844" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="98" lineNum="121" parent="globals/FieldDelegate" pc="268440853" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="99" lineNum="14" parent="globals/RequestDelegate" pc="268440863" symbol="makeWebRequest"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="99" lineNum="15" parent="globals/RequestDelegate" pc="268440865" symbol="makeWebRequest"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="100" lineNum="9" parent="globals/RequestDelegate" pc="268440898" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="100" lineNum="10" parent="globals/RequestDelegate" pc="268440900" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="100" lineNum="11" parent="globals/RequestDelegate" pc="268440909" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="101" lineNum="18" parent="globals/RequestDelegate" pc="268440919" symbol="onWebResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="101" lineNum="19" parent="globals/RequestDelegate" pc="268440921" symbol="onWebResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="7" parent="globals/Browse" pc="268440945" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="8" parent="globals/Browse" pc="268440956" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="9" parent="globals/Browse" pc="268441022" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="10" parent="globals/Browse" pc="268441092" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="11" parent="globals/Browse" pc="268441162" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="12" parent="globals/Browse" pc="268441232" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="102" lineNum="13" parent="globals/Browse" pc="268441302" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="17" parent="globals/Browse" pc="268441344" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="18" parent="globals/Browse" pc="268441355" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="19" parent="globals/Browse" pc="268441401" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="21" parent="globals/Browse" pc="268441506" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="23" parent="globals/Browse" pc="268441510" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="24" parent="globals/Browse" pc="268441520" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="25" parent="globals/Browse" pc="268441586" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="26" parent="globals/Browse" pc="268441602" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="27" parent="globals/Browse" pc="268441609" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="103" lineNum="29" parent="globals/Browse" pc="268441676" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="43" parent="globals/LibraryView" pc="268441716" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="44" parent="globals/LibraryView" pc="268441719" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="45" parent="globals/LibraryView" pc="268441746" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="46" parent="globals/LibraryView" pc="268441756" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="47" parent="globals/LibraryView" pc="268441822" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="48" parent="globals/LibraryView" pc="268441838" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="50" parent="globals/LibraryView" pc="268441845" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="51" parent="globals/LibraryView" pc="268441881" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="54" parent="globals/LibraryView" pc="268441944" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="56" parent="globals/LibraryView" pc="268441982" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="104" lineNum="57" parent="globals/LibraryView" pc="268442035" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="19" parent="globals/LibraryView" pc="268442047" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="23" parent="globals/LibraryView" pc="268442049" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="23" parent="globals/LibraryView" pc="268442057" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="24" parent="globals/LibraryView" pc="268442061" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="26" parent="globals/LibraryView" pc="268442069" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="28" parent="globals/LibraryView" pc="268442083" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="29" parent="globals/LibraryView" pc="268442094" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="105" lineNum="31" parent="globals/LibraryView" pc="268442098" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="106" lineNum="13" parent="globals/LibraryView" pc="268442125" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="106" lineNum="14" parent="globals/LibraryView" pc="268442127" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="106" lineNum="15" parent="globals/LibraryView" pc="268442139" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="106" lineNum="16" parent="globals/LibraryView" pc="268442177" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="107" lineNum="34" parent="globals/LibraryView" pc="268442186" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="107" lineNum="35" parent="globals/LibraryView" pc="268442188" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="107" lineNum="36" parent="globals/LibraryView" pc="268442200" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="107" lineNum="37" parent="globals/LibraryView" pc="268442208" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="107" lineNum="38" parent="globals/LibraryView" pc="268442224" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="108" lineNum="13" parent="globals/LibraryViewDelegate" pc="268442264" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="108" lineNum="14" parent="globals/LibraryViewDelegate" pc="268442266" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="108" lineNum="15" parent="globals/LibraryViewDelegate" pc="268442281" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="109" lineNum="8" parent="globals/LibraryViewDelegate" pc="268442283" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="109" lineNum="9" parent="globals/LibraryViewDelegate" pc="268442285" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="110" lineNum="134" parent="globals/BookMenuDelegate" pc="268442298" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="110" lineNum="135" parent="globals/BookMenuDelegate" pc="268442300" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="120" parent="globals/BookMenuDelegate" pc="268442316" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="121" parent="globals/BookMenuDelegate" pc="268442319" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="122" parent="globals/BookMenuDelegate" pc="268442338" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="122" parent="globals/BookMenuDelegate" pc="268442344" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="123" parent="globals/BookMenuDelegate" pc="268442349" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="124" parent="globals/BookMenuDelegate" pc="268442352" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="125" parent="globals/BookMenuDelegate" pc="268442361" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="126" parent="globals/BookMenuDelegate" pc="268442377" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="127" parent="globals/BookMenuDelegate" pc="268442387" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="128" parent="globals/BookMenuDelegate" pc="268442429" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="111" lineNum="131" parent="globals/BookMenuDelegate" pc="268442449" symbol="alreadyDownloadedCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="112" lineNum="14" parent="globals/BookMenuDelegate" pc="268442452" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="112" lineNum="15" parent="globals/BookMenuDelegate" pc="268442454" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="112" lineNum="16" parent="globals/BookMenuDelegate" pc="268442466" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="24" parent="globals/BookMenuDelegate" pc="268442475" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="25" parent="globals/BookMenuDelegate" pc="268442478" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="26" parent="globals/BookMenuDelegate" pc="268442524" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="28" parent="globals/BookMenuDelegate" pc="268442621" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="39" parent="globals/BookMenuDelegate" pc="268442625" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="40" parent="globals/BookMenuDelegate" pc="268442630" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="41" parent="globals/BookMenuDelegate" pc="268442634" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="42" parent="globals/BookMenuDelegate" pc="268442644" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="43" parent="globals/BookMenuDelegate" pc="268442654" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="43" parent="globals/BookMenuDelegate" pc="268442660" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="48" parent="globals/BookMenuDelegate" pc="268442670" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="49" parent="globals/BookMenuDelegate" pc="268442686" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="50" parent="globals/BookMenuDelegate" pc="268442705" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="52" parent="globals/BookMenuDelegate" pc="268442787" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="55" parent="globals/BookMenuDelegate" pc="268442791" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="56" parent="globals/BookMenuDelegate" pc="268442810" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="56" parent="globals/BookMenuDelegate" pc="268442816" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="58" parent="globals/BookMenuDelegate" pc="268442823" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="59" parent="globals/BookMenuDelegate" pc="268442826" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="60" parent="globals/BookMenuDelegate" pc="268442829" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="61" parent="globals/BookMenuDelegate" pc="268442845" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="62" parent="globals/BookMenuDelegate" pc="268442858" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="63" parent="globals/BookMenuDelegate" pc="268442886" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="63" parent="globals/BookMenuDelegate" pc="268442893" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="64" parent="globals/BookMenuDelegate" pc="268442899" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="65" parent="globals/BookMenuDelegate" pc="268442902" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="66" parent="globals/BookMenuDelegate" pc="268442910" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="67" parent="globals/BookMenuDelegate" pc="268442926" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="68" parent="globals/BookMenuDelegate" pc="268442933" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="68" parent="globals/BookMenuDelegate" pc="268442941" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="69" parent="globals/BookMenuDelegate" pc="268442948" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="80" parent="globals/BookMenuDelegate" pc="268443046" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="81" parent="globals/BookMenuDelegate" pc="268443053" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="83" parent="globals/BookMenuDelegate" pc="268443060" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="86" parent="globals/BookMenuDelegate" pc="268443077" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="87" parent="globals/BookMenuDelegate" pc="268443084" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="88" parent="globals/BookMenuDelegate" pc="268443166" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="91" parent="globals/BookMenuDelegate" pc="268443170" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="92" parent="globals/BookMenuDelegate" pc="268443190" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="113" lineNum="93" parent="globals/BookMenuDelegate" pc="268443272" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="114" lineNum="96" parent="globals/BookMenuDelegate" pc="268443284" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="114" lineNum="97" parent="globals/BookMenuDelegate" pc="268443286" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="114" lineNum="97" parent="globals/BookMenuDelegate" pc="268443292" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="114" lineNum="98" parent="globals/BookMenuDelegate" pc="268443298" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="103" parent="globals/BookMenuDelegate" pc="268443301" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="104" parent="globals/BookMenuDelegate" pc="268443304" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="105" parent="globals/BookMenuDelegate" pc="268443307" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="106" parent="globals/BookMenuDelegate" pc="268443323" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="107" parent="globals/BookMenuDelegate" pc="268443351" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="107" parent="globals/BookMenuDelegate" pc="268443358" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="108" parent="globals/BookMenuDelegate" pc="268443364" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="109" parent="globals/BookMenuDelegate" pc="268443367" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="110" parent="globals/BookMenuDelegate" pc="268443375" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="111" parent="globals/BookMenuDelegate" pc="268443391" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="112" parent="globals/BookMenuDelegate" pc="268443398" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="112" parent="globals/BookMenuDelegate" pc="268443406" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="113" parent="globals/BookMenuDelegate" pc="268443413" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="114" parent="globals/BookMenuDelegate" pc="268443420" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="115" lineNum="117" parent="globals/BookMenuDelegate" pc="268443437" symbol="expectedChunkCount"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="116" lineNum="19" parent="globals/BookMenuDelegate" pc="268443440" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="116" lineNum="20" parent="globals/BookMenuDelegate" pc="268443442" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="116" lineNum="21" parent="globals/BookMenuDelegate" pc="268443456" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="103" parent="globals/LoginView" pc="268443488" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="104" parent="globals/LoginView" pc="268443490" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="105" parent="globals/LoginView" pc="268443535" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="106" parent="globals/LoginView" pc="268443572" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="108" parent="globals/LoginView" pc="268443626" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="109" parent="globals/LoginView" pc="268443635" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="117" lineNum="110" parent="globals/LoginView" pc="268443688" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="118" lineNum="63" parent="globals/LoginView" pc="268443700" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="118" lineNum="64" parent="globals/LoginView" pc="268443702" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="118" lineNum="64" parent="globals/LoginView" pc="268443709" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="118" lineNum="65" parent="globals/LoginView" pc="268443744" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="118" lineNum="65" parent="globals/LoginView" pc="268443752" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="118" lineNum="66" parent="globals/LoginView" pc="268443787" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="90" parent="globals/LoginView" pc="268443819" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="91" parent="globals/LoginView" pc="268443821" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="91" parent="globals/LoginView" pc="268443828" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="92" parent="globals/LoginView" pc="268443844" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="92" parent="globals/LoginView" pc="268443852" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="93" parent="globals/LoginView" pc="268443868" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="93" parent="globals/LoginView" pc="268443876" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="94" parent="globals/LoginView" pc="268443892" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="44" parent="globals/LoginView" pc="268443905" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="45" parent="globals/LoginView" pc="268443907" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="46" parent="globals/LoginView" pc="268443918" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="47" parent="globals/LoginView" pc="268443938" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="48" parent="globals/LoginView" pc="268443949" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="49" parent="globals/LoginView" pc="268443978" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="50" parent="globals/LoginView" pc="268444012" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="51" parent="globals/LoginView" pc="268444023" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="52" parent="globals/LoginView" pc="268444032" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="53" parent="globals/LoginView" pc="268444070" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="54" parent="globals/LoginView" pc="268444081" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="97" parent="globals/LoginView" pc="268444141" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="98" parent="globals/LoginView" pc="268444143" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="99" parent="globals/LoginView" pc="268444152" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="100" parent="globals/LoginView" pc="268444190" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="70" parent="globals/LoginView" pc="268444202" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="71" parent="globals/LoginView" pc="268444204" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="72" parent="globals/LoginView" pc="268444212" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="73" parent="globals/LoginView" pc="268444222" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="74" parent="globals/LoginView" pc="268444292" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="75" parent="globals/LoginView" pc="268444303" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="76" parent="globals/LoginView" pc="268444374" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="77" parent="globals/LoginView" pc="268444385" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="33" parent="globals/LoginView" pc="268444452" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="34" parent="globals/LoginView" pc="268444455" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="35" parent="globals/LoginView" pc="268444467" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="36" parent="globals/LoginView" pc="268444475" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="37" parent="globals/LoginView" pc="268444500" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="38" parent="globals/LoginView" pc="268444512" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="39" parent="globals/LoginView" pc="268444539" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="123" lineNum="40" parent="globals/LoginView" pc="268444551" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="124" lineNum="59" parent="globals/LoginView" pc="268444560" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="124" lineNum="60" parent="globals/LoginView" pc="268444562" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="124" lineNum="60" parent="globals/LoginView" pc="268444571" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="124" lineNum="60" parent="globals/LoginView" pc="268444583" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="125" lineNum="81" parent="globals/LoginView" pc="268444595" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="125" lineNum="82" parent="globals/LoginView" pc="268444597" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="125" lineNum="83" parent="globals/LoginView" pc="268444609" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="125" lineNum="84" parent="globals/LoginView" pc="268444617" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="125" lineNum="85" parent="globals/LoginView" pc="268444633" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="82" parent="globals/DownloadedMenuDelegate" pc="268444673" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="83" parent="globals/DownloadedMenuDelegate" pc="268444676" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="83" parent="globals/DownloadedMenuDelegate" pc="268444688" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="85" parent="globals/DownloadedMenuDelegate" pc="268444692" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="86" parent="globals/DownloadedMenuDelegate" pc="268444711" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="86" parent="globals/DownloadedMenuDelegate" pc="268444717" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="87" parent="globals/DownloadedMenuDelegate" pc="268444724" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="88" parent="globals/DownloadedMenuDelegate" pc="268444740" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="90" parent="globals/DownloadedMenuDelegate" pc="268444765" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="92" parent="globals/DownloadedMenuDelegate" pc="268444785" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="126" lineNum="93" parent="globals/DownloadedMenuDelegate" pc="268444796" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="127" lineNum="96" parent="globals/DownloadedMenuDelegate" pc="268444879" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="127" lineNum="97" parent="globals/DownloadedMenuDelegate" pc="268444881" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="128" lineNum="12" parent="globals/DownloadedMenuDelegate" pc="268444897" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="128" lineNum="13" parent="globals/DownloadedMenuDelegate" pc="268444899" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="16" parent="globals/DownloadedMenuDelegate" pc="268444912" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="17" parent="globals/DownloadedMenuDelegate" pc="268444915" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="21" parent="globals/DownloadedMenuDelegate" pc="268444924" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="22" parent="globals/DownloadedMenuDelegate" pc="268444957" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="23" parent="globals/DownloadedMenuDelegate" pc="268445008" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="31" parent="globals/DownloadedMenuDelegate" pc="268445012" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="32" parent="globals/DownloadedMenuDelegate" pc="268445045" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="33" parent="globals/DownloadedMenuDelegate" pc="268445059" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="39" parent="globals/DownloadedMenuDelegate" pc="268445063" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="40" parent="globals/DownloadedMenuDelegate" pc="268445096" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="41" parent="globals/DownloadedMenuDelegate" pc="268445107" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="42" parent="globals/DownloadedMenuDelegate" pc="268445158" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="48" parent="globals/DownloadedMenuDelegate" pc="268445162" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="49" parent="globals/DownloadedMenuDelegate" pc="268445195" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="50" parent="globals/DownloadedMenuDelegate" pc="268445215" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="51" parent="globals/DownloadedMenuDelegate" pc="268445235" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="52" parent="globals/DownloadedMenuDelegate" pc="268445317" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="56" parent="globals/DownloadedMenuDelegate" pc="268445321" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="57" parent="globals/DownloadedMenuDelegate" pc="268445354" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="58" parent="globals/DownloadedMenuDelegate" pc="268445373" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="58" parent="globals/DownloadedMenuDelegate" pc="268445379" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="59" parent="globals/DownloadedMenuDelegate" pc="268445386" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="60" parent="globals/DownloadedMenuDelegate" pc="268445402" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="67" parent="globals/DownloadedMenuDelegate" pc="268445406" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="68" parent="globals/DownloadedMenuDelegate" pc="268445425" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="68" parent="globals/DownloadedMenuDelegate" pc="268445431" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="69" parent="globals/DownloadedMenuDelegate" pc="268445438" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="70" parent="globals/DownloadedMenuDelegate" pc="268445447" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="71" parent="globals/DownloadedMenuDelegate" pc="268445451" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="72" parent="globals/DownloadedMenuDelegate" pc="268445467" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="73" parent="globals/DownloadedMenuDelegate" pc="268445477" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="74" parent="globals/DownloadedMenuDelegate" pc="268445516" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="129" lineNum="77" parent="globals/DownloadedMenuDelegate" pc="268445544" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="130" lineNum="14" parent="globals/ErrorViewDelegate" pc="268445556" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="130" lineNum="15" parent="globals/ErrorViewDelegate" pc="268445558" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="130" lineNum="16" parent="globals/ErrorViewDelegate" pc="268445573" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="131" lineNum="10" parent="globals/ErrorViewDelegate" pc="268445575" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="131" lineNum="11" parent="globals/ErrorViewDelegate" pc="268445577" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="132" lineNum="9" parent="globals/ErrorView" pc="268445590" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="132" lineNum="10" parent="globals/ErrorView" pc="268445592" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="132" lineNum="11" parent="globals/ErrorView" pc="268445604" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="133" lineNum="14" parent="globals/ErrorView" pc="268445614" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="133" lineNum="15" parent="globals/ErrorView" pc="268445616" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="133" lineNum="16" parent="globals/ErrorView" pc="268445628" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="133" lineNum="17" parent="globals/ErrorView" pc="268445636" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="133" lineNum="18" parent="globals/ErrorView" pc="268445652" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="108" parent="globals/DownloadedMenu" pc="268445692" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="109" parent="globals/DownloadedMenu" pc="268445695" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="110" parent="globals/DownloadedMenu" pc="268445707" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="111" parent="globals/DownloadedMenu" pc="268445710" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="111" parent="globals/DownloadedMenu" pc="268445727" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="112" parent="globals/DownloadedMenu" pc="268445739" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="134" lineNum="113" parent="globals/DownloadedMenu" pc="268445754" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="135" lineNum="62" parent="globals/DownloadedMenu" pc="268445813" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="135" lineNum="63" parent="globals/DownloadedMenu" pc="268445816" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="135" lineNum="64" parent="globals/DownloadedMenu" pc="268445835" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="135" lineNum="65" parent="globals/DownloadedMenu" pc="268445854" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="14" parent="globals/DownloadedMenu" pc="268445899" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="15" parent="globals/DownloadedMenu" pc="268445902" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="20" parent="globals/DownloadedMenu" pc="268445933" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="22" parent="globals/DownloadedMenu" pc="268446002" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="23" parent="globals/DownloadedMenu" pc="268446010" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="31" parent="globals/DownloadedMenu" pc="268446019" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="32" parent="globals/DownloadedMenu" pc="268446031" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="37" parent="globals/DownloadedMenu" pc="268446103" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="38" parent="globals/DownloadedMenu" pc="268446116" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="46" parent="globals/DownloadedMenu" pc="268446188" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="47" parent="globals/DownloadedMenu" pc="268446197" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="50" parent="globals/DownloadedMenu" pc="268446269" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="51" parent="globals/DownloadedMenu" pc="268446281" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="54" parent="globals/DownloadedMenu" pc="268446353" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="55" parent="globals/DownloadedMenu" pc="268446369" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="56" parent="globals/DownloadedMenu" pc="268446376" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="57" parent="globals/DownloadedMenu" pc="268446383" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="136" lineNum="58" parent="globals/DownloadedMenu" pc="268446433" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="71" parent="globals/DownloadedMenu" pc="268446488" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="72" parent="globals/DownloadedMenu" pc="268446491" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="73" parent="globals/DownloadedMenu" pc="268446510" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="73" parent="globals/DownloadedMenu" pc="268446516" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="75" parent="globals/DownloadedMenu" pc="268446523" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="76" parent="globals/DownloadedMenu" pc="268446527" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="77" parent="globals/DownloadedMenu" pc="268446536" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="78" parent="globals/DownloadedMenu" pc="268446552" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="79" parent="globals/DownloadedMenu" pc="268446562" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="80" parent="globals/DownloadedMenu" pc="268446572" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="80" parent="globals/DownloadedMenu" pc="268446578" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="82" parent="globals/DownloadedMenu" pc="268446588" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="83" parent="globals/DownloadedMenu" pc="268446595" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="84" parent="globals/DownloadedMenu" pc="268446601" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="85" parent="globals/DownloadedMenu" pc="268446631" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="87" parent="globals/DownloadedMenu" pc="268446641" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="137" lineNum="89" parent="globals/DownloadedMenu" pc="268446670" symbol="groupedBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="94" parent="globals/DownloadedMenu" pc="268446673" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="95" parent="globals/DownloadedMenu" pc="268446676" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="96" parent="globals/DownloadedMenu" pc="268446704" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="97" parent="globals/DownloadedMenu" pc="268446720" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="98" parent="globals/DownloadedMenu" pc="268446755" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="100" parent="globals/DownloadedMenu" pc="268446772" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="100" parent="globals/DownloadedMenu" pc="268446784" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="101" parent="globals/DownloadedMenu" pc="268446796" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="101" parent="globals/DownloadedMenu" pc="268446808" symbol="bookTitle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="138" lineNum="102" parent="globals/DownloadedMenu" pc="268446820" symbol="bookTitle"/>
+    </pcToLineNum>
+    <symbolTable>
+        <entry id="8388639" module="true" symbol="Graphics"/>
+        <entry id="8390434" method="true" symbol="getSyncConfigurationView"/>
+        <entry id="49" method="true" symbol="typeToEncoding"/>
+        <entry id="17" object="true" symbol="DownloadedMenu"/>
+        <entry field="true" id="54" symbol="&lt;globals/GroupDelegate/&lt;&gt;mType&gt;"/>
+        <entry id="8390557" method="true" symbol="resetContentIterator"/>
+        <entry id="76" method="true" symbol="isConfigured"/>
+        <entry id="112" method="true" symbol="titleWithSize"/>
+        <entry id="8390211" module="true" symbol="Media"/>
+        <entry id="96" method="true" symbol="numOr"/>
+        <entry field="true" id="127" symbol="errItems"/>
+        <entry id="39" method="true" symbol="pushGroups"/>
+        <entry id="13" object="true" symbol="AbsProgressListener"/>
+        <entry id="28" object="true" symbol="LoginView"/>
+        <entry id="8388632" method="true" symbol="&lt;init&gt;"/>
+        <entry id="8390379" method="true" symbol="onThumbsUp"/>
+        <entry id="8390380" method="true" symbol="onThumbsDown"/>
+        <entry id="59" method="true" symbol="buildPlaylist"/>
+        <entry field="true" id="119" symbol="byAuthor"/>
+        <entry id="81" method="true" symbol="saveLogin"/>
+        <entry field="true" id="128" symbol="errLibraries"/>
+        <entry id="58" method="true" symbol="bookTitleOf"/>
+        <entry id="47" method="true" symbol="onOpDone"/>
+        <entry id="8390335" object="true" symbol="ContentIterator"/>
+        <entry field="true" id="144" symbol="settingApiKey"/>
+        <entry id="8388826" method="true" symbol="next"/>
+        <entry field="true" id="141" symbol="playDownloaded"/>
+        <entry field="true" id="87" symbol="mCallback"/>
+        <entry id="23" object="true" symbol="LibraryMenuDelegate"/>
+        <entry field="true" id="53" symbol="&lt;globals/GroupDelegate/&lt;&gt;mLib&gt;"/>
+        <entry id="94" method="true" symbol="expectedChunkCount"/>
+        <entry field="true" id="132" symbol="fieldServer"/>
+        <entry id="14" object="true" symbol="BookMenuDelegate"/>
+        <entry id="37" method="true" symbol="onCollections"/>
+        <entry field="true" id="61" symbol="&lt;globals/ContentIterator/&lt;&gt;mPlaylist&gt;"/>
+        <entry field="true" id="116" symbol="allBooks"/>
+        <entry field="true" id="143" symbol="queued"/>
+        <entry id="8390336" object="true" symbol="ContentDelegate"/>
+        <entry id="12" module="true" symbol="AbsApi"/>
+        <entry field="true" id="142" symbol="queueCleared"/>
+        <entry id="32" module="true" symbol="Versions"/>
+        <entry field="true" id="8388611" module="true" symbol="Toybox"/>
+        <entry field="true" id="45" symbol="&lt;globals/SyncDelegate/&lt;&gt;mSyncList&gt;"/>
+        <entry id="107" method="true" symbol="queueDelete"/>
+        <entry id="8390377" method="true" symbol="getContentIterator"/>
+        <entry id="8389108" method="true" symbol="onResponse"/>
+        <entry id="80" method="true" symbol="progressSeconds"/>
+        <entry id="74" method="true" symbol="getLibraries"/>
+        <entry field="true" id="137" symbol="loggingIn"/>
+        <entry field="true" id="42" symbol="&lt;globals/SyncDelegate/&lt;&gt;mDeleteList&gt;"/>
+        <entry id="8390373" method="true" symbol="shuffling"/>
+        <entry id="66" method="true" symbol="_noSlash"/>
+        <entry id="33" object="true" symbol="WatchShelfApp"/>
+        <entry field="true" id="115" symbol="AppName"/>
+        <entry id="8390440" symbol="contentType"/>
+        <entry id="8390459" method="true" symbol="onStopSync"/>
+        <entry id="7" module="true" symbol="globals/Rez/Strings"/>
+        <entry id="15" module="true" symbol="Browse"/>
+        <entry id="8389594" symbol="headers"/>
+        <entry field="true" id="108" symbol="&lt;globals/ErrorView/&lt;&gt;mMessage&gt;"/>
+        <entry field="true" id="138" symbol="loginFailed"/>
+        <entry field="true" id="100" symbol="&lt;globals/LoginView/&lt;&gt;mCreds&gt;"/>
+        <entry id="8390430" method="true" symbol="getContentDelegate"/>
+        <entry field="true" id="43" symbol="&lt;globals/SyncDelegate/&lt;&gt;mDone&gt;"/>
+        <entry id="92" method="true" symbol="onLibraries"/>
+        <entry field="true" id="131" symbol="fieldPass"/>
+        <entry id="8388648" module="true" symbol="WatchUi"/>
+        <entry id="8389081" method="true" symbol="onBack"/>
+        <entry field="true" id="133" symbol="fieldUser"/>
+        <entry field="true" id="55" symbol="&lt;globals/ContentDelegate/&lt;&gt;mIterator&gt;"/>
+        <entry id="11" module="true" symbol="globals/Versions"/>
+        <entry id="73" method="true" symbol="getGroups"/>
+        <entry id="5" module="true" symbol="globals/Rez"/>
+        <entry id="35" method="true" symbol="onAuthors"/>
+        <entry id="68" method="true" symbol="authToken"/>
+        <entry id="8388789" method="true" symbol="get"/>
+        <entry id="8390342" method="true" symbol="isSyncNeeded"/>
+        <entry field="true" id="126" symbol="errDetail"/>
+        <entry id="57" method="true" symbol="before"/>
+        <entry field="true" id="118" symbol="browseLibrary"/>
+        <entry id="8389124" method="true" symbol="onUpdate"/>
+        <entry field="true" id="102" symbol="&lt;globals/LoginView/&lt;&gt;mState&gt;"/>
+        <entry id="8390431" method="true" symbol="getSyncDelegate"/>
+        <entry id="24" object="true" symbol="LibraryView"/>
+        <entry id="65" method="true" symbol="toggleShuffle"/>
+        <entry field="true" id="8390516" symbol="mContext"/>
+        <entry id="63" method="true" symbol="objAt"/>
+        <entry id="8388771" module="true" object="true" symbol="Drawables"/>
+        <entry field="true" id="147" symbol="settingServerUrlPrompt"/>
+        <entry id="67" method="true" symbol="_prop"/>
+        <entry id="26" module="true" symbol="Login"/>
+        <entry id="8390433" method="true" symbol="getProviderIconInfo"/>
+        <entry id="48" method="true" symbol="onTrackDownloaded"/>
+        <entry id="4" module="true" symbol="globals/Login"/>
+        <entry field="true" id="139" symbol="pickBook"/>
+        <entry field="true" id="117" symbol="alreadyDownloaded"/>
+        <entry field="true" id="52" symbol="username"/>
+        <entry field="true" id="145" symbol="settingApiKeyPrompt"/>
+        <entry field="true" id="51" symbol="server"/>
+        <entry id="8390442" method="true" symbol="shuffle"/>
+        <entry field="true" id="62" symbol="&lt;globals/ContentIterator/&lt;&gt;mShuffling&gt;"/>
+        <entry id="8390337" object="true" symbol="SyncDelegate"/>
+        <entry id="104" method="true" symbol="onLogin"/>
+        <entry field="true" id="125" symbol="downloaded"/>
+        <entry id="30" module="true" symbol="Store"/>
+        <entry id="93" method="true" symbol="alreadyDownloadedCount"/>
+        <entry id="9" module="true" symbol="globals/Store"/>
+        <entry id="8388637" module="true" symbol="Communications"/>
+        <entry id="82" method="true" symbol="serverUrl"/>
+        <entry id="19" object="true" symbol="ErrorView"/>
+        <entry id="27" object="true" symbol="LoginCreds"/>
+        <entry id="6" module="true" symbol="globals/Rez/Drawables"/>
+        <entry id="8390371" method="true" symbol="peekNext"/>
+        <entry id="10" module="true" symbol="globals/TrackInfo"/>
+        <entry field="true" id="130" symbol="errNone"/>
+        <entry field="true" id="120" symbol="byCollection"/>
+        <entry id="8390372" method="true" symbol="peekPrevious"/>
+        <entry id="8389844" symbol="responseType"/>
+        <entry field="true" id="90" symbol="&lt;globals/LibraryView/&lt;&gt;mMessage&gt;"/>
+        <entry field="true" id="8392276" symbol="skipForwardTimeDelta"/>
+        <entry id="8392335" module="true" object="true" symbol="Settings"/>
+        <entry field="true" id="140" symbol="pickLibrary"/>
+        <entry id="36" method="true" symbol="onBooks"/>
+        <entry id="78" method="true" symbol="logout"/>
+        <entry id="8388786" method="true" symbol="method"/>
+        <entry id="105" method="true" symbol="openField"/>
+        <entry field="true" id="136" symbol="logOut"/>
+        <entry id="31" module="true" symbol="TrackInfo"/>
+        <entry id="8388644" module="true" symbol="System"/>
+        <entry id="8390382" method="true" symbol="onSong"/>
+        <entry id="77" method="true" symbol="login"/>
+        <entry field="true" id="101" symbol="&lt;globals/LoginView/&lt;&gt;mMessage&gt;"/>
+        <entry id="8389619" method="true" symbol="onSelect"/>
+        <entry id="8388769" module="true" object="true" symbol="Rez"/>
+        <entry field="true" id="34" symbol="&lt;globals/BrowseDelegate/&lt;&gt;mLib&gt;"/>
+        <entry field="true" id="50" symbol="password"/>
+        <entry field="true" id="44" symbol="&lt;globals/SyncDelegate/&lt;&gt;mKeys&gt;"/>
+        <entry id="20" object="true" symbol="ErrorViewDelegate"/>
+        <entry id="79" method="true" symbol="patchProgress"/>
+        <entry id="8389540" method="true" symbol="onTextEntered"/>
+        <entry id="8390432" method="true" symbol="getPlaybackConfigurationView"/>
+        <entry id="75" method="true" symbol="getSeries"/>
+        <entry id="89" method="true" symbol="showBooks"/>
+        <entry field="true" id="8392277" symbol="skipBackwardTimeDelta"/>
+        <entry field="true" id="86" symbol="&lt;globals/FieldDelegate/&lt;&gt;mView&gt;"/>
+        <entry id="8388640" module="true" symbol="Lang"/>
+        <entry field="true" id="146" symbol="settingServerUrl"/>
+        <entry id="98" method="true" symbol="cancelFlow"/>
+        <entry field="true" id="134" symbol="loading"/>
+        <entry id="18" object="true" symbol="DownloadedMenuDelegate"/>
+        <entry id="8390784" method="true" symbol="onRepeat"/>
+        <entry id="8390374" method="true" symbol="canSkip"/>
+        <entry field="true" id="103" symbol="&lt;globals/LoginView/&lt;&gt;mTimer&gt;"/>
+        <entry id="106" method="true" symbol="setField"/>
+        <entry id="8388610" symbol="statics"/>
+        <entry id="70" method="true" symbol="getBookList"/>
+        <entry id="8389123" method="true" symbol="onShow"/>
+        <entry id="8" module="true" symbol="globals/Settings"/>
+        <entry id="25" object="true" symbol="LibraryViewDelegate"/>
+        <entry id="21" object="true" symbol="FieldDelegate"/>
+        <entry id="8390369" method="true" symbol="getPlaybackProfile"/>
+        <entry id="8389835" method="true" symbol="makeWebRequest"/>
+        <entry id="8390370" method="true" symbol="previous"/>
+        <entry field="true" id="113" symbol="launcher"/>
+        <entry field="true" id="91" symbol="&lt;globals/LibraryView/&lt;&gt;mStarted&gt;"/>
+        <entry id="8389350" module="true" symbol="globals"/>
+        <entry field="true" id="122" symbol="clearQueue"/>
+        <entry id="8388770" module="true" object="true" symbol="Strings"/>
+        <entry id="16" object="true" symbol="BrowseDelegate"/>
+        <entry id="8388702" method="true" symbol="initialize"/>
+        <entry field="true" id="95" symbol="&lt;globals/BookMenuDelegate/&lt;&gt;mItemId&gt;"/>
+        <entry id="40" method="true" symbol="deleteQueued"/>
+        <entry field="true" id="135" symbol="logIn"/>
+        <entry id="64" method="true" symbol="startOf"/>
+        <entry field="true" id="124" symbol="deleting"/>
+        <entry id="29" object="true" symbol="RequestDelegate"/>
+        <entry id="41" method="true" symbol="downloadNext"/>
+        <entry id="2" module="true" symbol="globals/AbsApi"/>
+        <entry id="8388641" module="true" symbol="Math"/>
+        <entry id="8389541" method="true" symbol="onCancel"/>
+        <entry id="56" method="true" symbol="syncProgress"/>
+        <entry id="8390341" method="true" symbol="onStartSync"/>
+        <entry id="88" method="true" symbol="onWebResponse"/>
+        <entry id="69" method="true" symbol="getAuthors"/>
+        <entry field="true" id="46" symbol="&lt;globals/SyncDelegate/&lt;&gt;mTotal&gt;"/>
+        <entry id="97" method="true" symbol="onFiles"/>
+        <entry id="72" method="true" symbol="getFiles"/>
+        <entry id="84" method="true" symbol="sidecarChunkUrl"/>
+        <entry id="8388646" module="true" object="true" symbol="Timer"/>
+        <entry id="3" module="true" symbol="globals/Browse"/>
+        <entry id="83" method="true" symbol="sidecarBase"/>
+        <entry id="38" method="true" symbol="onSeries"/>
+        <entry field="true" id="129" symbol="errNoAudio"/>
+        <entry id="8388698" method="true" symbol="start"/>
+        <entry id="8390381" method="true" symbol="onShuffle"/>
+        <entry id="109" method="true" symbol="bookTitle"/>
+        <entry id="22" object="true" symbol="GroupDelegate"/>
+        <entry field="true" id="60" symbol="&lt;globals/ContentIterator/&lt;&gt;mIndex&gt;"/>
+        <entry id="8390441" object="true" symbol="mediaEncoding"/>
+        <entry id="111" method="true" symbol="hasQueued"/>
+        <entry field="true" id="121" symbol="bySeries"/>
+        <entry field="true" id="123" symbol="deleteAllDownloads"/>
+        <entry id="8389125" method="true" symbol="onHide"/>
+        <entry field="true" id="114" symbol="providerIcon"/>
+        <entry id="99" method="true" symbol="labelFor"/>
+        <entry id="110" method="true" symbol="groupedBooks"/>
+        <entry id="8388635" module="true" symbol="Application"/>
+        <entry field="true" id="8389642" symbol="title"/>
+        <entry field="true" id="85" symbol="&lt;globals/FieldDelegate/&lt;&gt;mField&gt;"/>
+        <entry id="71" method="true" symbol="getCollections"/>
+    </symbolTable>
+    <localVars>
+        <entry arg="true" endPc="268435697" name="code" stackId="1" startPc="268435672"/>
+        <entry arg="true" endPc="268435697" name="data" stackId="2" startPc="268435672"/>
+        <entry arg="true" endPc="268435741" name="code" stackId="1" startPc="268435716"/>
+        <entry arg="true" endPc="268435741" name="data" stackId="2" startPc="268435716"/>
+        <entry arg="true" endPc="268436108" name="code" stackId="1" startPc="268435742"/>
+        <entry arg="true" endPc="268436108" name="data" stackId="2" startPc="268435742"/>
+        <entry arg="true" endPc="268436108" name="key" stackId="3" startPc="268435742"/>
+        <entry arg="true" endPc="268436108" name="filterType" stackId="4" startPc="268435742"/>
+        <entry endPc="268436107" name="groups" stackId="5" startPc="268435745"/>
+        <entry endPc="268436107" name="m" stackId="6" startPc="268435745"/>
+        <entry endPc="268436065" name="i" stackId="7" startPc="268435960"/>
+        <entry endPc="268436055" name="g" stackId="8" startPc="268435960"/>
+        <entry endPc="268436055" name="sub" stackId="9" startPc="268435960"/>
+        <entry arg="true" endPc="268436128" name="code" stackId="1" startPc="268436109"/>
+        <entry arg="true" endPc="268436128" name="data" stackId="2" startPc="268436109"/>
+        <entry arg="true" endPc="268436154" name="code" stackId="1" startPc="268436129"/>
+        <entry arg="true" endPc="268436154" name="data" stackId="2" startPc="268436129"/>
+        <entry arg="true" endPc="268436178" name="libId" stackId="1" startPc="268436155"/>
+        <entry arg="true" endPc="268436377" name="item" stackId="1" startPc="268436179"/>
+        <entry endPc="268436376" name="mode" stackId="2" startPc="268436182"/>
+        <entry endPc="268436710" name="key" stackId="1" startPc="268436474"/>
+        <entry endPc="268436710" name="info" stackId="2" startPc="268436474"/>
+        <entry endPc="268436710" name="context" stackId="3" startPc="268436474"/>
+        <entry endPc="268436710" name="options" stackId="4" startPc="268436474"/>
+        <entry endPc="268436710" name="delegate" stackId="5" startPc="268436474"/>
+        <entry endPc="268436710" name="url" stackId="6" startPc="268436474"/>
+        <entry endPc="268436772" name="pct" stackId="1" startPc="268436715"/>
+        <entry endPc="268436953" name="tracks" stackId="1" startPc="268436777"/>
+        <entry endPc="268436906" name="i" stackId="2" startPc="268436829"/>
+        <entry endPc="268436896" name="refId" stackId="3" startPc="268436829"/>
+        <entry arg="true" endPc="268437163" name="code" stackId="1" startPc="268436955"/>
+        <entry arg="true" endPc="268437163" name="data" stackId="2" startPc="268436955"/>
+        <entry arg="true" endPc="268437163" name="context" stackId="3" startPc="268436955"/>
+        <entry endPc="268437132" name="refId" stackId="4" startPc="268436967"/>
+        <entry endPc="268437132" name="tracks" stackId="5" startPc="268436967"/>
+        <entry arg="true" endPc="268437287" name="type" stackId="1" startPc="268437192"/>
+        <entry arg="true" endPc="268437512" name="code" stackId="1" startPc="268437493"/>
+        <entry arg="true" endPc="268437512" name="data" stackId="2" startPc="268437493"/>
+        <entry arg="true" endPc="268437545" name="libId" stackId="1" startPc="268437513"/>
+        <entry arg="true" endPc="268437545" name="filterType" stackId="2" startPc="268437513"/>
+        <entry arg="true" endPc="268437591" name="item" stackId="1" startPc="268437546"/>
+        <entry arg="true" endPc="268437627" name="code" stackId="1" startPc="268437592"/>
+        <entry arg="true" endPc="268437627" name="data" stackId="2" startPc="268437592"/>
+        <entry arg="true" endPc="268437683" name="item" stackId="1" startPc="268437661"/>
+        <entry arg="true" endPc="268437802" name="args" stackId="1" startPc="268437782"/>
+        <entry endPc="268437908" name="version" stackId="1" startPc="268437827"/>
+        <entry arg="true" endPc="268438102" name="refId" stackId="1" startPc="268437982"/>
+        <entry arg="true" endPc="268438102" name="positionInChapter" stackId="2" startPc="268437982"/>
+        <entry endPc="268438101" name="tracks" stackId="3" startPc="268437985"/>
+        <entry endPc="268438101" name="info" stackId="4" startPc="268437985"/>
+        <entry endPc="268438101" name="start" stackId="5" startPc="268437985"/>
+        <entry endPc="268438101" name="absolute" stackId="6" startPc="268437985"/>
+        <entry arg="true" endPc="268438178" name="refId" stackId="1" startPc="268438128"/>
+        <entry arg="true" endPc="268438178" name="songEvent" stackId="2" startPc="268438128"/>
+        <entry arg="true" endPc="268438178" name="playbackPosition" stackId="3" startPc="268438128"/>
+        <entry arg="true" endPc="268438422" name="idx" stackId="1" startPc="268438274"/>
+        <entry endPc="268438412" name="e" stackId="2" startPc="268438355"/>
+        <entry arg="true" endPc="268438549" name="tracks" stackId="1" startPc="268438469"/>
+        <entry arg="true" endPc="268438549" name="refIdA" stackId="2" startPc="268438469"/>
+        <entry arg="true" endPc="268438549" name="refIdB" stackId="3" startPc="268438469"/>
+        <entry endPc="268438549" name="titleA" stackId="4" startPc="268438472"/>
+        <entry endPc="268438549" name="titleB" stackId="5" startPc="268438472"/>
+        <entry endPc="268438745" name="profile" stackId="1" startPc="268438620"/>
+        <entry arg="true" endPc="268438787" name="tracks" stackId="1" startPc="268438746"/>
+        <entry arg="true" endPc="268438787" name="refId" stackId="2" startPc="268438746"/>
+        <entry endPc="268438787" name="info" stackId="3" startPc="268438749"/>
+        <entry endPc="268438958" name="i" stackId="1" startPc="268438895"/>
+        <entry endPc="268438948" name="j" stackId="2" startPc="268438895"/>
+        <entry endPc="268438948" name="tmp" stackId="3" startPc="268438895"/>
+        <entry arg="true" endPc="268439013" name="tracks" stackId="1" startPc="268438968"/>
+        <entry arg="true" endPc="268439013" name="refId" stackId="2" startPc="268438968"/>
+        <entry endPc="268439013" name="info" stackId="3" startPc="268438971"/>
+        <entry endPc="268439375" name="tracks" stackId="1" startPc="268439017"/>
+        <entry endPc="268439375" name="refIds" stackId="2" startPc="268439017"/>
+        <entry endPc="268439375" name="iter" stackId="3" startPc="268439017"/>
+        <entry endPc="268439141" name="ref" stackId="4" startPc="268439095"/>
+        <entry endPc="268439367" name="i" stackId="5" startPc="268439161"/>
+        <entry endPc="268439357" name="refId" stackId="6" startPc="268439161"/>
+        <entry endPc="268439357" name="pos" stackId="7" startPc="268439161"/>
+        <entry endPc="268439243" name="j" stackId="8" startPc="268439201"/>
+        <entry endPc="268439357" name="rebuilt" stackId="9" startPc="268439161"/>
+        <entry endPc="268439294" name="k" stackId="10" startPc="268439272"/>
+        <entry endPc="268439348" name="k" stackId="11" startPc="268439323"/>
+        <entry endPc="268439534" name="v" stackId="1" startPc="268439489"/>
+        <entry arg="true" endPc="268439593" name="server" stackId="1" startPc="268439535"/>
+        <entry arg="true" endPc="268439593" name="token" stackId="2" startPc="268439535"/>
+        <entry arg="true" endPc="268439622" name="libId" stackId="1" startPc="268439594"/>
+        <entry arg="true" endPc="268439622" name="cb" stackId="2" startPc="268439594"/>
+        <entry arg="true" endPc="268439733" name="server" stackId="1" startPc="268439640"/>
+        <entry arg="true" endPc="268439733" name="username" stackId="2" startPc="268439640"/>
+        <entry arg="true" endPc="268439733" name="password" stackId="3" startPc="268439640"/>
+        <entry arg="true" endPc="268439733" name="cb" stackId="4" startPc="268439640"/>
+        <entry arg="true" endPc="268439816" name="itemId" stackId="1" startPc="268439734"/>
+        <entry arg="true" endPc="268439816" name="cb" stackId="2" startPc="268439734"/>
+        <entry arg="true" endPc="268439885" name="key" stackId="1" startPc="268439817"/>
+        <entry endPc="268439885" name="v" stackId="2" startPc="268439828"/>
+        <entry arg="true" endPc="268439995" name="libId" stackId="1" startPc="268439886"/>
+        <entry arg="true" endPc="268439995" name="filterType" stackId="2" startPc="268439886"/>
+        <entry arg="true" endPc="268439995" name="filterId" stackId="3" startPc="268439886"/>
+        <entry arg="true" endPc="268439995" name="cb" stackId="4" startPc="268439886"/>
+        <entry endPc="268439994" name="params" stackId="5" startPc="268439897"/>
+        <entry arg="true" endPc="268440196" name="itemId" stackId="1" startPc="268440043"/>
+        <entry arg="true" endPc="268440196" name="currentTimeSec" stackId="2" startPc="268440043"/>
+        <entry arg="true" endPc="268440196" name="durationSec" stackId="3" startPc="268440043"/>
+        <entry endPc="268440195" name="params" stackId="4" startPc="268440054"/>
+        <entry arg="true" endPc="268440225" name="libId" stackId="1" startPc="268440197"/>
+        <entry arg="true" endPc="268440225" name="cb" stackId="2" startPc="268440197"/>
+        <entry arg="true" endPc="268440278" name="detail" stackId="1" startPc="268440226"/>
+        <entry endPc="268440278" name="p" stackId="2" startPc="268440237"/>
+        <entry arg="true" endPc="268440307" name="libId" stackId="1" startPc="268440279"/>
+        <entry arg="true" endPc="268440307" name="cb" stackId="2" startPc="268440279"/>
+        <entry arg="true" endPc="268440383" name="itemId" stackId="1" startPc="268440308"/>
+        <entry arg="true" endPc="268440383" name="ino" stackId="2" startPc="268440308"/>
+        <entry arg="true" endPc="268440383" name="startSec" stackId="3" startPc="268440308"/>
+        <entry arg="true" endPc="268440383" name="endSec" stackId="4" startPc="268440308"/>
+        <entry arg="true" endPc="268440486" name="url" stackId="1" startPc="268440384"/>
+        <entry endPc="268440633" name="v" stackId="1" startPc="268440498"/>
+        <entry arg="true" endPc="268440708" name="callback" stackId="1" startPc="268440634"/>
+        <entry arg="true" endPc="268440788" name="path" stackId="1" startPc="268440709"/>
+        <entry arg="true" endPc="268440788" name="libId" stackId="2" startPc="268440709"/>
+        <entry arg="true" endPc="268440788" name="cb" stackId="3" startPc="268440709"/>
+        <entry arg="true" endPc="268440813" name="text" stackId="1" startPc="268440789"/>
+        <entry arg="true" endPc="268440813" name="changed" stackId="2" startPc="268440789"/>
+        <entry arg="true" endPc="268440862" name="view" stackId="1" startPc="268440830"/>
+        <entry arg="true" endPc="268440862" name="field" stackId="2" startPc="268440830"/>
+        <entry arg="true" endPc="268440897" name="url" stackId="1" startPc="268440863"/>
+        <entry arg="true" endPc="268440897" name="params" stackId="2" startPc="268440863"/>
+        <entry arg="true" endPc="268440897" name="options" stackId="3" startPc="268440863"/>
+        <entry arg="true" endPc="268440918" name="callback" stackId="1" startPc="268440898"/>
+        <entry arg="true" endPc="268440918" name="context" stackId="2" startPc="268440898"/>
+        <entry arg="true" endPc="268440944" name="code" stackId="1" startPc="268440919"/>
+        <entry arg="true" endPc="268440944" name="data" stackId="2" startPc="268440919"/>
+        <entry arg="true" endPc="268441343" name="libId" stackId="1" startPc="268440945"/>
+        <entry endPc="268441342" name="m" stackId="2" startPc="268440956"/>
+        <entry arg="true" endPc="268441715" name="code" stackId="1" startPc="268441344"/>
+        <entry arg="true" endPc="268441715" name="data" stackId="2" startPc="268441344"/>
+        <entry endPc="268441714" name="books" stackId="3" startPc="268441355"/>
+        <entry endPc="268441714" name="m" stackId="4" startPc="268441355"/>
+        <entry endPc="268441675" name="i" stackId="5" startPc="268441602"/>
+        <entry endPc="268441665" name="b" stackId="6" startPc="268441602"/>
+        <entry arg="true" endPc="268442046" name="code" stackId="1" startPc="268441716"/>
+        <entry arg="true" endPc="268442046" name="data" stackId="2" startPc="268441716"/>
+        <entry endPc="268441978" name="libs" stackId="3" startPc="268441746"/>
+        <entry endPc="268441978" name="menu" stackId="4" startPc="268441746"/>
+        <entry endPc="268441943" name="i" stackId="5" startPc="268441838"/>
+        <entry endPc="268441933" name="lib" stackId="6" startPc="268441838"/>
+        <entry arg="true" endPc="268442263" name="dc" stackId="1" startPc="268442186"/>
+        <entry endPc="268442451" name="tracks" stackId="1" startPc="268442319"/>
+        <entry endPc="268442451" name="count" stackId="2" startPc="268442319"/>
+        <entry endPc="268442451" name="refIds" stackId="3" startPc="268442319"/>
+        <entry endPc="268442448" name="i" stackId="4" startPc="268442377"/>
+        <entry endPc="268442438" name="info" stackId="5" startPc="268442377"/>
+        <entry arg="true" endPc="268443283" name="code" stackId="1" startPc="268442475"/>
+        <entry arg="true" endPc="268443283" name="data" stackId="2" startPc="268442475"/>
+        <entry endPc="268443282" name="chunk" stackId="3" startPc="268442478"/>
+        <entry endPc="268443282" name="firstChunk" stackId="4" startPc="268442478"/>
+        <entry endPc="268443282" name="files" stackId="5" startPc="268442478"/>
+        <entry endPc="268443282" name="title" stackId="6" startPc="268442478"/>
+        <entry endPc="268443282" name="expected" stackId="7" startPc="268442478"/>
+        <entry endPc="268443282" name="syncList" stackId="8" startPc="268442478"/>
+        <entry endPc="268443282" name="bookOffset" stackId="9" startPc="268442478"/>
+        <entry endPc="268443282" name="idx" stackId="10" startPc="268442478"/>
+        <entry endPc="268443076" name="f" stackId="11" startPc="268442845"/>
+        <entry endPc="268443066" name="ino" stackId="12" startPc="268442845"/>
+        <entry endPc="268443066" name="dur" stackId="13" startPc="268442845"/>
+        <entry endPc="268443066" name="pos" stackId="14" startPc="268442845"/>
+        <entry endPc="268443056" name="size" stackId="15" startPc="268442910"/>
+        <entry endPc="268443056" name="end" stackId="16" startPc="268442910"/>
+        <entry arg="true" endPc="268443300" name="v" stackId="1" startPc="268443284"/>
+        <entry arg="true" endPc="268443300" name="dflt" stackId="2" startPc="268443284"/>
+        <entry arg="true" endPc="268443439" name="files" stackId="1" startPc="268443301"/>
+        <entry arg="true" endPc="268443439" name="chunk" stackId="2" startPc="268443301"/>
+        <entry arg="true" endPc="268443439" name="firstChunk" stackId="3" startPc="268443301"/>
+        <entry endPc="268443439" name="count" stackId="4" startPc="268443304"/>
+        <entry endPc="268443436" name="f" stackId="5" startPc="268443323"/>
+        <entry endPc="268443426" name="dur" stackId="6" startPc="268443323"/>
+        <entry endPc="268443426" name="pos" stackId="7" startPc="268443323"/>
+        <entry endPc="268443423" name="size" stackId="8" startPc="268443375"/>
+        <entry endPc="268443423" name="end" stackId="9" startPc="268443375"/>
+        <entry arg="true" endPc="268443487" name="item" stackId="1" startPc="268443440"/>
+        <entry arg="true" endPc="268443699" name="code" stackId="1" startPc="268443488"/>
+        <entry arg="true" endPc="268443699" name="data" stackId="2" startPc="268443488"/>
+        <entry arg="true" endPc="268443818" name="state" stackId="1" startPc="268443700"/>
+        <entry arg="true" endPc="268443904" name="field" stackId="1" startPc="268443819"/>
+        <entry arg="true" endPc="268443904" name="text" stackId="2" startPc="268443819"/>
+        <entry endPc="268444558" name="s" stackId="1" startPc="268444455"/>
+        <entry arg="true" endPc="268444672" name="dc" stackId="1" startPc="268444595"/>
+        <entry arg="true" endPc="268444878" name="refIds" stackId="1" startPc="268444673"/>
+        <entry endPc="268444877" name="deleteList" stackId="2" startPc="268444676"/>
+        <entry endPc="268444764" name="i" stackId="3" startPc="268444740"/>
+        <entry arg="true" endPc="268445555" name="item" stackId="1" startPc="268444912"/>
+        <entry endPc="268445554" name="id" stackId="2" startPc="268444915"/>
+        <entry endPc="268445402" name="tracks" stackId="3" startPc="268445354"/>
+        <entry endPc="268445554" name="tracks" stackId="4" startPc="268444915"/>
+        <entry endPc="268445554" name="refIds" stackId="5" startPc="268444915"/>
+        <entry endPc="268445554" name="toDelete" stackId="6" startPc="268444915"/>
+        <entry endPc="268445543" name="i" stackId="7" startPc="268445467"/>
+        <entry endPc="268445533" name="info" stackId="8" startPc="268445467"/>
+        <entry arg="true" endPc="268445613" name="message" stackId="1" startPc="268445590"/>
+        <entry arg="true" endPc="268445691" name="dc" stackId="1" startPc="268445614"/>
+        <entry endPc="268445812" name="stats" stackId="1" startPc="268445695"/>
+        <entry endPc="268445812" name="used" stackId="2" startPc="268445695"/>
+        <entry endPc="268445812" name="mb" stackId="3" startPc="268445695"/>
+        <entry endPc="268445898" name="syncList" stackId="1" startPc="268445816"/>
+        <entry endPc="268445898" name="deleteList" stackId="2" startPc="268445816"/>
+        <entry endPc="268446486" name="books" stackId="1" startPc="268445902"/>
+        <entry endPc="268446486" name="itemIds" stackId="2" startPc="268445902"/>
+        <entry endPc="268446486" name="i" stackId="3" startPc="268446369"/>
+        <entry endPc="268446476" name="itemId" stackId="4" startPc="268446369"/>
+        <entry endPc="268446476" name="book" stackId="5" startPc="268446369"/>
+        <entry endPc="268446476" name="sub" stackId="6" startPc="268446369"/>
+        <entry endPc="268446672" name="tracks" stackId="1" startPc="268446491"/>
+        <entry endPc="268446672" name="books" stackId="2" startPc="268446491"/>
+        <entry endPc="268446672" name="refIds" stackId="3" startPc="268446491"/>
+        <entry endPc="268446669" name="i" stackId="4" startPc="268446552"/>
+        <entry endPc="268446659" name="info" stackId="5" startPc="268446552"/>
+        <entry endPc="268446659" name="itemId" stackId="6" startPc="268446552"/>
+        <entry endPc="268446659" name="book" stackId="7" startPc="268446552"/>
+        <entry arg="true" endPc="268446825" name="refId" stackId="1" startPc="268446673"/>
+        <entry arg="true" endPc="268446825" name="info" stackId="2" startPc="268446673"/>
+        <entry endPc="268446825" name="ref" stackId="3" startPc="268446676"/>
+        <entry endPc="268446825" name="obj" stackId="4" startPc="268446676"/>
+    </localVars>
+    <deviceInfo deviceVersion="e6263c2a80ff43933f83afa71f1f6645dc2cb4a3" partNumber="006-B4533-00"/>
+    <annotations>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="queued"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldServer"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="byAuthor"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errNone"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="AppName"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errNoAudio"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="deleteAllDownloads"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingApiKeyPrompt"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldUser"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingServerUrlPrompt"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loggingIn"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingServerUrl"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="deleting"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errItems"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldPass"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingApiKey"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="clearQueue"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="logIn"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="browseLibrary"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="pickBook"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="alreadyDownloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="bySeries"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loginFailed"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="byCollection"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errLibraries"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="pickLibrary"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="playDownloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loading"/>
+        <annotationEntry annotation="initialized" class="Drawables" module="globals/Rez" symbol="providerIcon"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errDetail"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="allBooks"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="logOut"/>
+        <annotationEntry annotation="initialized" class="Drawables" module="globals/Rez" symbol="launcher"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="downloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="queueCleared"/>
+    </annotations>
+    <dataEntryOffsetMappings>
+        <dataEntry label="globals" offset="112" parentId="" symbolId="globals" type="module"/>
+        <dataEntry label="globals/BrowseDelegate" offset="386" parentId="globals" symbolId="BrowseDelegate" type="class"/>
+        <dataEntry label="globals/SyncDelegate" offset="502" parentId="globals" symbolId="SyncDelegate" type="class"/>
+        <dataEntry label="globals/Rez" offset="663" parentId="globals" symbolId="Rez" type="module"/>
+        <dataEntry label="globals/LoginCreds" offset="707" parentId="globals" symbolId="LoginCreds" type="class"/>
+        <dataEntry label="globals/GroupDelegate" offset="778" parentId="globals" symbolId="GroupDelegate" type="class"/>
+        <dataEntry label="globals/Store" offset="867" parentId="globals" symbolId="Store" type="module"/>
+        <dataEntry label="globals/AbsProgressListener" offset="893" parentId="globals" symbolId="AbsProgressListener" type="class"/>
+        <dataEntry label="globals/TrackInfo" offset="946" parentId="globals" symbolId="TrackInfo" type="module"/>
+        <dataEntry label="globals/LibraryMenuDelegate" offset="972" parentId="globals" symbolId="LibraryMenuDelegate" type="class"/>
+        <dataEntry label="globals/WatchShelfApp" offset="1034" parentId="globals" symbolId="WatchShelfApp" type="class"/>
+        <dataEntry label="globals/Settings" offset="1123" parentId="globals" symbolId="Settings" type="module"/>
+        <dataEntry label="globals/ContentDelegate" offset="1149" parentId="globals" symbolId="ContentDelegate" type="class"/>
+        <dataEntry label="globals/ContentIterator" offset="1274" parentId="globals" symbolId="ContentIterator" type="class"/>
+        <dataEntry label="globals/Login" offset="1480" parentId="globals" symbolId="Login" type="module"/>
+        <dataEntry label="globals/AbsApi" offset="1515" parentId="globals" symbolId="AbsApi" type="module"/>
+        <dataEntry label="globals/FieldDelegate" offset="1712" parentId="globals" symbolId="FieldDelegate" type="class"/>
+        <dataEntry label="globals/RequestDelegate" offset="1792" parentId="globals" symbolId="RequestDelegate" type="class"/>
+        <dataEntry label="globals/Browse" offset="1872" parentId="globals" symbolId="Browse" type="module"/>
+        <dataEntry label="globals/Versions" offset="1916" parentId="globals" symbolId="Versions" type="module"/>
+        <dataEntry label="globals/LibraryView" offset="1942" parentId="globals" symbolId="LibraryView" type="class"/>
+        <dataEntry label="globals/LibraryViewDelegate" offset="2031" parentId="globals" symbolId="LibraryViewDelegate" type="class"/>
+        <dataEntry label="globals/BookMenuDelegate" offset="2084" parentId="globals" symbolId="BookMenuDelegate" type="class"/>
+        <dataEntry label="globals/LoginView" offset="2191" parentId="globals" symbolId="LoginView" type="class"/>
+        <dataEntry label="globals/DownloadedMenuDelegate" offset="2343" parentId="globals" symbolId="DownloadedMenuDelegate" type="class"/>
+        <dataEntry label="globals/ErrorViewDelegate" offset="2414" parentId="globals" symbolId="ErrorViewDelegate" type="class"/>
+        <dataEntry label="globals/ErrorView" offset="2467" parentId="globals" symbolId="ErrorView" type="class"/>
+        <dataEntry label="globals/DownloadedMenu" offset="2529" parentId="globals" symbolId="DownloadedMenu" type="class"/>
+        <dataEntry label="globals/Rez/Drawables" offset="2609" parentId="Rez" symbolId="Drawables" type="module"/>
+        <dataEntry label="globals/Rez/Strings" offset="2653" parentId="Rez" symbolId="Strings" type="module"/>
+    </dataEntryOffsetMappings>
+    <functions>
+        <functionEntry accessMode="public" endPc="268435471" name="&lt;init&gt;" parent="BrowseDelegate" startPc="268435460">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435483" name="&lt;init&gt;" parent="SyncDelegate" startPc="268435472">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435503" name="&lt;init&gt;" parent="Rez" startPc="268435484">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="LoginCreds">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435515" name="&lt;init&gt;" parent="GroupDelegate" startPc="268435504">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Store">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="AbsProgressListener">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="TrackInfo">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435527" name="&lt;init&gt;" parent="LibraryMenuDelegate" startPc="268435516">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435539" name="&lt;init&gt;" parent="WatchShelfApp" startPc="268435528">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Settings">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435551" name="&lt;init&gt;" parent="ContentDelegate" startPc="268435540">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435563" name="&lt;init&gt;" parent="ContentIterator" startPc="268435552">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Login">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="AbsApi">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435575" name="&lt;init&gt;" parent="FieldDelegate" startPc="268435564">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="RequestDelegate">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Browse">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Versions">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435587" name="&lt;init&gt;" parent="LibraryView" startPc="268435576">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435599" name="&lt;init&gt;" parent="LibraryViewDelegate" startPc="268435588">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435611" name="&lt;init&gt;" parent="BookMenuDelegate" startPc="268435600">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435623" name="&lt;init&gt;" parent="LoginView" startPc="268435612">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435635" name="&lt;init&gt;" parent="DownloadedMenuDelegate" startPc="268435624">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435647" name="&lt;init&gt;" parent="ErrorViewDelegate" startPc="268435636">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435659" name="&lt;init&gt;" parent="ErrorView" startPc="268435648">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435671" name="&lt;init&gt;" parent="DownloadedMenu" startPc="268435660">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435697" name="onSeries" parent="BrowseDelegate" startPc="268435672">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435715" name="onBack" parent="BrowseDelegate" startPc="268435698">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435741" name="onAuthors" parent="BrowseDelegate" startPc="268435716">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436108" name="pushGroups" parent="BrowseDelegate" startPc="268435742">
+            <param id="code"/>
+            <param id="data"/>
+            <param id="key"/>
+            <param id="filterType"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436128" name="onBooks" parent="BrowseDelegate" startPc="268436109">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436154" name="onCollections" parent="BrowseDelegate" startPc="268436129">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436178" name="initialize" parent="BrowseDelegate" startPc="268436155">
+            <param id="libId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436377" name="onSelect" parent="BrowseDelegate" startPc="268436179">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436470" name="onStartSync" parent="SyncDelegate" startPc="268436378">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436711" name="downloadNext" parent="SyncDelegate" startPc="268436471">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436773" name="onOpDone" parent="SyncDelegate" startPc="268436712">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436954" name="deleteQueued" parent="SyncDelegate" startPc="268436774">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437163" name="onTrackDownloaded" parent="SyncDelegate" startPc="268436955">
+            <param id="code"/>
+            <param id="data"/>
+            <param id="context"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437191" name="onStopSync" parent="SyncDelegate" startPc="268437164">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437287" name="typeToEncoding" parent="SyncDelegate" startPc="268437192">
+            <param id="type"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437400" name="initialize" parent="SyncDelegate" startPc="268437288">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437435" name="isSyncNeeded" parent="SyncDelegate" startPc="268437401">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Drawables">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Strings">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437474" name="initialize" parent="LoginCreds" startPc="268437436">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437492" name="onBack" parent="GroupDelegate" startPc="268437475">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437512" name="onBooks" parent="GroupDelegate" startPc="268437493">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437545" name="initialize" parent="GroupDelegate" startPc="268437513">
+            <param id="libId"/>
+            <param id="filterType"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437591" name="onSelect" parent="GroupDelegate" startPc="268437546">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437627" name="onResponse" parent="AbsProgressListener" startPc="268437592">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="initialize" parent="AbsProgressListener">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437645" name="onBack" parent="LibraryMenuDelegate" startPc="268437628">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437660" name="initialize" parent="LibraryMenuDelegate" startPc="268437646">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437683" name="onSelect" parent="LibraryMenuDelegate" startPc="268437661">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437732" name="getProviderIconInfo" parent="WatchShelfApp" startPc="268437684">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437781" name="getPlaybackConfigurationView" parent="WatchShelfApp" startPc="268437733">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437802" name="getContentDelegate" parent="WatchShelfApp" startPc="268437782">
+            <param id="args"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437823" name="getSyncDelegate" parent="WatchShelfApp" startPc="268437803">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437909" name="initialize" parent="WatchShelfApp" startPc="268437824">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437958" name="getSyncConfigurationView" parent="WatchShelfApp" startPc="268437910">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437973" name="onShuffle" parent="ContentDelegate" startPc="268437959">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437981" name="getContentIterator" parent="ContentDelegate" startPc="268437974">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438102" name="syncProgress" parent="ContentDelegate" startPc="268437982">
+            <param id="refId"/>
+            <param id="positionInChapter"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438105" name="onThumbsUp" parent="ContentDelegate" startPc="268438103">
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438127" name="initialize" parent="ContentDelegate" startPc="268438106">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438178" name="onSong" parent="ContentDelegate" startPc="268438128">
+            <param id="refId"/>
+            <param id="songEvent"/>
+            <param id="playbackPosition"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="onRepeat" parent="ContentDelegate">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438211" name="resetContentIterator" parent="ContentDelegate" startPc="268438179">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438214" name="onThumbsDown" parent="ContentDelegate" startPc="268438212">
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438273" name="next" parent="ContentIterator" startPc="268438215">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438422" name="objAt" parent="ContentIterator" startPc="268438274">
+            <param id="idx"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438468" name="previous" parent="ContentIterator" startPc="268438423">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438549" name="before" parent="ContentIterator" startPc="268438469">
+            <param id="tracks"/>
+            <param id="refIdA"/>
+            <param id="refIdB"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438568" name="peekPrevious" parent="ContentIterator" startPc="268438550">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438572" name="canSkip" parent="ContentIterator" startPc="268438569">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438616" name="toggleShuffle" parent="ContentIterator" startPc="268438573">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438745" name="getPlaybackProfile" parent="ContentIterator" startPc="268438617">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438787" name="startOf" parent="ContentIterator" startPc="268438746">
+            <param id="tracks"/>
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438806" name="peekNext" parent="ContentIterator" startPc="268438788">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438822" name="get" parent="ContentIterator" startPc="268438807">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438830" name="shuffling" parent="ContentIterator" startPc="268438823">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438868" name="initialize" parent="ContentIterator" startPc="268438831">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438967" name="shuffle" parent="ContentIterator" startPc="268438869">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439013" name="bookTitleOf" parent="ContentIterator" startPc="268438968">
+            <param id="tracks"/>
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439376" name="buildPlaylist" parent="ContentIterator" startPc="268439014">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439446" name="start" parent="Login" startPc="268439377">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439477" name="isConfigured" parent="AbsApi" startPc="268439447">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439534" name="authToken" parent="AbsApi" startPc="268439478">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439593" name="saveLogin" parent="AbsApi" startPc="268439535">
+            <param id="server"/>
+            <param id="token"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439622" name="getCollections" parent="AbsApi" startPc="268439594">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439639" name="sidecarBase" parent="AbsApi" startPc="268439623">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439733" name="login" parent="AbsApi" startPc="268439640">
+            <param id="server"/>
+            <param id="username"/>
+            <param id="password"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439816" name="getFiles" parent="AbsApi" startPc="268439734">
+            <param id="itemId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439885" name="_prop" parent="AbsApi" startPc="268439817">
+            <param id="key"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439995" name="getBookList" parent="AbsApi" startPc="268439886">
+            <param id="libId"/>
+            <param id="filterType"/>
+            <param id="filterId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440042" name="logout" parent="AbsApi" startPc="268439996">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440196" name="patchProgress" parent="AbsApi" startPc="268440043">
+            <param id="itemId"/>
+            <param id="currentTimeSec"/>
+            <param id="durationSec"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440225" name="getSeries" parent="AbsApi" startPc="268440197">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440278" name="progressSeconds" parent="AbsApi" startPc="268440226">
+            <param id="detail"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440307" name="getAuthors" parent="AbsApi" startPc="268440279">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440383" name="sidecarChunkUrl" parent="AbsApi" startPc="268440308">
+            <param id="itemId"/>
+            <param id="ino"/>
+            <param id="startSec"/>
+            <param id="endSec"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440486" name="_noSlash" parent="AbsApi" startPc="268440384">
+            <param id="url"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440633" name="serverUrl" parent="AbsApi" startPc="268440487">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440708" name="getLibraries" parent="AbsApi" startPc="268440634">
+            <param id="callback"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440788" name="getGroups" parent="AbsApi" startPc="268440709">
+            <param id="path"/>
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440813" name="onTextEntered" parent="FieldDelegate" startPc="268440789">
+            <param id="text"/>
+            <param id="changed"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440829" name="onCancel" parent="FieldDelegate" startPc="268440814">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440862" name="initialize" parent="FieldDelegate" startPc="268440830">
+            <param id="view"/>
+            <param id="field"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440897" name="makeWebRequest" parent="RequestDelegate" startPc="268440863">
+            <param id="url"/>
+            <param id="params"/>
+            <param id="options"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440918" name="initialize" parent="RequestDelegate" startPc="268440898">
+            <param id="callback"/>
+            <param id="context"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440944" name="onWebResponse" parent="RequestDelegate" startPc="268440919">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441343" name="start" parent="Browse" startPc="268440945">
+            <param id="libId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441715" name="showBooks" parent="Browse" startPc="268441344">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442046" name="onLibraries" parent="LibraryView" startPc="268441716">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442124" name="onShow" parent="LibraryView" startPc="268442047">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442185" name="initialize" parent="LibraryView" startPc="268442125">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442263" name="onUpdate" parent="LibraryView" startPc="268442186">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442282" name="onBack" parent="LibraryViewDelegate" startPc="268442264">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442297" name="initialize" parent="LibraryViewDelegate" startPc="268442283">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442315" name="onBack" parent="BookMenuDelegate" startPc="268442298">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442451" name="alreadyDownloadedCount" parent="BookMenuDelegate" startPc="268442316">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442474" name="initialize" parent="BookMenuDelegate" startPc="268442452">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443283" name="onFiles" parent="BookMenuDelegate" startPc="268442475">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443300" name="numOr" parent="BookMenuDelegate" startPc="268443284">
+            <param id="v"/>
+            <param id="dflt"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443439" name="expectedChunkCount" parent="BookMenuDelegate" startPc="268443301">
+            <param id="files"/>
+            <param id="chunk"/>
+            <param id="firstChunk"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443487" name="onSelect" parent="BookMenuDelegate" startPc="268443440">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443699" name="onLogin" parent="LoginView" startPc="268443488">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443818" name="labelFor" parent="LoginView" startPc="268443700">
+            <param id="state"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443904" name="setField" parent="LoginView" startPc="268443819">
+            <param id="field"/>
+            <param id="text"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444140" name="onShow" parent="LoginView" startPc="268443905">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444201" name="cancelFlow" parent="LoginView" startPc="268444141">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444451" name="openField" parent="LoginView" startPc="268444202">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444559" name="initialize" parent="LoginView" startPc="268444452">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444594" name="onHide" parent="LoginView" startPc="268444560">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444672" name="onUpdate" parent="LoginView" startPc="268444595">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444878" name="queueDelete" parent="DownloadedMenuDelegate" startPc="268444673">
+            <param id="refIds"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444896" name="onBack" parent="DownloadedMenuDelegate" startPc="268444879">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444911" name="initialize" parent="DownloadedMenuDelegate" startPc="268444897">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445555" name="onSelect" parent="DownloadedMenuDelegate" startPc="268444912">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445574" name="onBack" parent="ErrorViewDelegate" startPc="268445556">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445589" name="initialize" parent="ErrorViewDelegate" startPc="268445575">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445613" name="initialize" parent="ErrorView" startPc="268445590">
+            <param id="message"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445691" name="onUpdate" parent="ErrorView" startPc="268445614">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445812" name="titleWithSize" parent="DownloadedMenu" startPc="268445692">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445898" name="hasQueued" parent="DownloadedMenu" startPc="268445813">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446487" name="initialize" parent="DownloadedMenu" startPc="268445899">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446672" name="groupedBooks" parent="DownloadedMenu" startPc="268446488">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446825" name="bookTitle" parent="DownloadedMenu" startPc="268446673">
+            <param id="refId"/>
+            <param id="info"/>
+            <documentation/>
+        </functionEntry>
+    </functions>
+</debugInfo>

--- a/debug-symbols/b26.debug.xml
+++ b/debug-symbols/b26.debug.xml
@@ -1,0 +1,1978 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<debugInfo>
+    <manifest filename="/Users/cbrooker/Code/ABS-Garmin/manifest.xml"/>
+    <pcToLineNum>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="1" lineNum="33" parent="globals/BrowseDelegate" pc="268435460" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="2" lineNum="29" parent="globals/SyncDelegate" pc="268435472" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/bin/gen/006-B4533-00/source/Rez.mcgen" id="3" lineNum="7" parent="globals/Rez" pc="268435484" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="4" lineNum="65" parent="globals/GroupDelegate" pc="268435504" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="5" lineNum="4" parent="globals/LibraryMenuDelegate" pc="268435516" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="6" lineNum="7" parent="globals/WatchShelfApp" pc="268435528" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="7" lineNum="7" parent="globals/ContentDelegate" pc="268435540" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="8" lineNum="18" parent="globals/ContentIterator" pc="268435552" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="9" lineNum="115" parent="globals/FieldDelegate" pc="268435564" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="10" lineNum="8" parent="globals/LibraryView" pc="268435576" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="11" lineNum="6" parent="globals/LibraryViewDelegate" pc="268435588" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="12" lineNum="11" parent="globals/BookMenuDelegate" pc="268435600" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="13" lineNum="27" parent="globals/LoginView" pc="268435612" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="14" lineNum="10" parent="globals/DownloadedMenuDelegate" pc="268435624" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="15" lineNum="8" parent="globals/ErrorViewDelegate" pc="268435636" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="16" lineNum="5" parent="globals/ErrorView" pc="268435648" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="17" lineNum="11" parent="globals/DownloadedMenu" pc="268435660" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="17" parent="globals/Chunks" pc="268435672" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="18" parent="globals/Chunks" pc="268435683" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="19" parent="globals/Chunks" pc="268435686" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="20" parent="globals/Chunks" pc="268435702" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="21" parent="globals/Chunks" pc="268435709" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="21" parent="globals/Chunks" pc="268435716" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="22" parent="globals/Chunks" pc="268435722" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="23" parent="globals/Chunks" pc="268435725" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="24" parent="globals/Chunks" pc="268435733" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="25" parent="globals/Chunks" pc="268435750" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="26" parent="globals/Chunks" pc="268435757" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="26" parent="globals/Chunks" pc="268435765" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="27" parent="globals/Chunks" pc="268435772" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="28" parent="globals/Chunks" pc="268435779" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="31" parent="globals/Chunks" pc="268435796" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="59" parent="globals/Chunks" pc="268435799" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="60" parent="globals/Chunks" pc="268435810" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="61" parent="globals/Chunks" pc="268435813" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="62" parent="globals/Chunks" pc="268435816" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="63" parent="globals/Chunks" pc="268435832" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="64" parent="globals/Chunks" pc="268435839" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="64" parent="globals/Chunks" pc="268435846" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="65" parent="globals/Chunks" pc="268435852" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="66" parent="globals/Chunks" pc="268435855" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="67" parent="globals/Chunks" pc="268435863" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="68" parent="globals/Chunks" pc="268435880" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="69" parent="globals/Chunks" pc="268435887" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="69" parent="globals/Chunks" pc="268435895" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="70" parent="globals/Chunks" pc="268435902" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="71" parent="globals/Chunks" pc="268435910" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="78" parent="globals/Chunks" pc="268435954" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="79" parent="globals/Chunks" pc="268435961" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="81" parent="globals/Chunks" pc="268435968" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="83" parent="globals/Chunks" pc="268435985" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="37" parent="globals/Chunks" pc="268435987" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="38" parent="globals/Chunks" pc="268435998" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="39" parent="globals/Chunks" pc="268436002" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="40" parent="globals/Chunks" pc="268436005" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="41" parent="globals/Chunks" pc="268436021" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="42" parent="globals/Chunks" pc="268436028" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="42" parent="globals/Chunks" pc="268436035" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="43" parent="globals/Chunks" pc="268436041" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="44" parent="globals/Chunks" pc="268436044" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="45" parent="globals/Chunks" pc="268436052" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="46" parent="globals/Chunks" pc="268436074" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="47" parent="globals/Chunks" pc="268436081" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="47" parent="globals/Chunks" pc="268436089" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="48" parent="globals/Chunks" pc="268436096" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="49" parent="globals/Chunks" pc="268436111" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="51" parent="globals/Chunks" pc="268436118" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="53" parent="globals/Chunks" pc="268436135" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="45" parent="globals/BrowseDelegate" pc="268436138" symbol="onSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="21" lineNum="45" parent="globals/BrowseDelegate" pc="268436140" symbol="onSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="22" lineNum="62" parent="globals/BrowseDelegate" pc="268436164" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="22" lineNum="62" parent="globals/BrowseDelegate" pc="268436166" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="23" lineNum="44" parent="globals/BrowseDelegate" pc="268436182" symbol="onAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="23" lineNum="44" parent="globals/BrowseDelegate" pc="268436184" symbol="onAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="48" parent="globals/BrowseDelegate" pc="268436208" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="49" parent="globals/BrowseDelegate" pc="268436211" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="50" parent="globals/BrowseDelegate" pc="268436251" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="51" parent="globals/BrowseDelegate" pc="268436333" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="53" parent="globals/BrowseDelegate" pc="268436337" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="54" parent="globals/BrowseDelegate" pc="268436344" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="55" parent="globals/BrowseDelegate" pc="268436410" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="56" parent="globals/BrowseDelegate" pc="268436426" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="57" parent="globals/BrowseDelegate" pc="268436433" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="58" parent="globals/BrowseDelegate" pc="268436471" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="60" parent="globals/BrowseDelegate" pc="268436532" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="43" parent="globals/BrowseDelegate" pc="268436575" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="43" parent="globals/BrowseDelegate" pc="268436577" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="26" lineNum="46" parent="globals/BrowseDelegate" pc="268436595" symbol="onCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="26" lineNum="46" parent="globals/BrowseDelegate" pc="268436597" symbol="onCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="27" lineNum="35" parent="globals/BrowseDelegate" pc="268436621" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="27" lineNum="35" parent="globals/BrowseDelegate" pc="268436623" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="27" lineNum="35" parent="globals/BrowseDelegate" pc="268436635" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="36" parent="globals/BrowseDelegate" pc="268436645" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="37" parent="globals/BrowseDelegate" pc="268436648" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="38" parent="globals/BrowseDelegate" pc="268436657" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="38" parent="globals/BrowseDelegate" pc="268436674" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="39" parent="globals/BrowseDelegate" pc="268436710" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="39" parent="globals/BrowseDelegate" pc="268436727" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="40" parent="globals/BrowseDelegate" pc="268436761" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="40" parent="globals/BrowseDelegate" pc="268436778" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="41" parent="globals/BrowseDelegate" pc="268436812" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="55" parent="globals/SyncDelegate" pc="268436844" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="56" parent="globals/SyncDelegate" pc="268436847" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="61" parent="globals/SyncDelegate" pc="268436855" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="62" parent="globals/SyncDelegate" pc="268436867" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="63" parent="globals/SyncDelegate" pc="268436875" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="64" parent="globals/SyncDelegate" pc="268436878" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="65" parent="globals/SyncDelegate" pc="268436894" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="66" parent="globals/SyncDelegate" pc="268436906" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="67" parent="globals/SyncDelegate" pc="268436921" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="70" parent="globals/SyncDelegate" pc="268436937" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="71" parent="globals/SyncDelegate" pc="268436942" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="75" parent="globals/SyncDelegate" pc="268436968" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="76" parent="globals/SyncDelegate" pc="268436976" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="77" parent="globals/SyncDelegate" pc="268436990" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="78" parent="globals/SyncDelegate" pc="268436999" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="79" parent="globals/SyncDelegate" pc="268437015" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="80" parent="globals/SyncDelegate" pc="268437025" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="81" parent="globals/SyncDelegate" pc="268437056" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="81" parent="globals/SyncDelegate" pc="268437063" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="83" parent="globals/SyncDelegate" pc="268437091" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="84" parent="globals/SyncDelegate" pc="268437101" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="85" parent="globals/SyncDelegate" pc="268437115" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="88" parent="globals/SyncDelegate" pc="268437119" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="29" lineNum="89" parent="globals/SyncDelegate" pc="268437130" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="45" parent="globals/SyncDelegate" pc="268437138" symbol="deletes"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="46" parent="globals/SyncDelegate" pc="268437141" symbol="deletes"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="30" lineNum="47" parent="globals/SyncDelegate" pc="268437160" symbol="deletes"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="141" parent="globals/SyncDelegate" pc="268437174" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="142" parent="globals/SyncDelegate" pc="268437177" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="143" parent="globals/SyncDelegate" pc="268437185" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="144" parent="globals/SyncDelegate" pc="268437194" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="145" parent="globals/SyncDelegate" pc="268437206" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="146" parent="globals/SyncDelegate" pc="268437220" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="149" parent="globals/SyncDelegate" pc="268437224" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="154" parent="globals/SyncDelegate" pc="268437230" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="155" parent="globals/SyncDelegate" pc="268437249" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="156" parent="globals/SyncDelegate" pc="268437261" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="157" parent="globals/SyncDelegate" pc="268437281" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="158" parent="globals/SyncDelegate" pc="268437288" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="161" parent="globals/SyncDelegate" pc="268437292" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="162" parent="globals/SyncDelegate" pc="268437299" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="163" parent="globals/SyncDelegate" pc="268437329" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="165" parent="globals/SyncDelegate" pc="268437335" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="166" parent="globals/SyncDelegate" pc="268437347" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="167" parent="globals/SyncDelegate" pc="268437367" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="168" parent="globals/SyncDelegate" pc="268437374" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="171" parent="globals/SyncDelegate" pc="268437378" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="179" parent="globals/SyncDelegate" pc="268437409" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="180" parent="globals/SyncDelegate" pc="268437424" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="181" parent="globals/SyncDelegate" pc="268437459" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="183" parent="globals/SyncDelegate" pc="268437508" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="227" parent="globals/SyncDelegate" pc="268437524" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="228" parent="globals/SyncDelegate" pc="268437527" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="229" parent="globals/SyncDelegate" pc="268437546" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="229" parent="globals/SyncDelegate" pc="268437552" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="230" parent="globals/SyncDelegate" pc="268437559" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="231" parent="globals/SyncDelegate" pc="268437575" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="231" parent="globals/SyncDelegate" pc="268437593" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="233" parent="globals/SyncDelegate" pc="268437607" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="234" parent="globals/SyncDelegate" pc="268437619" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="40" parent="globals/SyncDelegate" pc="268437640" symbol="jobs"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="41" parent="globals/SyncDelegate" pc="268437643" symbol="jobs"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="42" parent="globals/SyncDelegate" pc="268437662" symbol="jobs"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="247" parent="globals/SyncDelegate" pc="268437676" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="248" parent="globals/SyncDelegate" pc="268437679" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="251" parent="globals/SyncDelegate" pc="268437694" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="252" parent="globals/SyncDelegate" pc="268437722" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="252" parent="globals/SyncDelegate" pc="268437730" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="253" parent="globals/SyncDelegate" pc="268437737" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="104" parent="globals/SyncDelegate" pc="268437753" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="105" parent="globals/SyncDelegate" pc="268437756" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="105" parent="globals/SyncDelegate" pc="268437768" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="106" parent="globals/SyncDelegate" pc="268437772" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="107" parent="globals/SyncDelegate" pc="268437788" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="108" parent="globals/SyncDelegate" pc="268437806" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="109" parent="globals/SyncDelegate" pc="268437820" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="115" parent="globals/SyncDelegate" pc="268437837" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="116" parent="globals/SyncDelegate" pc="268437845" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="117" parent="globals/SyncDelegate" pc="268437849" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="118" parent="globals/SyncDelegate" pc="268437865" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="118" parent="globals/SyncDelegate" pc="268437884" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="120" parent="globals/SyncDelegate" pc="268437912" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="121" parent="globals/SyncDelegate" pc="268437924" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="123" parent="globals/SyncDelegate" pc="268437947" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="126" parent="globals/SyncDelegate" pc="268437965" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="127" parent="globals/SyncDelegate" pc="268437984" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="128" parent="globals/SyncDelegate" pc="268438020" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="189" parent="globals/SyncDelegate" pc="268438035" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="190" parent="globals/SyncDelegate" pc="268438038" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="191" parent="globals/SyncDelegate" pc="268438053" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="192" parent="globals/SyncDelegate" pc="268438080" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="195" parent="globals/SyncDelegate" pc="268438084" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="196" parent="globals/SyncDelegate" pc="268438094" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="198" parent="globals/SyncDelegate" pc="268438103" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="199" parent="globals/SyncDelegate" pc="268438111" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="200" parent="globals/SyncDelegate" pc="268438118" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="204" parent="globals/SyncDelegate" pc="268438124" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="205" parent="globals/SyncDelegate" pc="268438163" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="206" parent="globals/SyncDelegate" pc="268438170" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="209" parent="globals/SyncDelegate" pc="268438174" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="210" parent="globals/SyncDelegate" pc="268438184" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="211" parent="globals/SyncDelegate" pc="268438215" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="212" parent="globals/SyncDelegate" pc="268438234" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="217" parent="globals/SyncDelegate" pc="268438245" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="218" parent="globals/SyncDelegate" pc="268438258" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="219" parent="globals/SyncDelegate" pc="268438290" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="221" parent="globals/SyncDelegate" pc="268438305" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="223" parent="globals/SyncDelegate" pc="268438325" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="224" parent="globals/SyncDelegate" pc="268438332" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="132" parent="globals/SyncDelegate" pc="268438340" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="133" parent="globals/SyncDelegate" pc="268438343" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="134" parent="globals/SyncDelegate" pc="268438359" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="134" parent="globals/SyncDelegate" pc="268438377" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="136" parent="globals/SyncDelegate" pc="268438392" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="38" lineNum="94" parent="globals/SyncDelegate" pc="268438394" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="38" lineNum="95" parent="globals/SyncDelegate" pc="268438396" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="38" lineNum="96" parent="globals/SyncDelegate" pc="268438407" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="237" parent="globals/SyncDelegate" pc="268438422" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="238" parent="globals/SyncDelegate" pc="268438425" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="239" parent="globals/SyncDelegate" pc="268438444" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="239" parent="globals/SyncDelegate" pc="268438450" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="240" parent="globals/SyncDelegate" pc="268438454" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="241" parent="globals/SyncDelegate" pc="268438458" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="242" parent="globals/SyncDelegate" pc="268438474" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="242" parent="globals/SyncDelegate" pc="268438493" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="244" parent="globals/SyncDelegate" pc="268438521" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="40" lineNum="34" parent="globals/SyncDelegate" pc="268438542" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="40" lineNum="35" parent="globals/SyncDelegate" pc="268438544" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="40" lineNum="36" parent="globals/SyncDelegate" pc="268438556" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="40" lineNum="37" parent="globals/SyncDelegate" pc="268438564" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="41" lineNum="51" parent="globals/SyncDelegate" pc="268438573" symbol="isSyncNeeded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="41" lineNum="52" parent="globals/SyncDelegate" pc="268438575" symbol="isSyncNeeded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="42" lineNum="18" parent="globals/LoginCreds" pc="268438610" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="42" lineNum="18" parent="globals/LoginCreds" pc="268438612" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="42" lineNum="18" parent="globals/LoginCreds" pc="268438624" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="42" lineNum="18" parent="globals/LoginCreds" pc="268438636" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="43" lineNum="71" parent="globals/GroupDelegate" pc="268438649" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="43" lineNum="71" parent="globals/GroupDelegate" pc="268438651" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="44" lineNum="70" parent="globals/GroupDelegate" pc="268438667" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="44" lineNum="70" parent="globals/GroupDelegate" pc="268438669" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="45" lineNum="68" parent="globals/GroupDelegate" pc="268438687" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="45" lineNum="68" parent="globals/GroupDelegate" pc="268438689" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="45" lineNum="68" parent="globals/GroupDelegate" pc="268438701" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="45" lineNum="68" parent="globals/GroupDelegate" pc="268438710" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="46" lineNum="69" parent="globals/GroupDelegate" pc="268438720" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="46" lineNum="69" parent="globals/GroupDelegate" pc="268438722" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="47" lineNum="168" parent="globals/AbsProgressListener" pc="268438766" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="47" lineNum="169" parent="globals/AbsProgressListener" pc="268438768" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="47" lineNum="170" parent="globals/AbsProgressListener" pc="268438777" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="49" lineNum="7" parent="globals/LibraryMenuDelegate" pc="268438802" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="49" lineNum="7" parent="globals/LibraryMenuDelegate" pc="268438804" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="50" lineNum="5" parent="globals/LibraryMenuDelegate" pc="268438820" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="50" lineNum="5" parent="globals/LibraryMenuDelegate" pc="268438822" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="51" lineNum="6" parent="globals/LibraryMenuDelegate" pc="268438835" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="51" lineNum="6" parent="globals/LibraryMenuDelegate" pc="268438837" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="52" lineNum="57" parent="globals/WatchShelfApp" pc="268438858" symbol="getProviderIconInfo"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="52" lineNum="58" parent="globals/WatchShelfApp" pc="268438860" symbol="getProviderIconInfo"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="53" lineNum="45" parent="globals/WatchShelfApp" pc="268438907" symbol="getPlaybackConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="53" lineNum="46" parent="globals/WatchShelfApp" pc="268438909" symbol="getPlaybackConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="54" lineNum="30" parent="globals/WatchShelfApp" pc="268438956" symbol="getContentDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="54" lineNum="31" parent="globals/WatchShelfApp" pc="268438958" symbol="getContentDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="55" lineNum="38" parent="globals/WatchShelfApp" pc="268438977" symbol="getSyncDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="55" lineNum="39" parent="globals/WatchShelfApp" pc="268438979" symbol="getSyncDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="9" parent="globals/WatchShelfApp" pc="268438998" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="14" parent="globals/WatchShelfApp" pc="268439001" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="15" parent="globals/WatchShelfApp" pc="268439020" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="16" parent="globals/WatchShelfApp" pc="268439028" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="17" parent="globals/WatchShelfApp" pc="268439047" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="18" parent="globals/WatchShelfApp" pc="268439066" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="19" parent="globals/WatchShelfApp" pc="268439077" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="20" parent="globals/WatchShelfApp" pc="268439088" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="20" parent="globals/WatchShelfApp" pc="268439094" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="21" parent="globals/WatchShelfApp" pc="268439117" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="21" parent="globals/WatchShelfApp" pc="268439123" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="22" parent="globals/WatchShelfApp" pc="268439146" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="26" parent="globals/WatchShelfApp" pc="268439169" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="57" lineNum="52" parent="globals/WatchShelfApp" pc="268439182" symbol="getSyncConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="57" lineNum="53" parent="globals/WatchShelfApp" pc="268439184" symbol="getSyncConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="58" lineNum="70" parent="globals/ContentDelegate" pc="268439231" symbol="onShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="58" lineNum="71" parent="globals/ContentDelegate" pc="268439233" symbol="onShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="59" lineNum="18" parent="globals/ContentDelegate" pc="268439246" symbol="getContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="59" lineNum="19" parent="globals/ContentDelegate" pc="268439248" symbol="getContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="42" parent="globals/ContentDelegate" pc="268439254" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="43" parent="globals/ContentDelegate" pc="268439257" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="43" parent="globals/ContentDelegate" pc="268439271" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="48" parent="globals/ContentDelegate" pc="268439275" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="49" parent="globals/ContentDelegate" pc="268439284" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="50" parent="globals/ContentDelegate" pc="268439293" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="51" parent="globals/ContentDelegate" pc="268439312" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="51" parent="globals/ContentDelegate" pc="268439318" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="52" parent="globals/ContentDelegate" pc="268439325" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="53" parent="globals/ContentDelegate" pc="268439341" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="54" parent="globals/ContentDelegate" pc="268439345" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="55" parent="globals/ContentDelegate" pc="268439367" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="56" parent="globals/ContentDelegate" pc="268439376" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="57" parent="globals/ContentDelegate" pc="268439392" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="62" parent="globals/ContentDelegate" pc="268439452" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="63" parent="globals/ContentDelegate" pc="268439462" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="63" parent="globals/ContentDelegate" pc="268439468" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="64" parent="globals/ContentDelegate" pc="268439472" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="67" parent="globals/ContentDelegate" pc="268439482" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="61" lineNum="75" parent="globals/ContentDelegate" pc="268439503" symbol="onThumbsUp"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="62" lineNum="12" parent="globals/ContentDelegate" pc="268439506" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="62" lineNum="13" parent="globals/ContentDelegate" pc="268439508" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="62" lineNum="14" parent="globals/ContentDelegate" pc="268439520" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="62" lineNum="15" parent="globals/ContentDelegate" pc="268439528" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="63" lineNum="33" parent="globals/ContentDelegate" pc="268439536" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="63" lineNum="34" parent="globals/ContentDelegate" pc="268439538" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="63" lineNum="38" parent="globals/ContentDelegate" pc="268439570" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="65" lineNum="22" parent="globals/ContentDelegate" pc="268439587" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="65" lineNum="23" parent="globals/ContentDelegate" pc="268439589" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="65" lineNum="24" parent="globals/ContentDelegate" pc="268439614" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="66" lineNum="76" parent="globals/ContentDelegate" pc="268439620" symbol="onThumbsDown"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="85" parent="globals/BookStore" pc="268439623" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="86" parent="globals/BookStore" pc="268439634" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="87" parent="globals/BookStore" pc="268439638" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="88" parent="globals/BookStore" pc="268439669" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="90" parent="globals/BookStore" pc="268439679" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="91" parent="globals/BookStore" pc="268439690" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="92" parent="globals/BookStore" pc="268439716" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="93" parent="globals/BookStore" pc="268439722" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="94" parent="globals/BookStore" pc="268439739" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="95" parent="globals/BookStore" pc="268439748" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="99" parent="globals/BookStore" pc="268439806" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="101" parent="globals/BookStore" pc="268439841" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="30" parent="globals/BookStore" pc="268439865" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="31" parent="globals/BookStore" pc="268439875" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="42" parent="globals/BookStore" pc="268439898" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="43" parent="globals/BookStore" pc="268439909" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="44" parent="globals/BookStore" pc="268439912" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="45" parent="globals/BookStore" pc="268439915" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="46" parent="globals/BookStore" pc="268439919" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="47" parent="globals/BookStore" pc="268439945" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="47" parent="globals/BookStore" pc="268439951" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="48" parent="globals/BookStore" pc="268439957" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="49" parent="globals/BookStore" pc="268439969" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="51" parent="globals/BookStore" pc="268439979" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="111" parent="globals/BookStore" pc="268439982" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="112" parent="globals/BookStore" pc="268439993" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="113" parent="globals/BookStore" pc="268440005" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="113" parent="globals/BookStore" pc="268440011" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="114" parent="globals/BookStore" pc="268440015" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="115" parent="globals/BookStore" pc="268440037" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="116" parent="globals/BookStore" pc="268440040" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="117" parent="globals/BookStore" pc="268440043" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="118" parent="globals/BookStore" pc="268440047" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="119" parent="globals/BookStore" pc="268440073" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="119" parent="globals/BookStore" pc="268440079" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="120" parent="globals/BookStore" pc="268440085" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="121" parent="globals/BookStore" pc="268440101" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="122" parent="globals/BookStore" pc="268440123" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="124" parent="globals/BookStore" pc="268440151" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="126" parent="globals/BookStore" pc="268440168" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="58" parent="globals/BookStore" pc="268440179" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="59" parent="globals/BookStore" pc="268440190" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="60" parent="globals/BookStore" pc="268440204" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="61" parent="globals/BookStore" pc="268440215" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="62" parent="globals/BookStore" pc="268440241" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="62" parent="globals/BookStore" pc="268440247" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="63" parent="globals/BookStore" pc="268440254" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="64" parent="globals/BookStore" pc="268440267" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="65" parent="globals/BookStore" pc="268440274" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="66" parent="globals/BookStore" pc="268440296" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="68" parent="globals/BookStore" pc="268440338" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="72" parent="globals/BookStore" pc="268440348" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="72" parent="globals/BookStore" pc="268440361" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="73" parent="globals/BookStore" pc="268440375" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="75" parent="globals/BookStore" pc="268440387" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="25" parent="globals/BookStore" pc="268440415" symbol="pageKey"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="26" parent="globals/BookStore" pc="268440425" symbol="pageKey"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="22" parent="globals/BookStore" pc="268440443" symbol="key"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="23" parent="globals/BookStore" pc="268440453" symbol="key"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="34" parent="globals/BookStore" pc="268440462" symbol="ensureMeta"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="35" parent="globals/BookStore" pc="268440472" symbol="ensureMeta"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="36" parent="globals/BookStore" pc="268440486" symbol="ensureMeta"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="60" parent="globals/ContentIterator" pc="268440534" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="61" parent="globals/ContentIterator" pc="268440536" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="62" parent="globals/ContentIterator" pc="268440559" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="63" parent="globals/ContentIterator" pc="268440574" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="75" lineNum="65" parent="globals/ContentIterator" pc="268440591" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="76" lineNum="104" parent="globals/ContentIterator" pc="268440593" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="76" lineNum="105" parent="globals/ContentIterator" pc="268440596" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="76" lineNum="107" parent="globals/ContentIterator" pc="268440620" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="76" lineNum="108" parent="globals/ContentIterator" pc="268440674" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="76" lineNum="113" parent="globals/ContentIterator" pc="268440678" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="76" lineNum="114" parent="globals/ContentIterator" pc="268440719" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="76" lineNum="117" parent="globals/ContentIterator" pc="268440740" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="77" lineNum="68" parent="globals/ContentIterator" pc="268440742" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="77" lineNum="69" parent="globals/ContentIterator" pc="268440744" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="77" lineNum="70" parent="globals/ContentIterator" pc="268440754" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="77" lineNum="71" parent="globals/ContentIterator" pc="268440769" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="77" lineNum="73" parent="globals/ContentIterator" pc="268440786" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="182" parent="globals/ContentIterator" pc="268440788" symbol="swap"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="183" parent="globals/ContentIterator" pc="268440791" symbol="swap"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="184" parent="globals/ContentIterator" pc="268440798" symbol="swap"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="185" parent="globals/ContentIterator" pc="268440811" symbol="swap"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="80" parent="globals/ContentIterator" pc="268440822" symbol="peekPrevious"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="81" parent="globals/ContentIterator" pc="268440824" symbol="peekPrevious"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="80" lineNum="84" parent="globals/ContentIterator" pc="268440841" symbol="canSkip"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="80" lineNum="85" parent="globals/ContentIterator" pc="268440843" symbol="canSkip"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="92" parent="globals/ContentIterator" pc="268440845" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="93" parent="globals/ContentIterator" pc="268440847" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="94" parent="globals/ContentIterator" pc="268440855" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="95" parent="globals/ContentIterator" pc="268440863" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="97" parent="globals/ContentIterator" pc="268440873" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="98" parent="globals/ContentIterator" pc="268440880" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="32" parent="globals/ContentIterator" pc="268440889" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="33" parent="globals/ContentIterator" pc="268440892" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="34" parent="globals/ContentIterator" pc="268440916" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="41" parent="globals/ContentIterator" pc="268440929" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="42" parent="globals/ContentIterator" pc="268440938" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="43" parent="globals/ContentIterator" pc="268440947" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="44" parent="globals/ContentIterator" pc="268440957" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="47" parent="globals/ContentIterator" pc="268440967" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="48" parent="globals/ContentIterator" pc="268440978" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="50" parent="globals/ContentIterator" pc="268440991" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="51" parent="globals/ContentIterator" pc="268441002" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="53" parent="globals/ContentIterator" pc="268441015" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="83" lineNum="76" parent="globals/ContentIterator" pc="268441018" symbol="peekNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="83" lineNum="77" parent="globals/ContentIterator" pc="268441020" symbol="peekNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="56" parent="globals/ContentIterator" pc="268441037" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="57" parent="globals/ContentIterator" pc="268441039" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="88" parent="globals/ContentIterator" pc="268441053" symbol="shuffling"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="89" parent="globals/ContentIterator" pc="268441055" symbol="shuffling"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="86" lineNum="24" parent="globals/ContentIterator" pc="268441061" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="86" lineNum="25" parent="globals/ContentIterator" pc="268441063" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="86" lineNum="26" parent="globals/ContentIterator" pc="268441075" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="86" lineNum="27" parent="globals/ContentIterator" pc="268441083" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="86" lineNum="28" parent="globals/ContentIterator" pc="268441091" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="87" lineNum="175" parent="globals/ContentIterator" pc="268441099" symbol="after"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="87" lineNum="176" parent="globals/ContentIterator" pc="268441101" symbol="after"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="87" lineNum="177" parent="globals/ContentIterator" pc="268441109" symbol="after"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="87" lineNum="179" parent="globals/ContentIterator" pc="268441118" symbol="after"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="88" lineNum="188" parent="globals/ContentIterator" pc="268441124" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="88" lineNum="189" parent="globals/ContentIterator" pc="268441127" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="88" lineNum="190" parent="globals/ContentIterator" pc="268441150" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="88" lineNum="191" parent="globals/ContentIterator" pc="268441168" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="88" lineNum="192" parent="globals/ContentIterator" pc="268441178" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="88" lineNum="193" parent="globals/ContentIterator" pc="268441194" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="88" lineNum="195" parent="globals/ContentIterator" pc="268441214" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="131" parent="globals/ContentIterator" pc="268441223" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="132" parent="globals/ContentIterator" pc="268441226" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="133" parent="globals/ContentIterator" pc="268441235" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="134" parent="globals/ContentIterator" pc="268441239" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="138" parent="globals/ContentIterator" pc="268441243" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="139" parent="globals/ContentIterator" pc="268441247" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="140" parent="globals/ContentIterator" pc="268441266" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="140" parent="globals/ContentIterator" pc="268441272" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="141" parent="globals/ContentIterator" pc="268441279" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="142" parent="globals/ContentIterator" pc="268441295" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="145" parent="globals/ContentIterator" pc="268441327" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="146" parent="globals/ContentIterator" pc="268441354" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="147" parent="globals/ContentIterator" pc="268441360" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="148" parent="globals/ContentIterator" pc="268441370" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="149" parent="globals/ContentIterator" pc="268441376" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="150" parent="globals/ContentIterator" pc="268441386" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="151" parent="globals/ContentIterator" pc="268441393" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="152" parent="globals/ContentIterator" pc="268441399" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="153" parent="globals/ContentIterator" pc="268441415" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="154" parent="globals/ContentIterator" pc="268441429" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="156" parent="globals/ContentIterator" pc="268441447" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="163" parent="globals/ContentIterator" pc="268441463" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="164" parent="globals/ContentIterator" pc="268441484" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="165" parent="globals/ContentIterator" pc="268441488" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="166" parent="globals/ContentIterator" pc="268441535" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="166" parent="globals/ContentIterator" pc="268441551" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="166" parent="globals/ContentIterator" pc="268441564" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="167" parent="globals/ContentIterator" pc="268441577" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="170" parent="globals/ContentIterator" pc="268441597" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="90" lineNum="22" parent="globals/Login" pc="268441606" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="90" lineNum="23" parent="globals/Login" pc="268441616" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="91" lineNum="94" parent="globals/AbsApi" pc="268441676" symbol="isConfigured"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="91" lineNum="95" parent="globals/AbsApi" pc="268441686" symbol="isConfigured"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="92" lineNum="29" parent="globals/AbsApi" pc="268441707" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="92" lineNum="30" parent="globals/AbsApi" pc="268441718" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="92" lineNum="31" parent="globals/AbsApi" pc="268441737" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="92" lineNum="31" parent="globals/AbsApi" pc="268441743" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="92" lineNum="32" parent="globals/AbsApi" pc="268441761" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="146" parent="globals/AbsApi" pc="268441764" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="147" parent="globals/AbsApi" pc="268441774" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="93" lineNum="148" parent="globals/AbsApi" pc="268441802" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="94" lineNum="65" parent="globals/AbsApi" pc="268441823" symbol="getCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="94" lineNum="65" parent="globals/AbsApi" pc="268441833" symbol="getCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="95" lineNum="40" parent="globals/AbsApi" pc="268441852" symbol="sidecarBase"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="95" lineNum="40" parent="globals/AbsApi" pc="268441862" symbol="sidecarBase"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="96" lineNum="137" parent="globals/AbsApi" pc="268441869" symbol="login"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="96" lineNum="138" parent="globals/AbsApi" pc="268441879" symbol="login"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="97" lineNum="68" parent="globals/AbsApi" pc="268441963" symbol="getFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="97" lineNum="69" parent="globals/AbsApi" pc="268441973" symbol="getFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="98" lineNum="86" parent="globals/AbsApi" pc="268442046" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="98" lineNum="89" parent="globals/AbsApi" pc="268442057" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="98" lineNum="90" parent="globals/AbsApi" pc="268442073" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="98" lineNum="90" parent="globals/AbsApi" pc="268442107" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="98" lineNum="91" parent="globals/AbsApi" pc="268442112" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="99" lineNum="44" parent="globals/AbsApi" pc="268442115" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="99" lineNum="45" parent="globals/AbsApi" pc="268442126" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="99" lineNum="46" parent="globals/AbsApi" pc="268442153" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="99" lineNum="46" parent="globals/AbsApi" pc="268442165" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="99" lineNum="47" parent="globals/AbsApi" pc="268442175" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="100" lineNum="150" parent="globals/AbsApi" pc="268442225" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="100" lineNum="151" parent="globals/AbsApi" pc="268442235" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="100" lineNum="152" parent="globals/AbsApi" pc="268442253" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="124" parent="globals/AbsApi" pc="268442272" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="125" parent="globals/AbsApi" pc="268442283" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="126" parent="globals/AbsApi" pc="268442306" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="126" parent="globals/AbsApi" pc="268442312" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="127" parent="globals/AbsApi" pc="268442325" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="102" lineNum="64" parent="globals/AbsApi" pc="268442426" symbol="getSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="102" lineNum="64" parent="globals/AbsApi" pc="268442436" symbol="getSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="103" lineNum="113" parent="globals/AbsApi" pc="268442455" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="103" lineNum="114" parent="globals/AbsApi" pc="268442466" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="103" lineNum="115" parent="globals/AbsApi" pc="268442476" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="103" lineNum="116" parent="globals/AbsApi" pc="268442494" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="103" lineNum="118" parent="globals/AbsApi" pc="268442506" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="104" lineNum="63" parent="globals/AbsApi" pc="268442508" symbol="getAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="104" lineNum="63" parent="globals/AbsApi" pc="268442518" symbol="getAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="105" lineNum="80" parent="globals/AbsApi" pc="268442537" symbol="sidecarChunkUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="105" lineNum="81" parent="globals/AbsApi" pc="268442547" symbol="sidecarChunkUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="106" lineNum="154" parent="globals/AbsApi" pc="268442613" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="106" lineNum="155" parent="globals/AbsApi" pc="268442623" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="106" lineNum="156" parent="globals/AbsApi" pc="268442687" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="106" lineNum="158" parent="globals/AbsApi" pc="268442713" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="19" parent="globals/AbsApi" pc="268442716" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="20" parent="globals/AbsApi" pc="268442727" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="21" parent="globals/AbsApi" pc="268442746" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="21" parent="globals/AbsApi" pc="268442752" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="22" parent="globals/AbsApi" pc="268442770" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="22" parent="globals/AbsApi" pc="268442776" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="23" parent="globals/AbsApi" pc="268442781" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="24" parent="globals/AbsApi" pc="268442835" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="26" parent="globals/AbsApi" pc="268442860" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="108" lineNum="101" parent="globals/AbsApi" pc="268442863" symbol="getLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="108" lineNum="102" parent="globals/AbsApi" pc="268442873" symbol="getLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="109" lineNum="55" parent="globals/AbsApi" pc="268442938" symbol="getGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="109" lineNum="56" parent="globals/AbsApi" pc="268442948" symbol="getGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="110" lineNum="125" parent="globals/FieldDelegate" pc="268443018" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="110" lineNum="126" parent="globals/FieldDelegate" pc="268443020" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="110" lineNum="127" parent="globals/FieldDelegate" pc="268443041" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="111" lineNum="129" parent="globals/FieldDelegate" pc="268443043" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="111" lineNum="130" parent="globals/FieldDelegate" pc="268443045" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="111" lineNum="131" parent="globals/FieldDelegate" pc="268443057" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="112" lineNum="118" parent="globals/FieldDelegate" pc="268443059" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="112" lineNum="119" parent="globals/FieldDelegate" pc="268443061" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="112" lineNum="120" parent="globals/FieldDelegate" pc="268443073" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="112" lineNum="121" parent="globals/FieldDelegate" pc="268443082" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="113" lineNum="14" parent="globals/RequestDelegate" pc="268443092" symbol="makeWebRequest"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="113" lineNum="15" parent="globals/RequestDelegate" pc="268443094" symbol="makeWebRequest"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="114" lineNum="9" parent="globals/RequestDelegate" pc="268443127" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="114" lineNum="10" parent="globals/RequestDelegate" pc="268443129" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="114" lineNum="11" parent="globals/RequestDelegate" pc="268443138" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="115" lineNum="18" parent="globals/RequestDelegate" pc="268443148" symbol="onWebResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="115" lineNum="19" parent="globals/RequestDelegate" pc="268443150" symbol="onWebResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="116" lineNum="7" parent="globals/Browse" pc="268443174" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="116" lineNum="8" parent="globals/Browse" pc="268443185" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="116" lineNum="9" parent="globals/Browse" pc="268443251" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="116" lineNum="10" parent="globals/Browse" pc="268443321" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="116" lineNum="11" parent="globals/Browse" pc="268443391" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="116" lineNum="12" parent="globals/Browse" pc="268443461" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="116" lineNum="13" parent="globals/Browse" pc="268443531" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="117" lineNum="17" parent="globals/Browse" pc="268443573" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="117" lineNum="18" parent="globals/Browse" pc="268443584" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="117" lineNum="19" parent="globals/Browse" pc="268443630" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="117" lineNum="21" parent="globals/Browse" pc="268443735" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="117" lineNum="23" parent="globals/Browse" pc="268443739" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="117" lineNum="24" parent="globals/Browse" pc="268443749" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="117" lineNum="25" parent="globals/Browse" pc="268443815" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="117" lineNum="26" parent="globals/Browse" pc="268443831" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="117" lineNum="27" parent="globals/Browse" pc="268443838" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="117" lineNum="29" parent="globals/Browse" pc="268443905" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="118" lineNum="43" parent="globals/LibraryView" pc="268443945" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="118" lineNum="44" parent="globals/LibraryView" pc="268443948" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="118" lineNum="45" parent="globals/LibraryView" pc="268443975" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="118" lineNum="46" parent="globals/LibraryView" pc="268443985" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="118" lineNum="47" parent="globals/LibraryView" pc="268444051" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="118" lineNum="48" parent="globals/LibraryView" pc="268444067" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="118" lineNum="50" parent="globals/LibraryView" pc="268444074" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="118" lineNum="51" parent="globals/LibraryView" pc="268444110" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="118" lineNum="54" parent="globals/LibraryView" pc="268444173" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="118" lineNum="56" parent="globals/LibraryView" pc="268444211" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="118" lineNum="57" parent="globals/LibraryView" pc="268444264" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="119" lineNum="19" parent="globals/LibraryView" pc="268444276" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="119" lineNum="23" parent="globals/LibraryView" pc="268444278" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="119" lineNum="23" parent="globals/LibraryView" pc="268444286" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="119" lineNum="24" parent="globals/LibraryView" pc="268444290" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="119" lineNum="26" parent="globals/LibraryView" pc="268444298" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="119" lineNum="28" parent="globals/LibraryView" pc="268444312" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="119" lineNum="29" parent="globals/LibraryView" pc="268444323" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="119" lineNum="31" parent="globals/LibraryView" pc="268444327" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="120" lineNum="13" parent="globals/LibraryView" pc="268444354" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="120" lineNum="14" parent="globals/LibraryView" pc="268444356" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="120" lineNum="15" parent="globals/LibraryView" pc="268444368" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="120" lineNum="16" parent="globals/LibraryView" pc="268444406" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="121" lineNum="34" parent="globals/LibraryView" pc="268444415" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="121" lineNum="35" parent="globals/LibraryView" pc="268444417" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="121" lineNum="36" parent="globals/LibraryView" pc="268444429" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="121" lineNum="37" parent="globals/LibraryView" pc="268444437" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="121" lineNum="38" parent="globals/LibraryView" pc="268444453" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="122" lineNum="13" parent="globals/LibraryViewDelegate" pc="268444493" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="122" lineNum="14" parent="globals/LibraryViewDelegate" pc="268444495" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="122" lineNum="15" parent="globals/LibraryViewDelegate" pc="268444510" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="123" lineNum="8" parent="globals/LibraryViewDelegate" pc="268444512" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="123" lineNum="9" parent="globals/LibraryViewDelegate" pc="268444514" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="124" lineNum="82" parent="globals/BookMenuDelegate" pc="268444527" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="124" lineNum="83" parent="globals/BookMenuDelegate" pc="268444529" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="125" lineNum="15" parent="globals/BookMenuDelegate" pc="268444545" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="125" lineNum="16" parent="globals/BookMenuDelegate" pc="268444547" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="125" lineNum="17" parent="globals/BookMenuDelegate" pc="268444559" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="25" parent="globals/BookMenuDelegate" pc="268444568" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="26" parent="globals/BookMenuDelegate" pc="268444571" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="27" parent="globals/BookMenuDelegate" pc="268444617" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="29" parent="globals/BookMenuDelegate" pc="268444714" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="32" parent="globals/BookMenuDelegate" pc="268444718" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="33" parent="globals/BookMenuDelegate" pc="268444728" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="34" parent="globals/BookMenuDelegate" pc="268444738" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="34" parent="globals/BookMenuDelegate" pc="268444744" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="36" parent="globals/BookMenuDelegate" pc="268444754" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="37" parent="globals/BookMenuDelegate" pc="268444758" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="38" parent="globals/BookMenuDelegate" pc="268444762" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="39" parent="globals/BookMenuDelegate" pc="268444778" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="40" parent="globals/BookMenuDelegate" pc="268444806" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="40" parent="globals/BookMenuDelegate" pc="268444813" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="41" parent="globals/BookMenuDelegate" pc="268444819" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="42" parent="globals/BookMenuDelegate" pc="268444840" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="45" parent="globals/BookMenuDelegate" pc="268444862" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="46" parent="globals/BookMenuDelegate" pc="268444878" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="47" parent="globals/BookMenuDelegate" pc="268444885" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="48" parent="globals/BookMenuDelegate" pc="268444967" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="53" parent="globals/BookMenuDelegate" pc="268444971" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="54" parent="globals/BookMenuDelegate" pc="268444990" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="55" parent="globals/BookMenuDelegate" pc="268444998" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="57" parent="globals/BookMenuDelegate" pc="268445080" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="63" parent="globals/BookMenuDelegate" pc="268445084" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="64" parent="globals/BookMenuDelegate" pc="268445103" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="64" parent="globals/BookMenuDelegate" pc="268445109" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="65" parent="globals/BookMenuDelegate" pc="268445116" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="71" parent="globals/BookMenuDelegate" pc="268445161" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="73" parent="globals/BookMenuDelegate" pc="268445181" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="126" lineNum="74" parent="globals/BookMenuDelegate" pc="268445263" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="127" lineNum="77" parent="globals/BookMenuDelegate" pc="268445275" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="127" lineNum="78" parent="globals/BookMenuDelegate" pc="268445277" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="127" lineNum="78" parent="globals/BookMenuDelegate" pc="268445283" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="127" lineNum="79" parent="globals/BookMenuDelegate" pc="268445289" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="128" lineNum="20" parent="globals/BookMenuDelegate" pc="268445292" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="128" lineNum="21" parent="globals/BookMenuDelegate" pc="268445294" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="128" lineNum="22" parent="globals/BookMenuDelegate" pc="268445308" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="129" lineNum="103" parent="globals/LoginView" pc="268445340" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="129" lineNum="104" parent="globals/LoginView" pc="268445342" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="129" lineNum="105" parent="globals/LoginView" pc="268445387" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="129" lineNum="106" parent="globals/LoginView" pc="268445424" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="129" lineNum="108" parent="globals/LoginView" pc="268445478" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="129" lineNum="109" parent="globals/LoginView" pc="268445487" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="129" lineNum="110" parent="globals/LoginView" pc="268445540" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="130" lineNum="63" parent="globals/LoginView" pc="268445552" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="130" lineNum="64" parent="globals/LoginView" pc="268445554" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="130" lineNum="64" parent="globals/LoginView" pc="268445561" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="130" lineNum="65" parent="globals/LoginView" pc="268445596" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="130" lineNum="65" parent="globals/LoginView" pc="268445604" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="130" lineNum="66" parent="globals/LoginView" pc="268445639" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="131" lineNum="90" parent="globals/LoginView" pc="268445671" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="131" lineNum="91" parent="globals/LoginView" pc="268445673" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="131" lineNum="91" parent="globals/LoginView" pc="268445680" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="131" lineNum="92" parent="globals/LoginView" pc="268445696" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="131" lineNum="92" parent="globals/LoginView" pc="268445704" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="131" lineNum="93" parent="globals/LoginView" pc="268445720" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="131" lineNum="93" parent="globals/LoginView" pc="268445728" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="131" lineNum="94" parent="globals/LoginView" pc="268445744" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="132" lineNum="44" parent="globals/LoginView" pc="268445757" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="132" lineNum="45" parent="globals/LoginView" pc="268445759" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="132" lineNum="46" parent="globals/LoginView" pc="268445770" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="132" lineNum="47" parent="globals/LoginView" pc="268445790" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="132" lineNum="48" parent="globals/LoginView" pc="268445801" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="132" lineNum="49" parent="globals/LoginView" pc="268445830" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="132" lineNum="50" parent="globals/LoginView" pc="268445864" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="132" lineNum="51" parent="globals/LoginView" pc="268445875" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="132" lineNum="52" parent="globals/LoginView" pc="268445884" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="132" lineNum="53" parent="globals/LoginView" pc="268445922" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="132" lineNum="54" parent="globals/LoginView" pc="268445933" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="133" lineNum="97" parent="globals/LoginView" pc="268445993" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="133" lineNum="98" parent="globals/LoginView" pc="268445995" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="133" lineNum="99" parent="globals/LoginView" pc="268446004" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="133" lineNum="100" parent="globals/LoginView" pc="268446042" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="134" lineNum="70" parent="globals/LoginView" pc="268446054" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="134" lineNum="71" parent="globals/LoginView" pc="268446056" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="134" lineNum="72" parent="globals/LoginView" pc="268446064" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="134" lineNum="73" parent="globals/LoginView" pc="268446074" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="134" lineNum="74" parent="globals/LoginView" pc="268446144" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="134" lineNum="75" parent="globals/LoginView" pc="268446155" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="134" lineNum="76" parent="globals/LoginView" pc="268446226" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="134" lineNum="77" parent="globals/LoginView" pc="268446237" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="135" lineNum="33" parent="globals/LoginView" pc="268446304" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="135" lineNum="34" parent="globals/LoginView" pc="268446307" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="135" lineNum="35" parent="globals/LoginView" pc="268446319" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="135" lineNum="36" parent="globals/LoginView" pc="268446327" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="135" lineNum="37" parent="globals/LoginView" pc="268446352" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="135" lineNum="38" parent="globals/LoginView" pc="268446364" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="135" lineNum="39" parent="globals/LoginView" pc="268446391" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="135" lineNum="40" parent="globals/LoginView" pc="268446403" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="136" lineNum="59" parent="globals/LoginView" pc="268446412" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="136" lineNum="60" parent="globals/LoginView" pc="268446414" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="136" lineNum="60" parent="globals/LoginView" pc="268446423" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="136" lineNum="60" parent="globals/LoginView" pc="268446435" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="137" lineNum="81" parent="globals/LoginView" pc="268446447" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="137" lineNum="82" parent="globals/LoginView" pc="268446449" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="137" lineNum="83" parent="globals/LoginView" pc="268446461" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="137" lineNum="84" parent="globals/LoginView" pc="268446469" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="137" lineNum="85" parent="globals/LoginView" pc="268446485" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="138" lineNum="74" parent="globals/DownloadedMenuDelegate" pc="268446525" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="138" lineNum="75" parent="globals/DownloadedMenuDelegate" pc="268446528" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="138" lineNum="75" parent="globals/DownloadedMenuDelegate" pc="268446540" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="138" lineNum="77" parent="globals/DownloadedMenuDelegate" pc="268446544" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="138" lineNum="78" parent="globals/DownloadedMenuDelegate" pc="268446563" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="138" lineNum="78" parent="globals/DownloadedMenuDelegate" pc="268446569" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="138" lineNum="79" parent="globals/DownloadedMenuDelegate" pc="268446576" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="138" lineNum="80" parent="globals/DownloadedMenuDelegate" pc="268446592" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="138" lineNum="82" parent="globals/DownloadedMenuDelegate" pc="268446617" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="138" lineNum="84" parent="globals/DownloadedMenuDelegate" pc="268446637" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="138" lineNum="85" parent="globals/DownloadedMenuDelegate" pc="268446648" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="139" lineNum="88" parent="globals/DownloadedMenuDelegate" pc="268446731" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="139" lineNum="89" parent="globals/DownloadedMenuDelegate" pc="268446733" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="140" lineNum="12" parent="globals/DownloadedMenuDelegate" pc="268446749" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="140" lineNum="13" parent="globals/DownloadedMenuDelegate" pc="268446751" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="16" parent="globals/DownloadedMenuDelegate" pc="268446764" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="17" parent="globals/DownloadedMenuDelegate" pc="268446767" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="21" parent="globals/DownloadedMenuDelegate" pc="268446776" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="22" parent="globals/DownloadedMenuDelegate" pc="268446809" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="23" parent="globals/DownloadedMenuDelegate" pc="268446860" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="31" parent="globals/DownloadedMenuDelegate" pc="268446864" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="32" parent="globals/DownloadedMenuDelegate" pc="268446897" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="33" parent="globals/DownloadedMenuDelegate" pc="268446911" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="39" parent="globals/DownloadedMenuDelegate" pc="268446915" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="40" parent="globals/DownloadedMenuDelegate" pc="268446948" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="41" parent="globals/DownloadedMenuDelegate" pc="268446959" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="42" parent="globals/DownloadedMenuDelegate" pc="268447010" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="49" parent="globals/DownloadedMenuDelegate" pc="268447014" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="50" parent="globals/DownloadedMenuDelegate" pc="268447047" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="51" parent="globals/DownloadedMenuDelegate" pc="268447067" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="52" parent="globals/DownloadedMenuDelegate" pc="268447087" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="53" parent="globals/DownloadedMenuDelegate" pc="268447169" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="57" parent="globals/DownloadedMenuDelegate" pc="268447173" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="58" parent="globals/DownloadedMenuDelegate" pc="268447206" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="59" parent="globals/DownloadedMenuDelegate" pc="268447225" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="59" parent="globals/DownloadedMenuDelegate" pc="268447231" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="60" parent="globals/DownloadedMenuDelegate" pc="268447238" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="61" parent="globals/DownloadedMenuDelegate" pc="268447249" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="141" lineNum="68" parent="globals/DownloadedMenuDelegate" pc="268447253" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="142" lineNum="14" parent="globals/ErrorViewDelegate" pc="268447272" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="142" lineNum="15" parent="globals/ErrorViewDelegate" pc="268447274" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="142" lineNum="16" parent="globals/ErrorViewDelegate" pc="268447289" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="143" lineNum="10" parent="globals/ErrorViewDelegate" pc="268447291" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="143" lineNum="11" parent="globals/ErrorViewDelegate" pc="268447293" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="144" lineNum="9" parent="globals/ErrorView" pc="268447306" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="144" lineNum="10" parent="globals/ErrorView" pc="268447308" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="144" lineNum="11" parent="globals/ErrorView" pc="268447320" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="145" lineNum="14" parent="globals/ErrorView" pc="268447330" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="145" lineNum="15" parent="globals/ErrorView" pc="268447332" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="145" lineNum="16" parent="globals/ErrorView" pc="268447344" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="145" lineNum="17" parent="globals/ErrorView" pc="268447352" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="145" lineNum="18" parent="globals/ErrorView" pc="268447368" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="146" lineNum="72" parent="globals/DownloadedMenu" pc="268447408" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="146" lineNum="73" parent="globals/DownloadedMenu" pc="268447411" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="146" lineNum="74" parent="globals/DownloadedMenu" pc="268447423" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="146" lineNum="75" parent="globals/DownloadedMenu" pc="268447426" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="146" lineNum="75" parent="globals/DownloadedMenu" pc="268447443" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="146" lineNum="76" parent="globals/DownloadedMenu" pc="268447455" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="146" lineNum="77" parent="globals/DownloadedMenu" pc="268447470" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="147" lineNum="62" parent="globals/DownloadedMenu" pc="268447529" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="147" lineNum="63" parent="globals/DownloadedMenu" pc="268447532" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="147" lineNum="64" parent="globals/DownloadedMenu" pc="268447551" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="147" lineNum="65" parent="globals/DownloadedMenu" pc="268447570" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="13" parent="globals/DownloadedMenu" pc="268447615" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="14" parent="globals/DownloadedMenu" pc="268447618" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="19" parent="globals/DownloadedMenu" pc="268447649" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="21" parent="globals/DownloadedMenu" pc="268447718" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="22" parent="globals/DownloadedMenu" pc="268447737" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="22" parent="globals/DownloadedMenu" pc="268447743" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="30" parent="globals/DownloadedMenu" pc="268447750" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="31" parent="globals/DownloadedMenu" pc="268447762" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="36" parent="globals/DownloadedMenu" pc="268447834" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="37" parent="globals/DownloadedMenu" pc="268447847" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="44" parent="globals/DownloadedMenu" pc="268447919" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="45" parent="globals/DownloadedMenu" pc="268447928" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="48" parent="globals/DownloadedMenu" pc="268448000" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="49" parent="globals/DownloadedMenu" pc="268448012" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="52" parent="globals/DownloadedMenu" pc="268448084" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="53" parent="globals/DownloadedMenu" pc="268448100" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="54" parent="globals/DownloadedMenu" pc="268448107" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="55" parent="globals/DownloadedMenu" pc="268448123" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="56" parent="globals/DownloadedMenu" pc="268448159" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="57" parent="globals/DownloadedMenu" pc="268448175" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="148" lineNum="58" parent="globals/DownloadedMenu" pc="268448212" symbol="initialize"/>
+    </pcToLineNum>
+    <symbolTable>
+        <entry id="45" method="true" symbol="containsId"/>
+        <entry id="8388639" module="true" symbol="Graphics"/>
+        <entry id="8390434" method="true" symbol="getSyncConfigurationView"/>
+        <entry id="20" object="true" symbol="DownloadedMenu"/>
+        <entry field="true" id="59" symbol="&lt;globals/GroupDelegate/&lt;&gt;mType&gt;"/>
+        <entry id="8390557" method="true" symbol="resetContentIterator"/>
+        <entry id="86" method="true" symbol="isConfigured"/>
+        <entry id="65" method="true" symbol="ensureMeta"/>
+        <entry id="118" method="true" symbol="titleWithSize"/>
+        <entry id="8390211" module="true" symbol="Media"/>
+        <entry id="104" method="true" symbol="numOr"/>
+        <entry field="true" id="133" symbol="errItems"/>
+        <entry id="43" method="true" symbol="pushGroups"/>
+        <entry id="14" object="true" symbol="AbsProgressListener"/>
+        <entry id="31" object="true" symbol="LoginView"/>
+        <entry id="8388632" method="true" symbol="&lt;init&gt;"/>
+        <entry id="8390379" method="true" symbol="onThumbsUp"/>
+        <entry id="8390380" method="true" symbol="onThumbsDown"/>
+        <entry id="69" method="true" symbol="buildPlaylist"/>
+        <entry id="49" method="true" symbol="jobs"/>
+        <entry id="3" module="true" symbol="globals/BookStore"/>
+        <entry field="true" id="125" symbol="byAuthor"/>
+        <entry id="91" method="true" symbol="saveLogin"/>
+        <entry field="true" id="134" symbol="errLibraries"/>
+        <entry id="52" method="true" symbol="onOpDone"/>
+        <entry id="8390335" object="true" symbol="ContentIterator"/>
+        <entry field="true" id="150" symbol="settingApiKey"/>
+        <entry id="8388826" method="true" symbol="next"/>
+        <entry field="true" id="147" symbol="playDownloaded"/>
+        <entry field="true" id="97" symbol="mCallback"/>
+        <entry id="26" object="true" symbol="LibraryMenuDelegate"/>
+        <entry field="true" id="58" symbol="&lt;globals/GroupDelegate/&lt;&gt;mLib&gt;"/>
+        <entry id="16" module="true" symbol="BookStore"/>
+        <entry field="true" id="138" symbol="fieldServer"/>
+        <entry id="15" object="true" symbol="BookMenuDelegate"/>
+        <entry id="41" method="true" symbol="onCollections"/>
+        <entry id="5" module="true" symbol="globals/Chunks"/>
+        <entry field="true" id="71" symbol="&lt;globals/ContentIterator/&lt;&gt;mPlaylist&gt;"/>
+        <entry field="true" id="122" symbol="allBooks"/>
+        <entry id="66" method="true" symbol="pageKey"/>
+        <entry id="74" method="true" symbol="swap"/>
+        <entry field="true" id="149" symbol="queued"/>
+        <entry id="8390336" object="true" symbol="ContentDelegate"/>
+        <entry id="13" module="true" symbol="AbsApi"/>
+        <entry field="true" id="148" symbol="queueCleared"/>
+        <entry id="34" module="true" symbol="Versions"/>
+        <entry field="true" id="8388611" module="true" symbol="Toybox"/>
+        <entry id="115" method="true" symbol="queueDelete"/>
+        <entry id="8390377" method="true" symbol="getContentIterator"/>
+        <entry id="8389108" method="true" symbol="onResponse"/>
+        <entry id="90" method="true" symbol="progressSeconds"/>
+        <entry id="84" method="true" symbol="getLibraries"/>
+        <entry field="true" id="143" symbol="loggingIn"/>
+        <entry id="8390373" method="true" symbol="shuffling"/>
+        <entry id="76" method="true" symbol="_noSlash"/>
+        <entry id="35" object="true" symbol="WatchShelfApp"/>
+        <entry field="true" id="121" symbol="AppName"/>
+        <entry id="8390440" symbol="contentType"/>
+        <entry id="8390459" method="true" symbol="onStopSync"/>
+        <entry id="9" module="true" symbol="globals/Rez/Strings"/>
+        <entry id="17" module="true" symbol="Browse"/>
+        <entry id="8389594" symbol="headers"/>
+        <entry field="true" id="116" symbol="&lt;globals/ErrorView/&lt;&gt;mMessage&gt;"/>
+        <entry field="true" id="144" symbol="loginFailed"/>
+        <entry field="true" id="108" symbol="&lt;globals/LoginView/&lt;&gt;mCreds&gt;"/>
+        <entry id="64" method="true" symbol="deleteBook"/>
+        <entry id="8390430" method="true" symbol="getContentDelegate"/>
+        <entry field="true" id="50" symbol="&lt;globals/SyncDelegate/&lt;&gt;mDone&gt;"/>
+        <entry id="102" method="true" symbol="onLibraries"/>
+        <entry field="true" id="137" symbol="fieldPass"/>
+        <entry id="8388648" module="true" symbol="WatchUi"/>
+        <entry id="8389081" method="true" symbol="onBack"/>
+        <entry field="true" id="139" symbol="fieldUser"/>
+        <entry field="true" id="60" symbol="&lt;globals/ContentDelegate/&lt;&gt;mIterator&gt;"/>
+        <entry id="12" module="true" symbol="globals/Versions"/>
+        <entry id="83" method="true" symbol="getGroups"/>
+        <entry id="7" module="true" symbol="globals/Rez"/>
+        <entry id="39" method="true" symbol="onAuthors"/>
+        <entry id="78" method="true" symbol="authToken"/>
+        <entry id="8388789" method="true" symbol="get"/>
+        <entry id="8390342" method="true" symbol="isSyncNeeded"/>
+        <entry field="true" id="132" symbol="errDetail"/>
+        <entry field="true" id="124" symbol="browseLibrary"/>
+        <entry id="8389124" method="true" symbol="onUpdate"/>
+        <entry field="true" id="110" symbol="&lt;globals/LoginView/&lt;&gt;mState&gt;"/>
+        <entry id="8390431" method="true" symbol="getSyncDelegate"/>
+        <entry id="27" object="true" symbol="LibraryView"/>
+        <entry id="75" method="true" symbol="toggleShuffle"/>
+        <entry field="true" id="8390516" symbol="mContext"/>
+        <entry id="73" method="true" symbol="objAt"/>
+        <entry id="8388771" module="true" object="true" symbol="Drawables"/>
+        <entry id="37" method="true" symbol="starts"/>
+        <entry field="true" id="153" symbol="settingServerUrlPrompt"/>
+        <entry id="77" method="true" symbol="_prop"/>
+        <entry id="29" module="true" symbol="Login"/>
+        <entry id="8390433" method="true" symbol="getProviderIconInfo"/>
+        <entry id="53" method="true" symbol="onTrackDownloaded"/>
+        <entry id="6" module="true" symbol="globals/Login"/>
+        <entry field="true" id="145" symbol="pickBook"/>
+        <entry field="true" id="123" symbol="alreadyDownloaded"/>
+        <entry field="true" id="57" symbol="username"/>
+        <entry id="8389850" method="true" symbol="count"/>
+        <entry field="true" id="151" symbol="settingApiKeyPrompt"/>
+        <entry field="true" id="56" symbol="server"/>
+        <entry id="8390442" method="true" symbol="shuffle"/>
+        <entry field="true" id="72" symbol="&lt;globals/ContentIterator/&lt;&gt;mShuffling&gt;"/>
+        <entry id="8390337" object="true" symbol="SyncDelegate"/>
+        <entry id="36" method="true" symbol="at"/>
+        <entry id="112" method="true" symbol="onLogin"/>
+        <entry field="true" id="131" symbol="downloaded"/>
+        <entry id="33" module="true" symbol="Store"/>
+        <entry id="11" module="true" symbol="globals/Store"/>
+        <entry id="8388637" module="true" symbol="Communications"/>
+        <entry id="92" method="true" symbol="serverUrl"/>
+        <entry id="22" object="true" symbol="ErrorView"/>
+        <entry id="30" object="true" symbol="LoginCreds"/>
+        <entry id="8" module="true" symbol="globals/Rez/Drawables"/>
+        <entry id="19" module="true" symbol="Chunks"/>
+        <entry id="8390371" method="true" symbol="peekNext"/>
+        <entry field="true" id="136" symbol="errNone"/>
+        <entry field="true" id="126" symbol="byCollection"/>
+        <entry id="8390372" method="true" symbol="peekPrevious"/>
+        <entry id="8389844" symbol="responseType"/>
+        <entry field="true" id="100" symbol="&lt;globals/LibraryView/&lt;&gt;mMessage&gt;"/>
+        <entry field="true" id="8392276" symbol="skipForwardTimeDelta"/>
+        <entry id="8392335" module="true" object="true" symbol="Settings"/>
+        <entry field="true" id="146" symbol="pickLibrary"/>
+        <entry id="40" method="true" symbol="onBooks"/>
+        <entry id="44" method="true" symbol="addToIndex"/>
+        <entry id="88" method="true" symbol="logout"/>
+        <entry id="8388786" method="true" symbol="method"/>
+        <entry id="113" method="true" symbol="openField"/>
+        <entry field="true" id="142" symbol="logOut"/>
+        <entry id="8388644" module="true" symbol="System"/>
+        <entry id="8390382" method="true" symbol="onSong"/>
+        <entry id="87" method="true" symbol="login"/>
+        <entry field="true" id="109" symbol="&lt;globals/LoginView/&lt;&gt;mMessage&gt;"/>
+        <entry id="8389619" method="true" symbol="onSelect"/>
+        <entry id="8388769" module="true" object="true" symbol="Rez"/>
+        <entry field="true" id="38" symbol="&lt;globals/BrowseDelegate/&lt;&gt;mLib&gt;"/>
+        <entry field="true" id="55" symbol="password"/>
+        <entry id="23" object="true" symbol="ErrorViewDelegate"/>
+        <entry id="89" method="true" symbol="patchProgress"/>
+        <entry id="8389540" method="true" symbol="onTextEntered"/>
+        <entry id="8390432" method="true" symbol="getPlaybackConfigurationView"/>
+        <entry id="85" method="true" symbol="getSeries"/>
+        <entry id="99" method="true" symbol="showBooks"/>
+        <entry field="true" id="8392277" symbol="skipBackwardTimeDelta"/>
+        <entry field="true" id="96" symbol="&lt;globals/FieldDelegate/&lt;&gt;mView&gt;"/>
+        <entry id="8388640" module="true" symbol="Lang"/>
+        <entry field="true" id="152" symbol="settingServerUrl"/>
+        <entry id="106" method="true" symbol="cancelFlow"/>
+        <entry field="true" id="140" symbol="loading"/>
+        <entry id="21" object="true" symbol="DownloadedMenuDelegate"/>
+        <entry id="8390784" method="true" symbol="onRepeat"/>
+        <entry id="8390374" method="true" symbol="canSkip"/>
+        <entry field="true" id="111" symbol="&lt;globals/LoginView/&lt;&gt;mTimer&gt;"/>
+        <entry id="114" method="true" symbol="setField"/>
+        <entry id="8388610" symbol="statics"/>
+        <entry id="80" method="true" symbol="getBookList"/>
+        <entry id="8389123" method="true" symbol="onShow"/>
+        <entry id="10" module="true" symbol="globals/Settings"/>
+        <entry id="28" object="true" symbol="LibraryViewDelegate"/>
+        <entry id="24" object="true" symbol="FieldDelegate"/>
+        <entry id="8390369" method="true" symbol="getPlaybackProfile"/>
+        <entry id="8389835" method="true" symbol="makeWebRequest"/>
+        <entry id="54" method="true" symbol="removeFromIndex"/>
+        <entry id="8390370" method="true" symbol="previous"/>
+        <entry id="8390522" method="true" symbol="key"/>
+        <entry field="true" id="119" symbol="launcher"/>
+        <entry field="true" id="101" symbol="&lt;globals/LibraryView/&lt;&gt;mStarted&gt;"/>
+        <entry id="8389350" module="true" symbol="globals"/>
+        <entry field="true" id="128" symbol="clearQueue"/>
+        <entry id="8388770" module="true" object="true" symbol="Strings"/>
+        <entry id="18" object="true" symbol="BrowseDelegate"/>
+        <entry id="8388702" method="true" symbol="initialize"/>
+        <entry field="true" id="103" symbol="&lt;globals/BookMenuDelegate/&lt;&gt;mItemId&gt;"/>
+        <entry id="46" method="true" symbol="deleteQueued"/>
+        <entry id="63" method="true" symbol="addLookup"/>
+        <entry field="true" id="141" symbol="logIn"/>
+        <entry field="true" id="61" symbol="&lt;globals/ContentDelegate/&lt;&gt;mProgressLookup&gt;"/>
+        <entry field="true" id="130" symbol="deleting"/>
+        <entry id="32" object="true" symbol="RequestDelegate"/>
+        <entry id="48" method="true" symbol="downloadNext"/>
+        <entry id="2" module="true" symbol="globals/AbsApi"/>
+        <entry id="8388641" module="true" symbol="Math"/>
+        <entry id="8389541" method="true" symbol="onCancel"/>
+        <entry id="62" method="true" symbol="syncProgress"/>
+        <entry id="8390341" method="true" symbol="onStartSync"/>
+        <entry id="98" method="true" symbol="onWebResponse"/>
+        <entry id="79" method="true" symbol="getAuthors"/>
+        <entry field="true" id="51" symbol="&lt;globals/SyncDelegate/&lt;&gt;mTotal&gt;"/>
+        <entry id="105" method="true" symbol="onFiles"/>
+        <entry id="67" method="true" symbol="saveChunk"/>
+        <entry id="82" method="true" symbol="getFiles"/>
+        <entry id="94" method="true" symbol="sidecarChunkUrl"/>
+        <entry id="8388646" module="true" object="true" symbol="Timer"/>
+        <entry id="4" module="true" symbol="globals/Browse"/>
+        <entry id="93" method="true" symbol="sidecarBase"/>
+        <entry id="42" method="true" symbol="onSeries"/>
+        <entry field="true" id="135" symbol="errNoAudio"/>
+        <entry id="8388698" method="true" symbol="start"/>
+        <entry id="47" method="true" symbol="deletes"/>
+        <entry id="8390381" method="true" symbol="onShuffle"/>
+        <entry id="25" object="true" symbol="GroupDelegate"/>
+        <entry field="true" id="8389866" method="true" symbol="total"/>
+        <entry field="true" id="70" symbol="&lt;globals/ContentIterator/&lt;&gt;mIndex&gt;"/>
+        <entry id="8390441" object="true" symbol="mediaEncoding"/>
+        <entry id="117" method="true" symbol="hasQueued"/>
+        <entry field="true" id="127" symbol="bySeries"/>
+        <entry field="true" id="129" symbol="deleteAllDownloads"/>
+        <entry id="8389125" method="true" symbol="onHide"/>
+        <entry field="true" id="120" symbol="providerIcon"/>
+        <entry id="107" method="true" symbol="labelFor"/>
+        <entry id="68" method="true" symbol="after"/>
+        <entry id="8388635" module="true" symbol="Application"/>
+        <entry field="true" id="8389642" symbol="title"/>
+        <entry field="true" id="95" symbol="&lt;globals/FieldDelegate/&lt;&gt;mField&gt;"/>
+        <entry id="81" method="true" symbol="getCollections"/>
+    </symbolTable>
+    <localVars>
+        <entry arg="true" endPc="268435798" name="durs" stackId="1" startPc="268435672"/>
+        <entry endPc="268435798" name="n" stackId="2" startPc="268435683"/>
+        <entry endPc="268435795" name="f" stackId="3" startPc="268435702"/>
+        <entry endPc="268435785" name="d" stackId="4" startPc="268435702"/>
+        <entry endPc="268435785" name="pos" stackId="5" startPc="268435702"/>
+        <entry endPc="268435782" name="size" stackId="6" startPc="268435733"/>
+        <entry endPc="268435782" name="end" stackId="7" startPc="268435733"/>
+        <entry arg="true" endPc="268435986" name="durs" stackId="1" startPc="268435799"/>
+        <entry arg="true" endPc="268435986" name="k" stackId="2" startPc="268435799"/>
+        <entry endPc="268435986" name="n" stackId="3" startPc="268435810"/>
+        <entry endPc="268435986" name="bookOffset" stackId="4" startPc="268435810"/>
+        <entry endPc="268435984" name="f" stackId="5" startPc="268435832"/>
+        <entry endPc="268435974" name="d" stackId="6" startPc="268435832"/>
+        <entry endPc="268435974" name="pos" stackId="7" startPc="268435832"/>
+        <entry endPc="268435964" name="size" stackId="8" startPc="268435863"/>
+        <entry endPc="268435964" name="end" stackId="9" startPc="268435863"/>
+        <entry arg="true" endPc="268436137" name="durs" stackId="1" startPc="268435987"/>
+        <entry endPc="268436137" name="out" stackId="2" startPc="268435998"/>
+        <entry endPc="268436137" name="bookOffset" stackId="3" startPc="268435998"/>
+        <entry endPc="268436134" name="f" stackId="4" startPc="268436021"/>
+        <entry endPc="268436124" name="d" stackId="5" startPc="268436021"/>
+        <entry endPc="268436124" name="pos" stackId="6" startPc="268436021"/>
+        <entry endPc="268436114" name="size" stackId="7" startPc="268436052"/>
+        <entry endPc="268436114" name="end" stackId="8" startPc="268436052"/>
+        <entry arg="true" endPc="268436163" name="code" stackId="1" startPc="268436138"/>
+        <entry arg="true" endPc="268436163" name="data" stackId="2" startPc="268436138"/>
+        <entry arg="true" endPc="268436207" name="code" stackId="1" startPc="268436182"/>
+        <entry arg="true" endPc="268436207" name="data" stackId="2" startPc="268436182"/>
+        <entry arg="true" endPc="268436574" name="code" stackId="1" startPc="268436208"/>
+        <entry arg="true" endPc="268436574" name="data" stackId="2" startPc="268436208"/>
+        <entry arg="true" endPc="268436574" name="key" stackId="3" startPc="268436208"/>
+        <entry arg="true" endPc="268436574" name="filterType" stackId="4" startPc="268436208"/>
+        <entry endPc="268436573" name="groups" stackId="5" startPc="268436211"/>
+        <entry endPc="268436573" name="m" stackId="6" startPc="268436211"/>
+        <entry endPc="268436531" name="i" stackId="7" startPc="268436426"/>
+        <entry endPc="268436521" name="g" stackId="8" startPc="268436426"/>
+        <entry endPc="268436521" name="sub" stackId="9" startPc="268436426"/>
+        <entry arg="true" endPc="268436594" name="code" stackId="1" startPc="268436575"/>
+        <entry arg="true" endPc="268436594" name="data" stackId="2" startPc="268436575"/>
+        <entry arg="true" endPc="268436620" name="code" stackId="1" startPc="268436595"/>
+        <entry arg="true" endPc="268436620" name="data" stackId="2" startPc="268436595"/>
+        <entry arg="true" endPc="268436644" name="libId" stackId="1" startPc="268436621"/>
+        <entry arg="true" endPc="268436843" name="item" stackId="1" startPc="268436645"/>
+        <entry endPc="268436842" name="mode" stackId="2" startPc="268436648"/>
+        <entry endPc="268437136" name="toDelete" stackId="1" startPc="268436847"/>
+        <entry endPc="268436964" name="j" stackId="2" startPc="268436867"/>
+        <entry endPc="268436964" name="changed" stackId="3" startPc="268436867"/>
+        <entry endPc="268436936" name="i" stackId="4" startPc="268436894"/>
+        <entry endPc="268437136" name="remaining" stackId="5" startPc="268436847"/>
+        <entry endPc="268437136" name="itemIds" stackId="6" startPc="268436847"/>
+        <entry endPc="268437090" name="i" stackId="7" startPc="268437015"/>
+        <entry endPc="268437080" name="job" stackId="8" startPc="268437015"/>
+        <entry endPc="268437080" name="left" stackId="9" startPc="268437015"/>
+        <entry endPc="268437173" name="d" stackId="1" startPc="268437141"/>
+        <entry endPc="268437522" name="j" stackId="1" startPc="268437177"/>
+        <entry endPc="268437522" name="itemIds" stackId="2" startPc="268437177"/>
+        <entry endPc="268437522" name="itemId" stackId="3" startPc="268437177"/>
+        <entry endPc="268437522" name="job" stackId="4" startPc="268437177"/>
+        <entry endPc="268437522" name="c" stackId="5" startPc="268437177"/>
+        <entry endPc="268437522" name="options" stackId="6" startPc="268437177"/>
+        <entry endPc="268437522" name="context" stackId="7" startPc="268437177"/>
+        <entry endPc="268437522" name="delegate" stackId="8" startPc="268437177"/>
+        <entry endPc="268437522" name="url" stackId="9" startPc="268437177"/>
+        <entry arg="true" endPc="268437639" name="itemId" stackId="1" startPc="268437524"/>
+        <entry endPc="268437638" name="index" stackId="2" startPc="268437527"/>
+        <entry endPc="268437606" name="i" stackId="3" startPc="268437575"/>
+        <entry endPc="268437675" name="j" stackId="1" startPc="268437643"/>
+        <entry endPc="268437751" name="pct" stackId="1" startPc="268437679"/>
+        <entry arg="true" endPc="268438034" name="toDelete" stackId="1" startPc="268437753"/>
+        <entry endPc="268437836" name="i" stackId="2" startPc="268437788"/>
+        <entry endPc="268438033" name="fresh" stackId="3" startPc="268437756"/>
+        <entry endPc="268438033" name="remaining" stackId="4" startPc="268437756"/>
+        <entry endPc="268437911" name="i" stackId="5" startPc="268437865"/>
+        <entry endPc="268438033" name="index" stackId="6" startPc="268437756"/>
+        <entry arg="true" endPc="268438339" name="code" stackId="1" startPc="268438035"/>
+        <entry arg="true" endPc="268438339" name="data" stackId="2" startPc="268438035"/>
+        <entry arg="true" endPc="268438339" name="context" stackId="3" startPc="268438035"/>
+        <entry endPc="268438338" name="itemId" stackId="4" startPc="268438038"/>
+        <entry endPc="268438338" name="refId" stackId="5" startPc="268438038"/>
+        <entry endPc="268438338" name="j" stackId="6" startPc="268438038"/>
+        <entry endPc="268438338" name="job" stackId="7" startPc="268438038"/>
+        <entry endPc="268438338" name="k" stackId="8" startPc="268438038"/>
+        <entry arg="true" endPc="268438393" name="arr" stackId="1" startPc="268438340"/>
+        <entry arg="true" endPc="268438393" name="itemId" stackId="2" startPc="268438340"/>
+        <entry endPc="268438391" name="i" stackId="3" startPc="268438359"/>
+        <entry arg="true" endPc="268438541" name="itemId" stackId="1" startPc="268438422"/>
+        <entry endPc="268438540" name="index" stackId="2" startPc="268438425"/>
+        <entry endPc="268438540" name="out" stackId="3" startPc="268438425"/>
+        <entry endPc="268438520" name="i" stackId="4" startPc="268438474"/>
+        <entry arg="true" endPc="268438686" name="code" stackId="1" startPc="268438667"/>
+        <entry arg="true" endPc="268438686" name="data" stackId="2" startPc="268438667"/>
+        <entry arg="true" endPc="268438719" name="libId" stackId="1" startPc="268438687"/>
+        <entry arg="true" endPc="268438719" name="filterType" stackId="2" startPc="268438687"/>
+        <entry arg="true" endPc="268438765" name="item" stackId="1" startPc="268438720"/>
+        <entry arg="true" endPc="268438801" name="code" stackId="1" startPc="268438766"/>
+        <entry arg="true" endPc="268438801" name="data" stackId="2" startPc="268438766"/>
+        <entry arg="true" endPc="268438857" name="item" stackId="1" startPc="268438835"/>
+        <entry arg="true" endPc="268438976" name="args" stackId="1" startPc="268438956"/>
+        <entry endPc="268439180" name="version" stackId="1" startPc="268439001"/>
+        <entry endPc="268439165" name="server" stackId="2" startPc="268439028"/>
+        <entry endPc="268439165" name="token" stackId="3" startPc="268439028"/>
+        <entry arg="true" endPc="268439502" name="refId" stackId="1" startPc="268439254"/>
+        <entry arg="true" endPc="268439502" name="positionInChapter" stackId="2" startPc="268439254"/>
+        <entry endPc="268439448" name="index" stackId="3" startPc="268439284"/>
+        <entry endPc="268439448" name="b" stackId="4" startPc="268439341"/>
+        <entry endPc="268439438" name="perBook" stackId="5" startPc="268439341"/>
+        <entry endPc="268439438" name="refIds" stackId="6" startPc="268439341"/>
+        <entry endPc="268439438" name="i" stackId="7" startPc="268439392"/>
+        <entry endPc="268439501" name="hit" stackId="8" startPc="268439257"/>
+        <entry endPc="268439501" name="absolute" stackId="9" startPc="268439257"/>
+        <entry arg="true" endPc="268439586" name="refId" stackId="1" startPc="268439536"/>
+        <entry arg="true" endPc="268439586" name="songEvent" stackId="2" startPc="268439536"/>
+        <entry arg="true" endPc="268439586" name="playbackPosition" stackId="3" startPc="268439536"/>
+        <entry arg="true" endPc="268439864" name="itemId" stackId="1" startPc="268439623"/>
+        <entry endPc="268439863" name="last" stackId="2" startPc="268439634"/>
+        <entry endPc="268439840" name="p" stackId="3" startPc="268439690"/>
+        <entry endPc="268439830" name="arr" stackId="4" startPc="268439690"/>
+        <entry endPc="268439802" name="i" stackId="5" startPc="268439739"/>
+        <entry arg="true" endPc="268439897" name="itemId" stackId="1" startPc="268439865"/>
+        <entry arg="true" endPc="268439981" name="itemId" stackId="1" startPc="268439898"/>
+        <entry endPc="268439981" name="total" stackId="2" startPc="268439909"/>
+        <entry endPc="268439981" name="p" stackId="3" startPc="268439909"/>
+        <entry endPc="268439975" name="arr" stackId="4" startPc="268439919"/>
+        <entry arg="true" endPc="268440178" name="itemId" stackId="1" startPc="268439982"/>
+        <entry arg="true" endPc="268440178" name="order" stackId="2" startPc="268439982"/>
+        <entry arg="true" endPc="268440178" name="out" stackId="3" startPc="268439982"/>
+        <entry endPc="268440177" name="meta" stackId="4" startPc="268439993"/>
+        <entry endPc="268440177" name="starts" stackId="5" startPc="268439993"/>
+        <entry endPc="268440177" name="k" stackId="6" startPc="268439993"/>
+        <entry endPc="268440177" name="p" stackId="7" startPc="268439993"/>
+        <entry endPc="268440174" name="arr" stackId="8" startPc="268440047"/>
+        <entry endPc="268440167" name="i" stackId="9" startPc="268440101"/>
+        <entry arg="true" endPc="268440414" name="itemId" stackId="1" startPc="268440179"/>
+        <entry arg="true" endPc="268440414" name="k" stackId="2" startPc="268440179"/>
+        <entry arg="true" endPc="268440414" name="refId" stackId="3" startPc="268440179"/>
+        <entry endPc="268440413" name="p" stackId="4" startPc="268440190"/>
+        <entry endPc="268440413" name="idx" stackId="5" startPc="268440190"/>
+        <entry endPc="268440413" name="arr" stackId="6" startPc="268440190"/>
+        <entry endPc="268440344" name="old" stackId="7" startPc="268440267"/>
+        <entry arg="true" endPc="268440442" name="itemId" stackId="1" startPc="268440415"/>
+        <entry arg="true" endPc="268440442" name="p" stackId="2" startPc="268440415"/>
+        <entry arg="true" endPc="268440461" name="itemId" stackId="1" startPc="268440443"/>
+        <entry arg="true" endPc="268440533" name="itemId" stackId="1" startPc="268440462"/>
+        <entry arg="true" endPc="268440533" name="title" stackId="2" startPc="268440462"/>
+        <entry arg="true" endPc="268440533" name="durs" stackId="3" startPc="268440462"/>
+        <entry arg="true" endPc="268440741" name="idx" stackId="1" startPc="268440593"/>
+        <entry endPc="268440731" name="e" stackId="2" startPc="268440674"/>
+        <entry arg="true" endPc="268440821" name="arr" stackId="1" startPc="268440788"/>
+        <entry arg="true" endPc="268440821" name="j" stackId="2" startPc="268440788"/>
+        <entry endPc="268440820" name="tmp" stackId="3" startPc="268440791"/>
+        <entry endPc="268441017" name="profile" stackId="1" startPc="268440892"/>
+        <entry arg="true" endPc="268441123" name="orderA" stackId="1" startPc="268441099"/>
+        <entry arg="true" endPc="268441123" name="startA" stackId="2" startPc="268441099"/>
+        <entry arg="true" endPc="268441123" name="orderB" stackId="3" startPc="268441099"/>
+        <entry arg="true" endPc="268441123" name="startB" stackId="4" startPc="268441099"/>
+        <entry endPc="268441213" name="i" stackId="1" startPc="268441150"/>
+        <entry endPc="268441203" name="j" stackId="2" startPc="268441150"/>
+        <entry endPc="268441203" name="tmp" stackId="3" startPc="268441150"/>
+        <entry endPc="268441604" name="orders" stackId="1" startPc="268441226"/>
+        <entry endPc="268441604" name="starts" stackId="2" startPc="268441226"/>
+        <entry endPc="268441604" name="lookup" stackId="3" startPc="268441226"/>
+        <entry endPc="268441604" name="index" stackId="4" startPc="268441226"/>
+        <entry endPc="268441326" name="b" stackId="5" startPc="268441295"/>
+        <entry endPc="268441604" name="iter" stackId="6" startPc="268441226"/>
+        <entry endPc="268441459" name="ref" stackId="7" startPc="268441360"/>
+        <entry endPc="268441456" name="refId" stackId="8" startPc="268441376"/>
+        <entry endPc="268441456" name="info" stackId="9" startPc="268441376"/>
+        <entry endPc="268441596" name="i" stackId="10" startPc="268441484"/>
+        <entry endPc="268441586" name="j" stackId="11" startPc="268441484"/>
+        <entry endPc="268441763" name="v" stackId="1" startPc="268441718"/>
+        <entry arg="true" endPc="268441822" name="server" stackId="1" startPc="268441764"/>
+        <entry arg="true" endPc="268441822" name="token" stackId="2" startPc="268441764"/>
+        <entry arg="true" endPc="268441851" name="libId" stackId="1" startPc="268441823"/>
+        <entry arg="true" endPc="268441851" name="cb" stackId="2" startPc="268441823"/>
+        <entry arg="true" endPc="268441962" name="server" stackId="1" startPc="268441869"/>
+        <entry arg="true" endPc="268441962" name="username" stackId="2" startPc="268441869"/>
+        <entry arg="true" endPc="268441962" name="password" stackId="3" startPc="268441869"/>
+        <entry arg="true" endPc="268441962" name="cb" stackId="4" startPc="268441869"/>
+        <entry arg="true" endPc="268442045" name="itemId" stackId="1" startPc="268441963"/>
+        <entry arg="true" endPc="268442045" name="cb" stackId="2" startPc="268441963"/>
+        <entry arg="true" endPc="268442114" name="key" stackId="1" startPc="268442046"/>
+        <entry endPc="268442114" name="v" stackId="2" startPc="268442057"/>
+        <entry arg="true" endPc="268442224" name="libId" stackId="1" startPc="268442115"/>
+        <entry arg="true" endPc="268442224" name="filterType" stackId="2" startPc="268442115"/>
+        <entry arg="true" endPc="268442224" name="filterId" stackId="3" startPc="268442115"/>
+        <entry arg="true" endPc="268442224" name="cb" stackId="4" startPc="268442115"/>
+        <entry endPc="268442223" name="params" stackId="5" startPc="268442126"/>
+        <entry arg="true" endPc="268442425" name="itemId" stackId="1" startPc="268442272"/>
+        <entry arg="true" endPc="268442425" name="currentTimeSec" stackId="2" startPc="268442272"/>
+        <entry arg="true" endPc="268442425" name="durationSec" stackId="3" startPc="268442272"/>
+        <entry endPc="268442424" name="params" stackId="4" startPc="268442283"/>
+        <entry arg="true" endPc="268442454" name="libId" stackId="1" startPc="268442426"/>
+        <entry arg="true" endPc="268442454" name="cb" stackId="2" startPc="268442426"/>
+        <entry arg="true" endPc="268442507" name="detail" stackId="1" startPc="268442455"/>
+        <entry endPc="268442507" name="p" stackId="2" startPc="268442466"/>
+        <entry arg="true" endPc="268442536" name="libId" stackId="1" startPc="268442508"/>
+        <entry arg="true" endPc="268442536" name="cb" stackId="2" startPc="268442508"/>
+        <entry arg="true" endPc="268442612" name="itemId" stackId="1" startPc="268442537"/>
+        <entry arg="true" endPc="268442612" name="ino" stackId="2" startPc="268442537"/>
+        <entry arg="true" endPc="268442612" name="startSec" stackId="3" startPc="268442537"/>
+        <entry arg="true" endPc="268442612" name="endSec" stackId="4" startPc="268442537"/>
+        <entry arg="true" endPc="268442715" name="url" stackId="1" startPc="268442613"/>
+        <entry endPc="268442862" name="v" stackId="1" startPc="268442727"/>
+        <entry arg="true" endPc="268442937" name="callback" stackId="1" startPc="268442863"/>
+        <entry arg="true" endPc="268443017" name="path" stackId="1" startPc="268442938"/>
+        <entry arg="true" endPc="268443017" name="libId" stackId="2" startPc="268442938"/>
+        <entry arg="true" endPc="268443017" name="cb" stackId="3" startPc="268442938"/>
+        <entry arg="true" endPc="268443042" name="text" stackId="1" startPc="268443018"/>
+        <entry arg="true" endPc="268443042" name="changed" stackId="2" startPc="268443018"/>
+        <entry arg="true" endPc="268443091" name="view" stackId="1" startPc="268443059"/>
+        <entry arg="true" endPc="268443091" name="field" stackId="2" startPc="268443059"/>
+        <entry arg="true" endPc="268443126" name="url" stackId="1" startPc="268443092"/>
+        <entry arg="true" endPc="268443126" name="params" stackId="2" startPc="268443092"/>
+        <entry arg="true" endPc="268443126" name="options" stackId="3" startPc="268443092"/>
+        <entry arg="true" endPc="268443147" name="callback" stackId="1" startPc="268443127"/>
+        <entry arg="true" endPc="268443147" name="context" stackId="2" startPc="268443127"/>
+        <entry arg="true" endPc="268443173" name="code" stackId="1" startPc="268443148"/>
+        <entry arg="true" endPc="268443173" name="data" stackId="2" startPc="268443148"/>
+        <entry arg="true" endPc="268443572" name="libId" stackId="1" startPc="268443174"/>
+        <entry endPc="268443571" name="m" stackId="2" startPc="268443185"/>
+        <entry arg="true" endPc="268443944" name="code" stackId="1" startPc="268443573"/>
+        <entry arg="true" endPc="268443944" name="data" stackId="2" startPc="268443573"/>
+        <entry endPc="268443943" name="books" stackId="3" startPc="268443584"/>
+        <entry endPc="268443943" name="m" stackId="4" startPc="268443584"/>
+        <entry endPc="268443904" name="i" stackId="5" startPc="268443831"/>
+        <entry endPc="268443894" name="b" stackId="6" startPc="268443831"/>
+        <entry arg="true" endPc="268444275" name="code" stackId="1" startPc="268443945"/>
+        <entry arg="true" endPc="268444275" name="data" stackId="2" startPc="268443945"/>
+        <entry endPc="268444207" name="libs" stackId="3" startPc="268443975"/>
+        <entry endPc="268444207" name="menu" stackId="4" startPc="268443975"/>
+        <entry endPc="268444172" name="i" stackId="5" startPc="268444067"/>
+        <entry endPc="268444162" name="lib" stackId="6" startPc="268444067"/>
+        <entry arg="true" endPc="268444492" name="dc" stackId="1" startPc="268444415"/>
+        <entry arg="true" endPc="268445274" name="code" stackId="1" startPc="268444568"/>
+        <entry arg="true" endPc="268445274" name="data" stackId="2" startPc="268444568"/>
+        <entry endPc="268445273" name="files" stackId="3" startPc="268444571"/>
+        <entry endPc="268445273" name="title" stackId="4" startPc="268444571"/>
+        <entry endPc="268445273" name="inos" stackId="5" startPc="268444571"/>
+        <entry endPc="268445273" name="durs" stackId="6" startPc="268444571"/>
+        <entry endPc="268444861" name="f" stackId="7" startPc="268444778"/>
+        <entry endPc="268444851" name="dur" stackId="8" startPc="268444778"/>
+        <entry endPc="268445273" name="expected" stackId="9" startPc="268444571"/>
+        <entry endPc="268445273" name="have" stackId="10" startPc="268444571"/>
+        <entry endPc="268445273" name="jobs" stackId="11" startPc="268444571"/>
+        <entry arg="true" endPc="268445291" name="v" stackId="1" startPc="268445275"/>
+        <entry arg="true" endPc="268445291" name="dflt" stackId="2" startPc="268445275"/>
+        <entry arg="true" endPc="268445339" name="item" stackId="1" startPc="268445292"/>
+        <entry arg="true" endPc="268445551" name="code" stackId="1" startPc="268445340"/>
+        <entry arg="true" endPc="268445551" name="data" stackId="2" startPc="268445340"/>
+        <entry arg="true" endPc="268445670" name="state" stackId="1" startPc="268445552"/>
+        <entry arg="true" endPc="268445756" name="field" stackId="1" startPc="268445671"/>
+        <entry arg="true" endPc="268445756" name="text" stackId="2" startPc="268445671"/>
+        <entry endPc="268446410" name="s" stackId="1" startPc="268446307"/>
+        <entry arg="true" endPc="268446524" name="dc" stackId="1" startPc="268446447"/>
+        <entry arg="true" endPc="268446730" name="itemIds" stackId="1" startPc="268446525"/>
+        <entry endPc="268446729" name="deleteList" stackId="2" startPc="268446528"/>
+        <entry endPc="268446616" name="i" stackId="3" startPc="268446592"/>
+        <entry arg="true" endPc="268447271" name="item" stackId="1" startPc="268446764"/>
+        <entry endPc="268447270" name="id" stackId="2" startPc="268446767"/>
+        <entry endPc="268447249" name="index" stackId="3" startPc="268447206"/>
+        <entry arg="true" endPc="268447329" name="message" stackId="1" startPc="268447306"/>
+        <entry arg="true" endPc="268447407" name="dc" stackId="1" startPc="268447330"/>
+        <entry endPc="268447528" name="stats" stackId="1" startPc="268447411"/>
+        <entry endPc="268447528" name="used" stackId="2" startPc="268447411"/>
+        <entry endPc="268447528" name="mb" stackId="3" startPc="268447411"/>
+        <entry endPc="268447614" name="jobs" stackId="1" startPc="268447532"/>
+        <entry endPc="268447614" name="deleteList" stackId="2" startPc="268447532"/>
+        <entry endPc="268448259" name="index" stackId="1" startPc="268447618"/>
+        <entry endPc="268448259" name="i" stackId="2" startPc="268448100"/>
+        <entry endPc="268448249" name="itemId" stackId="3" startPc="268448100"/>
+        <entry endPc="268448249" name="meta" stackId="4" startPc="268448100"/>
+        <entry endPc="268448249" name="title" stackId="5" startPc="268448100"/>
+        <entry endPc="268448249" name="count" stackId="6" startPc="268448100"/>
+        <entry endPc="268448249" name="sub" stackId="7" startPc="268448100"/>
+    </localVars>
+    <deviceInfo deviceVersion="e6263c2a80ff43933f83afa71f1f6645dc2cb4a3" partNumber="006-B4533-00"/>
+    <annotations>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="queued"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldServer"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="byAuthor"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errNone"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="AppName"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errNoAudio"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="deleteAllDownloads"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingApiKeyPrompt"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldUser"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingServerUrlPrompt"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loggingIn"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingServerUrl"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="deleting"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errItems"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldPass"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingApiKey"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="clearQueue"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="logIn"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="browseLibrary"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="pickBook"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="alreadyDownloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="bySeries"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loginFailed"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="byCollection"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errLibraries"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="pickLibrary"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="playDownloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loading"/>
+        <annotationEntry annotation="initialized" class="Drawables" module="globals/Rez" symbol="providerIcon"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errDetail"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="allBooks"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="logOut"/>
+        <annotationEntry annotation="initialized" class="Drawables" module="globals/Rez" symbol="launcher"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="downloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="queueCleared"/>
+    </annotations>
+    <dataEntryOffsetMappings>
+        <dataEntry label="globals" offset="121" parentId="" symbolId="globals" type="module"/>
+        <dataEntry label="globals/Chunks" offset="404" parentId="globals" symbolId="Chunks" type="module"/>
+        <dataEntry label="globals/BrowseDelegate" offset="457" parentId="globals" symbolId="BrowseDelegate" type="class"/>
+        <dataEntry label="globals/SyncDelegate" offset="573" parentId="globals" symbolId="SyncDelegate" type="class"/>
+        <dataEntry label="globals/Rez" offset="743" parentId="globals" symbolId="Rez" type="module"/>
+        <dataEntry label="globals/LoginCreds" offset="787" parentId="globals" symbolId="LoginCreds" type="class"/>
+        <dataEntry label="globals/GroupDelegate" offset="858" parentId="globals" symbolId="GroupDelegate" type="class"/>
+        <dataEntry label="globals/Store" offset="947" parentId="globals" symbolId="Store" type="module"/>
+        <dataEntry label="globals/AbsProgressListener" offset="973" parentId="globals" symbolId="AbsProgressListener" type="class"/>
+        <dataEntry label="globals/LibraryMenuDelegate" offset="1026" parentId="globals" symbolId="LibraryMenuDelegate" type="class"/>
+        <dataEntry label="globals/WatchShelfApp" offset="1088" parentId="globals" symbolId="WatchShelfApp" type="class"/>
+        <dataEntry label="globals/Settings" offset="1177" parentId="globals" symbolId="Settings" type="module"/>
+        <dataEntry label="globals/ContentDelegate" offset="1203" parentId="globals" symbolId="ContentDelegate" type="class"/>
+        <dataEntry label="globals/BookStore" offset="1337" parentId="globals" symbolId="BookStore" type="module"/>
+        <dataEntry label="globals/ContentIterator" offset="1435" parentId="globals" symbolId="ContentIterator" type="class"/>
+        <dataEntry label="globals/Login" offset="1632" parentId="globals" symbolId="Login" type="module"/>
+        <dataEntry label="globals/AbsApi" offset="1667" parentId="globals" symbolId="AbsApi" type="module"/>
+        <dataEntry label="globals/FieldDelegate" offset="1864" parentId="globals" symbolId="FieldDelegate" type="class"/>
+        <dataEntry label="globals/RequestDelegate" offset="1944" parentId="globals" symbolId="RequestDelegate" type="class"/>
+        <dataEntry label="globals/Browse" offset="2024" parentId="globals" symbolId="Browse" type="module"/>
+        <dataEntry label="globals/Versions" offset="2068" parentId="globals" symbolId="Versions" type="module"/>
+        <dataEntry label="globals/LibraryView" offset="2094" parentId="globals" symbolId="LibraryView" type="class"/>
+        <dataEntry label="globals/LibraryViewDelegate" offset="2183" parentId="globals" symbolId="LibraryViewDelegate" type="class"/>
+        <dataEntry label="globals/BookMenuDelegate" offset="2236" parentId="globals" symbolId="BookMenuDelegate" type="class"/>
+        <dataEntry label="globals/LoginView" offset="2325" parentId="globals" symbolId="LoginView" type="class"/>
+        <dataEntry label="globals/DownloadedMenuDelegate" offset="2477" parentId="globals" symbolId="DownloadedMenuDelegate" type="class"/>
+        <dataEntry label="globals/ErrorViewDelegate" offset="2548" parentId="globals" symbolId="ErrorViewDelegate" type="class"/>
+        <dataEntry label="globals/ErrorView" offset="2601" parentId="globals" symbolId="ErrorView" type="class"/>
+        <dataEntry label="globals/DownloadedMenu" offset="2663" parentId="globals" symbolId="DownloadedMenu" type="class"/>
+        <dataEntry label="globals/Rez/Drawables" offset="2725" parentId="Rez" symbolId="Drawables" type="module"/>
+        <dataEntry label="globals/Rez/Strings" offset="2769" parentId="Rez" symbolId="Strings" type="module"/>
+    </dataEntryOffsetMappings>
+    <functions>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Chunks">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435471" name="&lt;init&gt;" parent="BrowseDelegate" startPc="268435460">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435483" name="&lt;init&gt;" parent="SyncDelegate" startPc="268435472">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435503" name="&lt;init&gt;" parent="Rez" startPc="268435484">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="LoginCreds">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435515" name="&lt;init&gt;" parent="GroupDelegate" startPc="268435504">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Store">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="AbsProgressListener">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435527" name="&lt;init&gt;" parent="LibraryMenuDelegate" startPc="268435516">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435539" name="&lt;init&gt;" parent="WatchShelfApp" startPc="268435528">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Settings">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435551" name="&lt;init&gt;" parent="ContentDelegate" startPc="268435540">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="BookStore">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435563" name="&lt;init&gt;" parent="ContentIterator" startPc="268435552">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Login">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="AbsApi">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435575" name="&lt;init&gt;" parent="FieldDelegate" startPc="268435564">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="RequestDelegate">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Browse">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Versions">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435587" name="&lt;init&gt;" parent="LibraryView" startPc="268435576">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435599" name="&lt;init&gt;" parent="LibraryViewDelegate" startPc="268435588">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435611" name="&lt;init&gt;" parent="BookMenuDelegate" startPc="268435600">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435623" name="&lt;init&gt;" parent="LoginView" startPc="268435612">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435635" name="&lt;init&gt;" parent="DownloadedMenuDelegate" startPc="268435624">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435647" name="&lt;init&gt;" parent="ErrorViewDelegate" startPc="268435636">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435659" name="&lt;init&gt;" parent="ErrorView" startPc="268435648">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435671" name="&lt;init&gt;" parent="DownloadedMenu" startPc="268435660">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435798" name="total" parent="Chunks" startPc="268435672">
+            <param id="durs"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435986" name="at" parent="Chunks" startPc="268435799">
+            <param id="durs"/>
+            <param id="k"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436137" name="starts" parent="Chunks" startPc="268435987">
+            <param id="durs"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436163" name="onSeries" parent="BrowseDelegate" startPc="268436138">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436181" name="onBack" parent="BrowseDelegate" startPc="268436164">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436207" name="onAuthors" parent="BrowseDelegate" startPc="268436182">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436574" name="pushGroups" parent="BrowseDelegate" startPc="268436208">
+            <param id="code"/>
+            <param id="data"/>
+            <param id="key"/>
+            <param id="filterType"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436594" name="onBooks" parent="BrowseDelegate" startPc="268436575">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436620" name="onCollections" parent="BrowseDelegate" startPc="268436595">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436644" name="initialize" parent="BrowseDelegate" startPc="268436621">
+            <param id="libId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436843" name="onSelect" parent="BrowseDelegate" startPc="268436645">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437137" name="onStartSync" parent="SyncDelegate" startPc="268436844">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437173" name="deletes" parent="SyncDelegate" startPc="268437138">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437523" name="downloadNext" parent="SyncDelegate" startPc="268437174">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437639" name="addToIndex" parent="SyncDelegate" startPc="268437524">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437675" name="jobs" parent="SyncDelegate" startPc="268437640">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437752" name="onOpDone" parent="SyncDelegate" startPc="268437676">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438034" name="deleteQueued" parent="SyncDelegate" startPc="268437753">
+            <param id="toDelete"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438339" name="onTrackDownloaded" parent="SyncDelegate" startPc="268438035">
+            <param id="code"/>
+            <param id="data"/>
+            <param id="context"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438393" name="containsId" parent="SyncDelegate" startPc="268438340">
+            <param id="arr"/>
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438421" name="onStopSync" parent="SyncDelegate" startPc="268438394">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438541" name="removeFromIndex" parent="SyncDelegate" startPc="268438422">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438572" name="initialize" parent="SyncDelegate" startPc="268438542">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438609" name="isSyncNeeded" parent="SyncDelegate" startPc="268438573">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Drawables">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Strings">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438648" name="initialize" parent="LoginCreds" startPc="268438610">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438666" name="onBack" parent="GroupDelegate" startPc="268438649">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438686" name="onBooks" parent="GroupDelegate" startPc="268438667">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438719" name="initialize" parent="GroupDelegate" startPc="268438687">
+            <param id="libId"/>
+            <param id="filterType"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438765" name="onSelect" parent="GroupDelegate" startPc="268438720">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438801" name="onResponse" parent="AbsProgressListener" startPc="268438766">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="initialize" parent="AbsProgressListener">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438819" name="onBack" parent="LibraryMenuDelegate" startPc="268438802">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438834" name="initialize" parent="LibraryMenuDelegate" startPc="268438820">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438857" name="onSelect" parent="LibraryMenuDelegate" startPc="268438835">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438906" name="getProviderIconInfo" parent="WatchShelfApp" startPc="268438858">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438955" name="getPlaybackConfigurationView" parent="WatchShelfApp" startPc="268438907">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438976" name="getContentDelegate" parent="WatchShelfApp" startPc="268438956">
+            <param id="args"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438997" name="getSyncDelegate" parent="WatchShelfApp" startPc="268438977">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439181" name="initialize" parent="WatchShelfApp" startPc="268438998">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439230" name="getSyncConfigurationView" parent="WatchShelfApp" startPc="268439182">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439245" name="onShuffle" parent="ContentDelegate" startPc="268439231">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439253" name="getContentIterator" parent="ContentDelegate" startPc="268439246">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439502" name="syncProgress" parent="ContentDelegate" startPc="268439254">
+            <param id="refId"/>
+            <param id="positionInChapter"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439505" name="onThumbsUp" parent="ContentDelegate" startPc="268439503">
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439535" name="initialize" parent="ContentDelegate" startPc="268439506">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439586" name="onSong" parent="ContentDelegate" startPc="268439536">
+            <param id="refId"/>
+            <param id="songEvent"/>
+            <param id="playbackPosition"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="onRepeat" parent="ContentDelegate">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439619" name="resetContentIterator" parent="ContentDelegate" startPc="268439587">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439622" name="onThumbsDown" parent="ContentDelegate" startPc="268439620">
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439864" name="deleteBook" parent="BookStore" startPc="268439623">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439897" name="get" parent="BookStore" startPc="268439865">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439981" name="count" parent="BookStore" startPc="268439898">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440178" name="addLookup" parent="BookStore" startPc="268439982">
+            <param id="itemId"/>
+            <param id="order"/>
+            <param id="out"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440414" name="saveChunk" parent="BookStore" startPc="268440179">
+            <param id="itemId"/>
+            <param id="k"/>
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440442" name="pageKey" parent="BookStore" startPc="268440415">
+            <param id="itemId"/>
+            <param id="p"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440461" name="key" parent="BookStore" startPc="268440443">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440533" name="ensureMeta" parent="BookStore" startPc="268440462">
+            <param id="itemId"/>
+            <param id="title"/>
+            <param id="durs"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440592" name="next" parent="ContentIterator" startPc="268440534">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440741" name="objAt" parent="ContentIterator" startPc="268440593">
+            <param id="idx"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440787" name="previous" parent="ContentIterator" startPc="268440742">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440821" name="swap" parent="ContentIterator" startPc="268440788">
+            <param id="arr"/>
+            <param id="j"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440840" name="peekPrevious" parent="ContentIterator" startPc="268440822">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440844" name="canSkip" parent="ContentIterator" startPc="268440841">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440888" name="toggleShuffle" parent="ContentIterator" startPc="268440845">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441017" name="getPlaybackProfile" parent="ContentIterator" startPc="268440889">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441036" name="peekNext" parent="ContentIterator" startPc="268441018">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441052" name="get" parent="ContentIterator" startPc="268441037">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441060" name="shuffling" parent="ContentIterator" startPc="268441053">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441098" name="initialize" parent="ContentIterator" startPc="268441061">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441123" name="after" parent="ContentIterator" startPc="268441099">
+            <param id="orderA"/>
+            <param id="startA"/>
+            <param id="orderB"/>
+            <param id="startB"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441222" name="shuffle" parent="ContentIterator" startPc="268441124">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441605" name="buildPlaylist" parent="ContentIterator" startPc="268441223">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441675" name="start" parent="Login" startPc="268441606">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441706" name="isConfigured" parent="AbsApi" startPc="268441676">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441763" name="authToken" parent="AbsApi" startPc="268441707">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441822" name="saveLogin" parent="AbsApi" startPc="268441764">
+            <param id="server"/>
+            <param id="token"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441851" name="getCollections" parent="AbsApi" startPc="268441823">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441868" name="sidecarBase" parent="AbsApi" startPc="268441852">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441962" name="login" parent="AbsApi" startPc="268441869">
+            <param id="server"/>
+            <param id="username"/>
+            <param id="password"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442045" name="getFiles" parent="AbsApi" startPc="268441963">
+            <param id="itemId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442114" name="_prop" parent="AbsApi" startPc="268442046">
+            <param id="key"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442224" name="getBookList" parent="AbsApi" startPc="268442115">
+            <param id="libId"/>
+            <param id="filterType"/>
+            <param id="filterId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442271" name="logout" parent="AbsApi" startPc="268442225">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442425" name="patchProgress" parent="AbsApi" startPc="268442272">
+            <param id="itemId"/>
+            <param id="currentTimeSec"/>
+            <param id="durationSec"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442454" name="getSeries" parent="AbsApi" startPc="268442426">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442507" name="progressSeconds" parent="AbsApi" startPc="268442455">
+            <param id="detail"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442536" name="getAuthors" parent="AbsApi" startPc="268442508">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442612" name="sidecarChunkUrl" parent="AbsApi" startPc="268442537">
+            <param id="itemId"/>
+            <param id="ino"/>
+            <param id="startSec"/>
+            <param id="endSec"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442715" name="_noSlash" parent="AbsApi" startPc="268442613">
+            <param id="url"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442862" name="serverUrl" parent="AbsApi" startPc="268442716">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442937" name="getLibraries" parent="AbsApi" startPc="268442863">
+            <param id="callback"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443017" name="getGroups" parent="AbsApi" startPc="268442938">
+            <param id="path"/>
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443042" name="onTextEntered" parent="FieldDelegate" startPc="268443018">
+            <param id="text"/>
+            <param id="changed"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443058" name="onCancel" parent="FieldDelegate" startPc="268443043">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443091" name="initialize" parent="FieldDelegate" startPc="268443059">
+            <param id="view"/>
+            <param id="field"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443126" name="makeWebRequest" parent="RequestDelegate" startPc="268443092">
+            <param id="url"/>
+            <param id="params"/>
+            <param id="options"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443147" name="initialize" parent="RequestDelegate" startPc="268443127">
+            <param id="callback"/>
+            <param id="context"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443173" name="onWebResponse" parent="RequestDelegate" startPc="268443148">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443572" name="start" parent="Browse" startPc="268443174">
+            <param id="libId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443944" name="showBooks" parent="Browse" startPc="268443573">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444275" name="onLibraries" parent="LibraryView" startPc="268443945">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444353" name="onShow" parent="LibraryView" startPc="268444276">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444414" name="initialize" parent="LibraryView" startPc="268444354">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444492" name="onUpdate" parent="LibraryView" startPc="268444415">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444511" name="onBack" parent="LibraryViewDelegate" startPc="268444493">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444526" name="initialize" parent="LibraryViewDelegate" startPc="268444512">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444544" name="onBack" parent="BookMenuDelegate" startPc="268444527">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444567" name="initialize" parent="BookMenuDelegate" startPc="268444545">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445274" name="onFiles" parent="BookMenuDelegate" startPc="268444568">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445291" name="numOr" parent="BookMenuDelegate" startPc="268445275">
+            <param id="v"/>
+            <param id="dflt"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445339" name="onSelect" parent="BookMenuDelegate" startPc="268445292">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445551" name="onLogin" parent="LoginView" startPc="268445340">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445670" name="labelFor" parent="LoginView" startPc="268445552">
+            <param id="state"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445756" name="setField" parent="LoginView" startPc="268445671">
+            <param id="field"/>
+            <param id="text"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445992" name="onShow" parent="LoginView" startPc="268445757">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446053" name="cancelFlow" parent="LoginView" startPc="268445993">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446303" name="openField" parent="LoginView" startPc="268446054">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446411" name="initialize" parent="LoginView" startPc="268446304">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446446" name="onHide" parent="LoginView" startPc="268446412">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446524" name="onUpdate" parent="LoginView" startPc="268446447">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446730" name="queueDelete" parent="DownloadedMenuDelegate" startPc="268446525">
+            <param id="itemIds"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446748" name="onBack" parent="DownloadedMenuDelegate" startPc="268446731">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446763" name="initialize" parent="DownloadedMenuDelegate" startPc="268446749">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447271" name="onSelect" parent="DownloadedMenuDelegate" startPc="268446764">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447290" name="onBack" parent="ErrorViewDelegate" startPc="268447272">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447305" name="initialize" parent="ErrorViewDelegate" startPc="268447291">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447329" name="initialize" parent="ErrorView" startPc="268447306">
+            <param id="message"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447407" name="onUpdate" parent="ErrorView" startPc="268447330">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447528" name="titleWithSize" parent="DownloadedMenu" startPc="268447408">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447614" name="hasQueued" parent="DownloadedMenu" startPc="268447529">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448260" name="initialize" parent="DownloadedMenu" startPc="268447615">
+            <documentation/>
+        </functionEntry>
+    </functions>
+</debugInfo>

--- a/debug-symbols/b27.debug.xml
+++ b/debug-symbols/b27.debug.xml
@@ -1,0 +1,2207 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<debugInfo>
+    <manifest filename="/Users/cbrooker/Code/ABS-Garmin/manifest.xml"/>
+    <pcToLineNum>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="1" lineNum="33" parent="globals/BrowseDelegate" pc="268435460" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="2" lineNum="29" parent="globals/SyncDelegate" pc="268435472" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/bin/gen/006-B4533-00/source/Rez.mcgen" id="3" lineNum="7" parent="globals/Rez" pc="268435484" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="4" lineNum="65" parent="globals/GroupDelegate" pc="268435504" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="5" lineNum="4" parent="globals/LibraryMenuDelegate" pc="268435516" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="6" lineNum="7" parent="globals/WatchShelfApp" pc="268435528" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="7" lineNum="7" parent="globals/ContentDelegate" pc="268435540" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="8" lineNum="18" parent="globals/ContentIterator" pc="268435552" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="9" lineNum="115" parent="globals/FieldDelegate" pc="268435564" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="10" lineNum="8" parent="globals/LibraryView" pc="268435576" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="11" lineNum="6" parent="globals/LibraryViewDelegate" pc="268435588" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="12" lineNum="12" parent="globals/BookMenuDelegate" pc="268435600" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="13" lineNum="27" parent="globals/LoginView" pc="268435612" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="14" lineNum="10" parent="globals/DownloadedMenuDelegate" pc="268435624" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="15" lineNum="8" parent="globals/ErrorViewDelegate" pc="268435636" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="16" lineNum="5" parent="globals/ErrorView" pc="268435648" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="17" lineNum="11" parent="globals/DownloadedMenu" pc="268435660" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="38" parent="globals/Chunks" pc="268435672" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="39" parent="globals/Chunks" pc="268435683" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="40" parent="globals/Chunks" pc="268435686" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="41" parent="globals/Chunks" pc="268435702" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="42" parent="globals/Chunks" pc="268435709" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="42" parent="globals/Chunks" pc="268435716" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="43" parent="globals/Chunks" pc="268435722" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="44" parent="globals/Chunks" pc="268435725" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="45" parent="globals/Chunks" pc="268435733" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="46" parent="globals/Chunks" pc="268435750" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="47" parent="globals/Chunks" pc="268435757" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="47" parent="globals/Chunks" pc="268435765" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="48" parent="globals/Chunks" pc="268435772" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="49" parent="globals/Chunks" pc="268435779" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="52" parent="globals/Chunks" pc="268435796" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="28" parent="globals/Chunks" pc="268435799" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="29" parent="globals/Chunks" pc="268435810" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="29" parent="globals/Chunks" pc="268435822" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="30" parent="globals/Chunks" pc="268435831" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="30" parent="globals/Chunks" pc="268435849" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="31" parent="globals/Chunks" pc="268435854" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="32" parent="globals/Chunks" pc="268435870" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="32" parent="globals/Chunks" pc="268435884" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="34" parent="globals/Chunks" pc="268435899" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="80" parent="globals/Chunks" pc="268435901" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="81" parent="globals/Chunks" pc="268435912" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="82" parent="globals/Chunks" pc="268435915" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="83" parent="globals/Chunks" pc="268435918" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="84" parent="globals/Chunks" pc="268435934" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="85" parent="globals/Chunks" pc="268435941" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="85" parent="globals/Chunks" pc="268435948" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="86" parent="globals/Chunks" pc="268435954" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="87" parent="globals/Chunks" pc="268435957" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="88" parent="globals/Chunks" pc="268435965" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="89" parent="globals/Chunks" pc="268435982" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="90" parent="globals/Chunks" pc="268435989" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="90" parent="globals/Chunks" pc="268435997" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="91" parent="globals/Chunks" pc="268436004" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="92" parent="globals/Chunks" pc="268436012" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="99" parent="globals/Chunks" pc="268436056" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="100" parent="globals/Chunks" pc="268436063" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="102" parent="globals/Chunks" pc="268436070" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="104" parent="globals/Chunks" pc="268436087" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="58" parent="globals/Chunks" pc="268436089" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="59" parent="globals/Chunks" pc="268436100" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="60" parent="globals/Chunks" pc="268436104" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="61" parent="globals/Chunks" pc="268436107" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="62" parent="globals/Chunks" pc="268436123" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="63" parent="globals/Chunks" pc="268436130" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="63" parent="globals/Chunks" pc="268436137" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="64" parent="globals/Chunks" pc="268436143" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="65" parent="globals/Chunks" pc="268436146" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="66" parent="globals/Chunks" pc="268436154" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="67" parent="globals/Chunks" pc="268436176" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="68" parent="globals/Chunks" pc="268436183" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="68" parent="globals/Chunks" pc="268436191" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="69" parent="globals/Chunks" pc="268436198" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="70" parent="globals/Chunks" pc="268436213" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="72" parent="globals/Chunks" pc="268436220" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="74" parent="globals/Chunks" pc="268436237" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="22" lineNum="45" parent="globals/BrowseDelegate" pc="268436240" symbol="onSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="22" lineNum="45" parent="globals/BrowseDelegate" pc="268436242" symbol="onSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="23" lineNum="62" parent="globals/BrowseDelegate" pc="268436266" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="23" lineNum="62" parent="globals/BrowseDelegate" pc="268436268" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="44" parent="globals/BrowseDelegate" pc="268436284" symbol="onAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="44" parent="globals/BrowseDelegate" pc="268436286" symbol="onAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="48" parent="globals/BrowseDelegate" pc="268436310" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="49" parent="globals/BrowseDelegate" pc="268436313" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="50" parent="globals/BrowseDelegate" pc="268436353" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="51" parent="globals/BrowseDelegate" pc="268436435" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="53" parent="globals/BrowseDelegate" pc="268436439" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="54" parent="globals/BrowseDelegate" pc="268436446" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="55" parent="globals/BrowseDelegate" pc="268436512" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="56" parent="globals/BrowseDelegate" pc="268436528" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="57" parent="globals/BrowseDelegate" pc="268436535" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="58" parent="globals/BrowseDelegate" pc="268436573" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="60" parent="globals/BrowseDelegate" pc="268436634" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="26" lineNum="43" parent="globals/BrowseDelegate" pc="268436677" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="26" lineNum="43" parent="globals/BrowseDelegate" pc="268436679" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="27" lineNum="46" parent="globals/BrowseDelegate" pc="268436697" symbol="onCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="27" lineNum="46" parent="globals/BrowseDelegate" pc="268436699" symbol="onCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="35" parent="globals/BrowseDelegate" pc="268436723" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="35" parent="globals/BrowseDelegate" pc="268436725" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="35" parent="globals/BrowseDelegate" pc="268436737" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="36" parent="globals/BrowseDelegate" pc="268436747" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="37" parent="globals/BrowseDelegate" pc="268436750" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="38" parent="globals/BrowseDelegate" pc="268436759" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="38" parent="globals/BrowseDelegate" pc="268436776" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="39" parent="globals/BrowseDelegate" pc="268436812" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="39" parent="globals/BrowseDelegate" pc="268436829" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="40" parent="globals/BrowseDelegate" pc="268436863" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="40" parent="globals/BrowseDelegate" pc="268436880" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="41" parent="globals/BrowseDelegate" pc="268436914" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Notify.mc" id="30" lineNum="9" parent="globals/Notify" pc="268436946" symbol="flash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Notify.mc" id="30" lineNum="10" parent="globals/Notify" pc="268436956" symbol="flash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Notify.mc" id="30" lineNum="11" parent="globals/Notify" pc="268436971" symbol="flash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Notify.mc" id="30" lineNum="13" parent="globals/Notify" pc="268436990" symbol="flash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="50" parent="globals/SyncDelegate" pc="268437064" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="51" parent="globals/SyncDelegate" pc="268437067" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="56" parent="globals/SyncDelegate" pc="268437075" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="57" parent="globals/SyncDelegate" pc="268437091" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="60" parent="globals/SyncDelegate" pc="268437119" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="61" parent="globals/SyncDelegate" pc="268437133" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="62" parent="globals/SyncDelegate" pc="268437145" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="63" parent="globals/SyncDelegate" pc="268437161" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="64" parent="globals/SyncDelegate" pc="268437180" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="69" parent="globals/SyncDelegate" pc="268437186" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="70" parent="globals/SyncDelegate" pc="268437204" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="72" parent="globals/SyncDelegate" pc="268437210" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="73" parent="globals/SyncDelegate" pc="268437241" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="73" parent="globals/SyncDelegate" pc="268437248" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="75" parent="globals/SyncDelegate" pc="268437276" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="76" parent="globals/SyncDelegate" pc="268437286" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="77" parent="globals/SyncDelegate" pc="268437300" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="80" parent="globals/SyncDelegate" pc="268437304" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="81" parent="globals/SyncDelegate" pc="268437315" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="40" parent="globals/SyncDelegate" pc="268437323" symbol="deletes"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="41" parent="globals/SyncDelegate" pc="268437326" symbol="deletes"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="42" parent="globals/SyncDelegate" pc="268437345" symbol="deletes"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="125" parent="globals/SyncDelegate" pc="268437359" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="126" parent="globals/SyncDelegate" pc="268437362" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="127" parent="globals/SyncDelegate" pc="268437374" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="128" parent="globals/SyncDelegate" pc="268437386" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="129" parent="globals/SyncDelegate" pc="268437393" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="130" parent="globals/SyncDelegate" pc="268437407" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="133" parent="globals/SyncDelegate" pc="268437411" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="138" parent="globals/SyncDelegate" pc="268437417" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="139" parent="globals/SyncDelegate" pc="268437436" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="140" parent="globals/SyncDelegate" pc="268437451" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="141" parent="globals/SyncDelegate" pc="268437458" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="144" parent="globals/SyncDelegate" pc="268437462" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="145" parent="globals/SyncDelegate" pc="268437478" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="147" parent="globals/SyncDelegate" pc="268437484" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="148" parent="globals/SyncDelegate" pc="268437499" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="149" parent="globals/SyncDelegate" pc="268437506" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="152" parent="globals/SyncDelegate" pc="268437510" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="153" parent="globals/SyncDelegate" pc="268437540" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="155" parent="globals/SyncDelegate" pc="268437546" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="156" parent="globals/SyncDelegate" pc="268437561" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="157" parent="globals/SyncDelegate" pc="268437568" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="160" parent="globals/SyncDelegate" pc="268437572" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="174" parent="globals/SyncDelegate" pc="268437603" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="175" parent="globals/SyncDelegate" pc="268437646" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="176" parent="globals/SyncDelegate" pc="268437681" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="178" parent="globals/SyncDelegate" pc="268437730" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="261" parent="globals/SyncDelegate" pc="268437746" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="262" parent="globals/SyncDelegate" pc="268437749" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="265" parent="globals/SyncDelegate" pc="268437764" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="266" parent="globals/SyncDelegate" pc="268437792" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="266" parent="globals/SyncDelegate" pc="268437800" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="267" parent="globals/SyncDelegate" pc="268437807" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="93" parent="globals/SyncDelegate" pc="268437823" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="94" parent="globals/SyncDelegate" pc="268437826" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="94" parent="globals/SyncDelegate" pc="268437838" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="95" parent="globals/SyncDelegate" pc="268437842" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="96" parent="globals/SyncDelegate" pc="268437858" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="97" parent="globals/SyncDelegate" pc="268437876" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="98" parent="globals/SyncDelegate" pc="268437894" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="104" parent="globals/SyncDelegate" pc="268437911" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="105" parent="globals/SyncDelegate" pc="268437919" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="106" parent="globals/SyncDelegate" pc="268437923" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="107" parent="globals/SyncDelegate" pc="268437939" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="107" parent="globals/SyncDelegate" pc="268437958" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="109" parent="globals/SyncDelegate" pc="268437986" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="110" parent="globals/SyncDelegate" pc="268437998" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="112" parent="globals/SyncDelegate" pc="268438021" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="184" parent="globals/SyncDelegate" pc="268438040" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="185" parent="globals/SyncDelegate" pc="268438043" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="186" parent="globals/SyncDelegate" pc="268438058" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="187" parent="globals/SyncDelegate" pc="268438085" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="190" parent="globals/SyncDelegate" pc="268438089" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="191" parent="globals/SyncDelegate" pc="268438099" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="193" parent="globals/SyncDelegate" pc="268438108" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="194" parent="globals/SyncDelegate" pc="268438124" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="200" parent="globals/SyncDelegate" pc="268438170" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="201" parent="globals/SyncDelegate" pc="268438209" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="202" parent="globals/SyncDelegate" pc="268438216" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="205" parent="globals/SyncDelegate" pc="268438220" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="206" parent="globals/SyncDelegate" pc="268438230" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="207" parent="globals/SyncDelegate" pc="268438261" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="208" parent="globals/SyncDelegate" pc="268438280" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="213" parent="globals/SyncDelegate" pc="268438295" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="214" parent="globals/SyncDelegate" pc="268438308" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="215" parent="globals/SyncDelegate" pc="268438340" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="217" parent="globals/SyncDelegate" pc="268438358" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="220" parent="globals/SyncDelegate" pc="268438375" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="221" parent="globals/SyncDelegate" pc="268438382" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="116" parent="globals/SyncDelegate" pc="268438390" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="117" parent="globals/SyncDelegate" pc="268438393" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="118" parent="globals/SyncDelegate" pc="268438409" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="118" parent="globals/SyncDelegate" pc="268438427" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="120" parent="globals/SyncDelegate" pc="268438442" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="38" lineNum="86" parent="globals/SyncDelegate" pc="268438444" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="38" lineNum="87" parent="globals/SyncDelegate" pc="268438446" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="38" lineNum="88" parent="globals/SyncDelegate" pc="268438457" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="230" parent="globals/SyncDelegate" pc="268438472" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="231" parent="globals/SyncDelegate" pc="268438475" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="232" parent="globals/SyncDelegate" pc="268438479" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="233" parent="globals/SyncDelegate" pc="268438498" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="233" parent="globals/SyncDelegate" pc="268438504" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="234" parent="globals/SyncDelegate" pc="268438511" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="235" parent="globals/SyncDelegate" pc="268438527" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="240" parent="globals/SyncDelegate" pc="268438557" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="241" parent="globals/SyncDelegate" pc="268438569" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="242" parent="globals/SyncDelegate" pc="268438585" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="243" parent="globals/SyncDelegate" pc="268438604" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="247" parent="globals/SyncDelegate" pc="268438637" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="248" parent="globals/SyncDelegate" pc="268438641" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="249" parent="globals/SyncDelegate" pc="268438668" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="250" parent="globals/SyncDelegate" pc="268438674" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="251" parent="globals/SyncDelegate" pc="268438684" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="252" parent="globals/SyncDelegate" pc="268438690" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="252" parent="globals/SyncDelegate" pc="268438705" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="253" parent="globals/SyncDelegate" pc="268438726" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="256" parent="globals/SyncDelegate" pc="268438742" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="257" parent="globals/SyncDelegate" pc="268438758" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="40" lineNum="34" parent="globals/SyncDelegate" pc="268438811" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="40" lineNum="35" parent="globals/SyncDelegate" pc="268438813" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="40" lineNum="36" parent="globals/SyncDelegate" pc="268438825" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="40" lineNum="37" parent="globals/SyncDelegate" pc="268438833" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="41" lineNum="46" parent="globals/SyncDelegate" pc="268438842" symbol="isSyncNeeded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="41" lineNum="47" parent="globals/SyncDelegate" pc="268438844" symbol="isSyncNeeded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="42" lineNum="18" parent="globals/LoginCreds" pc="268438883" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="42" lineNum="18" parent="globals/LoginCreds" pc="268438885" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="42" lineNum="18" parent="globals/LoginCreds" pc="268438897" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="42" lineNum="18" parent="globals/LoginCreds" pc="268438909" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="43" lineNum="71" parent="globals/GroupDelegate" pc="268438922" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="43" lineNum="71" parent="globals/GroupDelegate" pc="268438924" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="44" lineNum="70" parent="globals/GroupDelegate" pc="268438940" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="44" lineNum="70" parent="globals/GroupDelegate" pc="268438942" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="45" lineNum="68" parent="globals/GroupDelegate" pc="268438960" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="45" lineNum="68" parent="globals/GroupDelegate" pc="268438962" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="45" lineNum="68" parent="globals/GroupDelegate" pc="268438974" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="45" lineNum="68" parent="globals/GroupDelegate" pc="268438983" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="46" lineNum="69" parent="globals/GroupDelegate" pc="268438993" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="46" lineNum="69" parent="globals/GroupDelegate" pc="268438995" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="47" lineNum="168" parent="globals/AbsProgressListener" pc="268439039" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="47" lineNum="169" parent="globals/AbsProgressListener" pc="268439041" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="47" lineNum="170" parent="globals/AbsProgressListener" pc="268439050" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="49" lineNum="7" parent="globals/LibraryMenuDelegate" pc="268439075" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="49" lineNum="7" parent="globals/LibraryMenuDelegate" pc="268439077" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="50" lineNum="5" parent="globals/LibraryMenuDelegate" pc="268439093" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="50" lineNum="5" parent="globals/LibraryMenuDelegate" pc="268439095" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="51" lineNum="6" parent="globals/LibraryMenuDelegate" pc="268439108" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="51" lineNum="6" parent="globals/LibraryMenuDelegate" pc="268439110" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="52" lineNum="57" parent="globals/WatchShelfApp" pc="268439131" symbol="getProviderIconInfo"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="52" lineNum="58" parent="globals/WatchShelfApp" pc="268439133" symbol="getProviderIconInfo"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="53" lineNum="45" parent="globals/WatchShelfApp" pc="268439180" symbol="getPlaybackConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="53" lineNum="46" parent="globals/WatchShelfApp" pc="268439182" symbol="getPlaybackConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="54" lineNum="30" parent="globals/WatchShelfApp" pc="268439229" symbol="getContentDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="54" lineNum="31" parent="globals/WatchShelfApp" pc="268439231" symbol="getContentDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="55" lineNum="38" parent="globals/WatchShelfApp" pc="268439250" symbol="getSyncDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="55" lineNum="39" parent="globals/WatchShelfApp" pc="268439252" symbol="getSyncDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="9" parent="globals/WatchShelfApp" pc="268439271" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="14" parent="globals/WatchShelfApp" pc="268439274" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="15" parent="globals/WatchShelfApp" pc="268439293" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="16" parent="globals/WatchShelfApp" pc="268439301" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="17" parent="globals/WatchShelfApp" pc="268439320" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="18" parent="globals/WatchShelfApp" pc="268439339" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="19" parent="globals/WatchShelfApp" pc="268439350" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="20" parent="globals/WatchShelfApp" pc="268439361" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="20" parent="globals/WatchShelfApp" pc="268439367" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="21" parent="globals/WatchShelfApp" pc="268439390" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="21" parent="globals/WatchShelfApp" pc="268439396" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="22" parent="globals/WatchShelfApp" pc="268439419" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="26" parent="globals/WatchShelfApp" pc="268439442" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="57" lineNum="52" parent="globals/WatchShelfApp" pc="268439455" symbol="getSyncConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="57" lineNum="53" parent="globals/WatchShelfApp" pc="268439457" symbol="getSyncConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="58" lineNum="70" parent="globals/ContentDelegate" pc="268439504" symbol="onShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="58" lineNum="71" parent="globals/ContentDelegate" pc="268439506" symbol="onShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="59" lineNum="18" parent="globals/ContentDelegate" pc="268439519" symbol="getContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="59" lineNum="19" parent="globals/ContentDelegate" pc="268439521" symbol="getContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="42" parent="globals/ContentDelegate" pc="268439527" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="43" parent="globals/ContentDelegate" pc="268439530" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="43" parent="globals/ContentDelegate" pc="268439544" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="48" parent="globals/ContentDelegate" pc="268439548" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="49" parent="globals/ContentDelegate" pc="268439557" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="50" parent="globals/ContentDelegate" pc="268439566" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="51" parent="globals/ContentDelegate" pc="268439585" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="51" parent="globals/ContentDelegate" pc="268439591" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="52" parent="globals/ContentDelegate" pc="268439598" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="53" parent="globals/ContentDelegate" pc="268439614" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="54" parent="globals/ContentDelegate" pc="268439618" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="55" parent="globals/ContentDelegate" pc="268439640" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="56" parent="globals/ContentDelegate" pc="268439649" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="57" parent="globals/ContentDelegate" pc="268439665" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="62" parent="globals/ContentDelegate" pc="268439725" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="63" parent="globals/ContentDelegate" pc="268439735" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="63" parent="globals/ContentDelegate" pc="268439741" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="64" parent="globals/ContentDelegate" pc="268439745" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="67" parent="globals/ContentDelegate" pc="268439755" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="61" lineNum="75" parent="globals/ContentDelegate" pc="268439776" symbol="onThumbsUp"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="62" lineNum="12" parent="globals/ContentDelegate" pc="268439779" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="62" lineNum="13" parent="globals/ContentDelegate" pc="268439781" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="62" lineNum="14" parent="globals/ContentDelegate" pc="268439793" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="62" lineNum="15" parent="globals/ContentDelegate" pc="268439801" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="63" lineNum="33" parent="globals/ContentDelegate" pc="268439809" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="63" lineNum="34" parent="globals/ContentDelegate" pc="268439811" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="63" lineNum="38" parent="globals/ContentDelegate" pc="268439843" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="65" lineNum="22" parent="globals/ContentDelegate" pc="268439860" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="65" lineNum="23" parent="globals/ContentDelegate" pc="268439862" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="65" lineNum="24" parent="globals/ContentDelegate" pc="268439887" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="66" lineNum="76" parent="globals/ContentDelegate" pc="268439893" symbol="onThumbsDown"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="85" parent="globals/BookStore" pc="268439896" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="86" parent="globals/BookStore" pc="268439907" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="87" parent="globals/BookStore" pc="268439911" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="88" parent="globals/BookStore" pc="268439942" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="90" parent="globals/BookStore" pc="268439952" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="91" parent="globals/BookStore" pc="268439963" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="92" parent="globals/BookStore" pc="268439989" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="93" parent="globals/BookStore" pc="268439995" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="94" parent="globals/BookStore" pc="268440012" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="95" parent="globals/BookStore" pc="268440021" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="99" parent="globals/BookStore" pc="268440079" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="101" parent="globals/BookStore" pc="268440114" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="106" parent="globals/BookStore" pc="268440138" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="107" parent="globals/BookStore" pc="268440149" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="108" parent="globals/BookStore" pc="268440168" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="108" parent="globals/BookStore" pc="268440174" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="109" parent="globals/BookStore" pc="268440181" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="110" parent="globals/BookStore" pc="268440197" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="110" parent="globals/BookStore" pc="268440215" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="112" parent="globals/BookStore" pc="268440229" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="113" parent="globals/BookStore" pc="268440241" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="116" parent="globals/BookStore" pc="268440262" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="117" parent="globals/BookStore" pc="268440273" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="118" parent="globals/BookStore" pc="268440292" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="118" parent="globals/BookStore" pc="268440298" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="119" parent="globals/BookStore" pc="268440302" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="120" parent="globals/BookStore" pc="268440306" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="121" parent="globals/BookStore" pc="268440322" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="121" parent="globals/BookStore" pc="268440341" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="123" parent="globals/BookStore" pc="268440369" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="30" parent="globals/BookStore" pc="268440390" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="31" parent="globals/BookStore" pc="268440400" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="42" parent="globals/BookStore" pc="268440423" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="43" parent="globals/BookStore" pc="268440434" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="44" parent="globals/BookStore" pc="268440437" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="45" parent="globals/BookStore" pc="268440440" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="46" parent="globals/BookStore" pc="268440444" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="47" parent="globals/BookStore" pc="268440470" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="47" parent="globals/BookStore" pc="268440476" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="48" parent="globals/BookStore" pc="268440482" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="49" parent="globals/BookStore" pc="268440494" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="51" parent="globals/BookStore" pc="268440504" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="128" parent="globals/BookStore" pc="268440507" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="129" parent="globals/BookStore" pc="268440518" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="130" parent="globals/BookStore" pc="268440521" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="131" parent="globals/BookStore" pc="268440525" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="132" parent="globals/BookStore" pc="268440551" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="132" parent="globals/BookStore" pc="268440557" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="133" parent="globals/BookStore" pc="268440561" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="134" parent="globals/BookStore" pc="268440577" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="134" parent="globals/BookStore" pc="268440586" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="136" parent="globals/BookStore" pc="268440608" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="147" parent="globals/BookStore" pc="268440619" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="148" parent="globals/BookStore" pc="268440630" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="149" parent="globals/BookStore" pc="268440642" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="149" parent="globals/BookStore" pc="268440648" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="150" parent="globals/BookStore" pc="268440652" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="151" parent="globals/BookStore" pc="268440674" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="152" parent="globals/BookStore" pc="268440677" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="153" parent="globals/BookStore" pc="268440680" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="154" parent="globals/BookStore" pc="268440684" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="155" parent="globals/BookStore" pc="268440710" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="155" parent="globals/BookStore" pc="268440716" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="156" parent="globals/BookStore" pc="268440722" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="157" parent="globals/BookStore" pc="268440738" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="158" parent="globals/BookStore" pc="268440760" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="160" parent="globals/BookStore" pc="268440788" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="162" parent="globals/BookStore" pc="268440805" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="58" parent="globals/BookStore" pc="268440816" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="59" parent="globals/BookStore" pc="268440827" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="60" parent="globals/BookStore" pc="268440841" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="61" parent="globals/BookStore" pc="268440852" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="62" parent="globals/BookStore" pc="268440878" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="62" parent="globals/BookStore" pc="268440884" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="63" parent="globals/BookStore" pc="268440891" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="64" parent="globals/BookStore" pc="268440904" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="65" parent="globals/BookStore" pc="268440911" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="66" parent="globals/BookStore" pc="268440933" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="68" parent="globals/BookStore" pc="268440975" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="72" parent="globals/BookStore" pc="268440985" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="72" parent="globals/BookStore" pc="268440998" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="73" parent="globals/BookStore" pc="268441012" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="75" parent="globals/BookStore" pc="268441024" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="75" lineNum="25" parent="globals/BookStore" pc="268441052" symbol="pageKey"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="75" lineNum="26" parent="globals/BookStore" pc="268441062" symbol="pageKey"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="76" lineNum="22" parent="globals/BookStore" pc="268441080" symbol="key"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="76" lineNum="23" parent="globals/BookStore" pc="268441090" symbol="key"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="77" lineNum="34" parent="globals/BookStore" pc="268441099" symbol="ensureMeta"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="77" lineNum="35" parent="globals/BookStore" pc="268441109" symbol="ensureMeta"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="77" lineNum="36" parent="globals/BookStore" pc="268441123" symbol="ensureMeta"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="60" parent="globals/ContentIterator" pc="268441171" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="61" parent="globals/ContentIterator" pc="268441173" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="62" parent="globals/ContentIterator" pc="268441196" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="63" parent="globals/ContentIterator" pc="268441211" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="65" parent="globals/ContentIterator" pc="268441228" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="104" parent="globals/ContentIterator" pc="268441230" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="105" parent="globals/ContentIterator" pc="268441233" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="107" parent="globals/ContentIterator" pc="268441257" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="108" parent="globals/ContentIterator" pc="268441311" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="113" parent="globals/ContentIterator" pc="268441315" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="114" parent="globals/ContentIterator" pc="268441356" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="117" parent="globals/ContentIterator" pc="268441377" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="80" lineNum="68" parent="globals/ContentIterator" pc="268441379" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="80" lineNum="69" parent="globals/ContentIterator" pc="268441381" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="80" lineNum="70" parent="globals/ContentIterator" pc="268441391" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="80" lineNum="71" parent="globals/ContentIterator" pc="268441406" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="80" lineNum="73" parent="globals/ContentIterator" pc="268441423" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="182" parent="globals/ContentIterator" pc="268441425" symbol="swap"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="183" parent="globals/ContentIterator" pc="268441428" symbol="swap"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="184" parent="globals/ContentIterator" pc="268441435" symbol="swap"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="185" parent="globals/ContentIterator" pc="268441448" symbol="swap"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="80" parent="globals/ContentIterator" pc="268441459" symbol="peekPrevious"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="81" parent="globals/ContentIterator" pc="268441461" symbol="peekPrevious"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="83" lineNum="84" parent="globals/ContentIterator" pc="268441478" symbol="canSkip"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="83" lineNum="85" parent="globals/ContentIterator" pc="268441480" symbol="canSkip"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="92" parent="globals/ContentIterator" pc="268441482" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="93" parent="globals/ContentIterator" pc="268441484" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="94" parent="globals/ContentIterator" pc="268441492" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="95" parent="globals/ContentIterator" pc="268441500" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="97" parent="globals/ContentIterator" pc="268441510" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="98" parent="globals/ContentIterator" pc="268441517" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="32" parent="globals/ContentIterator" pc="268441526" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="33" parent="globals/ContentIterator" pc="268441529" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="34" parent="globals/ContentIterator" pc="268441553" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="41" parent="globals/ContentIterator" pc="268441566" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="42" parent="globals/ContentIterator" pc="268441575" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="43" parent="globals/ContentIterator" pc="268441584" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="44" parent="globals/ContentIterator" pc="268441594" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="47" parent="globals/ContentIterator" pc="268441604" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="48" parent="globals/ContentIterator" pc="268441615" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="50" parent="globals/ContentIterator" pc="268441628" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="51" parent="globals/ContentIterator" pc="268441639" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="53" parent="globals/ContentIterator" pc="268441652" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="86" lineNum="76" parent="globals/ContentIterator" pc="268441655" symbol="peekNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="86" lineNum="77" parent="globals/ContentIterator" pc="268441657" symbol="peekNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="87" lineNum="56" parent="globals/ContentIterator" pc="268441674" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="87" lineNum="57" parent="globals/ContentIterator" pc="268441676" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="88" lineNum="88" parent="globals/ContentIterator" pc="268441690" symbol="shuffling"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="88" lineNum="89" parent="globals/ContentIterator" pc="268441692" symbol="shuffling"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="24" parent="globals/ContentIterator" pc="268441698" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="25" parent="globals/ContentIterator" pc="268441700" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="26" parent="globals/ContentIterator" pc="268441712" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="27" parent="globals/ContentIterator" pc="268441720" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="28" parent="globals/ContentIterator" pc="268441728" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="90" lineNum="175" parent="globals/ContentIterator" pc="268441736" symbol="after"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="90" lineNum="176" parent="globals/ContentIterator" pc="268441738" symbol="after"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="90" lineNum="177" parent="globals/ContentIterator" pc="268441746" symbol="after"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="90" lineNum="179" parent="globals/ContentIterator" pc="268441755" symbol="after"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="188" parent="globals/ContentIterator" pc="268441761" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="189" parent="globals/ContentIterator" pc="268441764" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="190" parent="globals/ContentIterator" pc="268441787" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="191" parent="globals/ContentIterator" pc="268441805" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="192" parent="globals/ContentIterator" pc="268441815" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="193" parent="globals/ContentIterator" pc="268441831" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="195" parent="globals/ContentIterator" pc="268441851" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="131" parent="globals/ContentIterator" pc="268441860" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="132" parent="globals/ContentIterator" pc="268441863" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="133" parent="globals/ContentIterator" pc="268441872" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="134" parent="globals/ContentIterator" pc="268441876" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="138" parent="globals/ContentIterator" pc="268441880" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="139" parent="globals/ContentIterator" pc="268441884" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="140" parent="globals/ContentIterator" pc="268441903" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="140" parent="globals/ContentIterator" pc="268441909" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="141" parent="globals/ContentIterator" pc="268441916" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="142" parent="globals/ContentIterator" pc="268441932" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="145" parent="globals/ContentIterator" pc="268441964" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="146" parent="globals/ContentIterator" pc="268441991" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="147" parent="globals/ContentIterator" pc="268441997" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="148" parent="globals/ContentIterator" pc="268442007" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="149" parent="globals/ContentIterator" pc="268442013" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="150" parent="globals/ContentIterator" pc="268442023" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="151" parent="globals/ContentIterator" pc="268442030" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="152" parent="globals/ContentIterator" pc="268442036" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="153" parent="globals/ContentIterator" pc="268442052" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="154" parent="globals/ContentIterator" pc="268442066" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="156" parent="globals/ContentIterator" pc="268442084" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="163" parent="globals/ContentIterator" pc="268442100" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="164" parent="globals/ContentIterator" pc="268442121" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="165" parent="globals/ContentIterator" pc="268442125" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="166" parent="globals/ContentIterator" pc="268442172" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="166" parent="globals/ContentIterator" pc="268442188" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="166" parent="globals/ContentIterator" pc="268442201" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="167" parent="globals/ContentIterator" pc="268442214" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="170" parent="globals/ContentIterator" pc="268442234" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="93" lineNum="44" parent="globals/JobStore" pc="268442243" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="93" lineNum="45" parent="globals/JobStore" pc="268442253" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="94" lineNum="39" parent="globals/JobStore" pc="268442276" symbol="list"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="94" lineNum="40" parent="globals/JobStore" pc="268442287" symbol="list"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="94" lineNum="41" parent="globals/JobStore" pc="268442306" symbol="list"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="95" lineNum="32" parent="globals/JobStore" pc="268442320" symbol="key"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="95" lineNum="33" parent="globals/JobStore" pc="268442330" symbol="key"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="48" parent="globals/JobStore" pc="268442339" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="49" parent="globals/JobStore" pc="268442350" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="50" parent="globals/JobStore" pc="268442375" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="51" parent="globals/JobStore" pc="268442383" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="52" parent="globals/JobStore" pc="268442399" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="52" parent="globals/JobStore" pc="268442417" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="54" parent="globals/JobStore" pc="268442431" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="55" parent="globals/JobStore" pc="268442443" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="58" parent="globals/JobStore" pc="268442464" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="59" parent="globals/JobStore" pc="268442475" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="60" parent="globals/JobStore" pc="268442483" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="61" parent="globals/JobStore" pc="268442487" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="62" parent="globals/JobStore" pc="268442503" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="62" parent="globals/JobStore" pc="268442522" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="64" parent="globals/JobStore" pc="268442550" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="65" parent="globals/JobStore" pc="268442562" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="67" parent="globals/JobStore" pc="268442585" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="69" parent="globals/JobStore" pc="268442603" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="98" lineNum="76" parent="globals/JobStore" pc="268442627" symbol="clearAll"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="98" lineNum="77" parent="globals/JobStore" pc="268442638" symbol="clearAll"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="98" lineNum="78" parent="globals/JobStore" pc="268442646" symbol="clearAll"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="98" lineNum="79" parent="globals/JobStore" pc="268442662" symbol="clearAll"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="99" lineNum="22" parent="globals/Login" pc="268442687" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="99" lineNum="23" parent="globals/Login" pc="268442697" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="100" lineNum="94" parent="globals/AbsApi" pc="268442757" symbol="isConfigured"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="100" lineNum="95" parent="globals/AbsApi" pc="268442767" symbol="isConfigured"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="29" parent="globals/AbsApi" pc="268442788" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="30" parent="globals/AbsApi" pc="268442799" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="31" parent="globals/AbsApi" pc="268442818" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="31" parent="globals/AbsApi" pc="268442824" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="32" parent="globals/AbsApi" pc="268442842" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="102" lineNum="146" parent="globals/AbsApi" pc="268442845" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="102" lineNum="147" parent="globals/AbsApi" pc="268442855" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="102" lineNum="148" parent="globals/AbsApi" pc="268442883" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="103" lineNum="65" parent="globals/AbsApi" pc="268442904" symbol="getCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="103" lineNum="65" parent="globals/AbsApi" pc="268442914" symbol="getCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="104" lineNum="40" parent="globals/AbsApi" pc="268442933" symbol="sidecarBase"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="104" lineNum="40" parent="globals/AbsApi" pc="268442943" symbol="sidecarBase"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="105" lineNum="137" parent="globals/AbsApi" pc="268442950" symbol="login"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="105" lineNum="138" parent="globals/AbsApi" pc="268442960" symbol="login"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="106" lineNum="68" parent="globals/AbsApi" pc="268443044" symbol="getFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="106" lineNum="69" parent="globals/AbsApi" pc="268443054" symbol="getFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="86" parent="globals/AbsApi" pc="268443127" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="89" parent="globals/AbsApi" pc="268443138" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="90" parent="globals/AbsApi" pc="268443154" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="90" parent="globals/AbsApi" pc="268443188" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="91" parent="globals/AbsApi" pc="268443193" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="108" lineNum="44" parent="globals/AbsApi" pc="268443196" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="108" lineNum="45" parent="globals/AbsApi" pc="268443207" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="108" lineNum="46" parent="globals/AbsApi" pc="268443234" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="108" lineNum="46" parent="globals/AbsApi" pc="268443246" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="108" lineNum="47" parent="globals/AbsApi" pc="268443256" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="109" lineNum="150" parent="globals/AbsApi" pc="268443306" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="109" lineNum="151" parent="globals/AbsApi" pc="268443316" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="109" lineNum="152" parent="globals/AbsApi" pc="268443334" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="110" lineNum="124" parent="globals/AbsApi" pc="268443353" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="110" lineNum="125" parent="globals/AbsApi" pc="268443364" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="110" lineNum="126" parent="globals/AbsApi" pc="268443387" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="110" lineNum="126" parent="globals/AbsApi" pc="268443393" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="110" lineNum="127" parent="globals/AbsApi" pc="268443406" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="111" lineNum="64" parent="globals/AbsApi" pc="268443507" symbol="getSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="111" lineNum="64" parent="globals/AbsApi" pc="268443517" symbol="getSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="112" lineNum="113" parent="globals/AbsApi" pc="268443536" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="112" lineNum="114" parent="globals/AbsApi" pc="268443547" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="112" lineNum="115" parent="globals/AbsApi" pc="268443557" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="112" lineNum="116" parent="globals/AbsApi" pc="268443575" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="112" lineNum="118" parent="globals/AbsApi" pc="268443587" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="113" lineNum="63" parent="globals/AbsApi" pc="268443589" symbol="getAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="113" lineNum="63" parent="globals/AbsApi" pc="268443599" symbol="getAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="114" lineNum="80" parent="globals/AbsApi" pc="268443618" symbol="sidecarChunkUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="114" lineNum="81" parent="globals/AbsApi" pc="268443628" symbol="sidecarChunkUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="115" lineNum="154" parent="globals/AbsApi" pc="268443694" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="115" lineNum="155" parent="globals/AbsApi" pc="268443704" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="115" lineNum="156" parent="globals/AbsApi" pc="268443768" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="115" lineNum="158" parent="globals/AbsApi" pc="268443794" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="116" lineNum="19" parent="globals/AbsApi" pc="268443797" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="116" lineNum="20" parent="globals/AbsApi" pc="268443808" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="116" lineNum="21" parent="globals/AbsApi" pc="268443827" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="116" lineNum="21" parent="globals/AbsApi" pc="268443833" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="116" lineNum="22" parent="globals/AbsApi" pc="268443851" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="116" lineNum="22" parent="globals/AbsApi" pc="268443857" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="116" lineNum="23" parent="globals/AbsApi" pc="268443862" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="116" lineNum="24" parent="globals/AbsApi" pc="268443916" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="116" lineNum="26" parent="globals/AbsApi" pc="268443941" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="117" lineNum="101" parent="globals/AbsApi" pc="268443944" symbol="getLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="117" lineNum="102" parent="globals/AbsApi" pc="268443954" symbol="getLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="118" lineNum="55" parent="globals/AbsApi" pc="268444019" symbol="getGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="118" lineNum="56" parent="globals/AbsApi" pc="268444029" symbol="getGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="125" parent="globals/FieldDelegate" pc="268444099" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="126" parent="globals/FieldDelegate" pc="268444101" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="119" lineNum="127" parent="globals/FieldDelegate" pc="268444122" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="129" parent="globals/FieldDelegate" pc="268444124" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="130" parent="globals/FieldDelegate" pc="268444126" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="131" parent="globals/FieldDelegate" pc="268444138" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="118" parent="globals/FieldDelegate" pc="268444140" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="119" parent="globals/FieldDelegate" pc="268444142" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="120" parent="globals/FieldDelegate" pc="268444154" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="121" parent="globals/FieldDelegate" pc="268444163" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="122" lineNum="14" parent="globals/RequestDelegate" pc="268444173" symbol="makeWebRequest"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="122" lineNum="15" parent="globals/RequestDelegate" pc="268444175" symbol="makeWebRequest"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="123" lineNum="9" parent="globals/RequestDelegate" pc="268444208" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="123" lineNum="10" parent="globals/RequestDelegate" pc="268444210" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="123" lineNum="11" parent="globals/RequestDelegate" pc="268444219" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="124" lineNum="18" parent="globals/RequestDelegate" pc="268444229" symbol="onWebResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="124" lineNum="19" parent="globals/RequestDelegate" pc="268444231" symbol="onWebResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="125" lineNum="7" parent="globals/Browse" pc="268444255" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="125" lineNum="8" parent="globals/Browse" pc="268444266" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="125" lineNum="9" parent="globals/Browse" pc="268444332" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="125" lineNum="10" parent="globals/Browse" pc="268444402" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="125" lineNum="11" parent="globals/Browse" pc="268444472" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="125" lineNum="12" parent="globals/Browse" pc="268444542" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="125" lineNum="13" parent="globals/Browse" pc="268444612" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="17" parent="globals/Browse" pc="268444654" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="18" parent="globals/Browse" pc="268444665" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="19" parent="globals/Browse" pc="268444711" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="21" parent="globals/Browse" pc="268444816" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="23" parent="globals/Browse" pc="268444820" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="24" parent="globals/Browse" pc="268444830" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="25" parent="globals/Browse" pc="268444896" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="26" parent="globals/Browse" pc="268444912" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="27" parent="globals/Browse" pc="268444919" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="29" parent="globals/Browse" pc="268444986" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="127" lineNum="43" parent="globals/LibraryView" pc="268445026" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="127" lineNum="44" parent="globals/LibraryView" pc="268445029" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="127" lineNum="45" parent="globals/LibraryView" pc="268445056" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="127" lineNum="46" parent="globals/LibraryView" pc="268445066" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="127" lineNum="47" parent="globals/LibraryView" pc="268445132" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="127" lineNum="48" parent="globals/LibraryView" pc="268445148" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="127" lineNum="50" parent="globals/LibraryView" pc="268445155" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="127" lineNum="51" parent="globals/LibraryView" pc="268445191" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="127" lineNum="54" parent="globals/LibraryView" pc="268445254" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="127" lineNum="56" parent="globals/LibraryView" pc="268445292" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="127" lineNum="57" parent="globals/LibraryView" pc="268445345" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="19" parent="globals/LibraryView" pc="268445357" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="23" parent="globals/LibraryView" pc="268445359" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="23" parent="globals/LibraryView" pc="268445367" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="24" parent="globals/LibraryView" pc="268445371" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="26" parent="globals/LibraryView" pc="268445379" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="28" parent="globals/LibraryView" pc="268445393" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="29" parent="globals/LibraryView" pc="268445404" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="31" parent="globals/LibraryView" pc="268445408" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="129" lineNum="13" parent="globals/LibraryView" pc="268445435" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="129" lineNum="14" parent="globals/LibraryView" pc="268445437" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="129" lineNum="15" parent="globals/LibraryView" pc="268445449" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="129" lineNum="16" parent="globals/LibraryView" pc="268445487" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="130" lineNum="34" parent="globals/LibraryView" pc="268445496" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="130" lineNum="35" parent="globals/LibraryView" pc="268445498" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="130" lineNum="36" parent="globals/LibraryView" pc="268445510" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="130" lineNum="37" parent="globals/LibraryView" pc="268445518" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="130" lineNum="38" parent="globals/LibraryView" pc="268445534" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="131" lineNum="13" parent="globals/LibraryViewDelegate" pc="268445574" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="131" lineNum="14" parent="globals/LibraryViewDelegate" pc="268445576" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="131" lineNum="15" parent="globals/LibraryViewDelegate" pc="268445591" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="132" lineNum="8" parent="globals/LibraryViewDelegate" pc="268445593" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="132" lineNum="9" parent="globals/LibraryViewDelegate" pc="268445595" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="133" lineNum="187" parent="globals/BookMenuDelegate" pc="268445608" symbol="inBookIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="133" lineNum="188" parent="globals/BookMenuDelegate" pc="268445611" symbol="inBookIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="133" lineNum="189" parent="globals/BookMenuDelegate" pc="268445630" symbol="inBookIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="133" lineNum="189" parent="globals/BookMenuDelegate" pc="268445636" symbol="inBookIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="133" lineNum="190" parent="globals/BookMenuDelegate" pc="268445641" symbol="inBookIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="134" lineNum="198" parent="globals/BookMenuDelegate" pc="268445654" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="134" lineNum="199" parent="globals/BookMenuDelegate" pc="268445656" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="135" lineNum="180" parent="globals/BookMenuDelegate" pc="268445672" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="135" lineNum="181" parent="globals/BookMenuDelegate" pc="268445675" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="135" lineNum="182" parent="globals/BookMenuDelegate" pc="268445691" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="135" lineNum="182" parent="globals/BookMenuDelegate" pc="268445709" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="135" lineNum="184" parent="globals/BookMenuDelegate" pc="268445724" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="157" parent="globals/BookMenuDelegate" pc="268445726" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="158" parent="globals/BookMenuDelegate" pc="268445729" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="160" parent="globals/BookMenuDelegate" pc="268445732" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="161" parent="globals/BookMenuDelegate" pc="268445751" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="161" parent="globals/BookMenuDelegate" pc="268445757" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="163" parent="globals/BookMenuDelegate" pc="268445764" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="164" parent="globals/BookMenuDelegate" pc="268445776" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="165" parent="globals/BookMenuDelegate" pc="268445792" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="165" parent="globals/BookMenuDelegate" pc="268445828" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="166" parent="globals/BookMenuDelegate" pc="268445834" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="167" parent="globals/BookMenuDelegate" pc="268445853" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="167" parent="globals/BookMenuDelegate" pc="268445859" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="170" parent="globals/BookMenuDelegate" pc="268445897" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="171" parent="globals/BookMenuDelegate" pc="268445916" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="171" parent="globals/BookMenuDelegate" pc="268445922" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="172" parent="globals/BookMenuDelegate" pc="268445929" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="173" parent="globals/BookMenuDelegate" pc="268445945" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="174" parent="globals/BookMenuDelegate" pc="268445999" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="175" parent="globals/BookMenuDelegate" pc="268446005" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="177" parent="globals/BookMenuDelegate" pc="268446037" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="16" parent="globals/BookMenuDelegate" pc="268446040" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="17" parent="globals/BookMenuDelegate" pc="268446042" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="18" parent="globals/BookMenuDelegate" pc="268446054" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="26" parent="globals/BookMenuDelegate" pc="268446063" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="27" parent="globals/BookMenuDelegate" pc="268446066" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="28" parent="globals/BookMenuDelegate" pc="268446112" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="30" parent="globals/BookMenuDelegate" pc="268446209" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="33" parent="globals/BookMenuDelegate" pc="268446213" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="34" parent="globals/BookMenuDelegate" pc="268446223" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="35" parent="globals/BookMenuDelegate" pc="268446233" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="35" parent="globals/BookMenuDelegate" pc="268446239" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="37" parent="globals/BookMenuDelegate" pc="268446249" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="38" parent="globals/BookMenuDelegate" pc="268446253" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="39" parent="globals/BookMenuDelegate" pc="268446257" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="40" parent="globals/BookMenuDelegate" pc="268446273" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="41" parent="globals/BookMenuDelegate" pc="268446301" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="41" parent="globals/BookMenuDelegate" pc="268446308" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="42" parent="globals/BookMenuDelegate" pc="268446314" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="43" parent="globals/BookMenuDelegate" pc="268446335" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="46" parent="globals/BookMenuDelegate" pc="268446357" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="47" parent="globals/BookMenuDelegate" pc="268446373" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="48" parent="globals/BookMenuDelegate" pc="268446380" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="49" parent="globals/BookMenuDelegate" pc="268446462" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="62" parent="globals/BookMenuDelegate" pc="268446466" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="63" parent="globals/BookMenuDelegate" pc="268446480" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="65" parent="globals/BookMenuDelegate" pc="268446562" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="75" parent="globals/BookMenuDelegate" pc="268446566" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="76" parent="globals/BookMenuDelegate" pc="268446585" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="77" parent="globals/BookMenuDelegate" pc="268446588" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="78" parent="globals/BookMenuDelegate" pc="268446594" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="85" parent="globals/BookMenuDelegate" pc="268446672" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="86" parent="globals/BookMenuDelegate" pc="268446701" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="88" parent="globals/BookMenuDelegate" pc="268446783" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="94" parent="globals/BookMenuDelegate" pc="268446787" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="95" parent="globals/BookMenuDelegate" pc="268446810" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="97" parent="globals/BookMenuDelegate" pc="268446892" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="103" parent="globals/BookMenuDelegate" pc="268446896" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="104" parent="globals/BookMenuDelegate" pc="268446915" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="112" parent="globals/BookMenuDelegate" pc="268446951" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="113" parent="globals/BookMenuDelegate" pc="268446956" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="114" parent="globals/BookMenuDelegate" pc="268446974" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="115" parent="globals/BookMenuDelegate" pc="268446992" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="122" parent="globals/BookMenuDelegate" pc="268447013" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="123" parent="globals/BookMenuDelegate" pc="268447032" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="124" parent="globals/BookMenuDelegate" pc="268447056" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="125" parent="globals/BookMenuDelegate" pc="268447060" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="126" parent="globals/BookMenuDelegate" pc="268447077" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="126" parent="globals/BookMenuDelegate" pc="268447099" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="128" parent="globals/BookMenuDelegate" pc="268447127" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="136" parent="globals/BookMenuDelegate" pc="268447150" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="137" parent="globals/BookMenuDelegate" pc="268447178" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="145" parent="globals/BookMenuDelegate" pc="268447241" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="146" parent="globals/BookMenuDelegate" pc="268447273" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="193" parent="globals/BookMenuDelegate" pc="268447285" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="194" parent="globals/BookMenuDelegate" pc="268447287" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="194" parent="globals/BookMenuDelegate" pc="268447293" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="195" parent="globals/BookMenuDelegate" pc="268447299" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="140" lineNum="21" parent="globals/BookMenuDelegate" pc="268447302" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="140" lineNum="22" parent="globals/BookMenuDelegate" pc="268447304" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="140" lineNum="23" parent="globals/BookMenuDelegate" pc="268447318" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="141" lineNum="103" parent="globals/LoginView" pc="268447350" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="141" lineNum="104" parent="globals/LoginView" pc="268447352" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="141" lineNum="105" parent="globals/LoginView" pc="268447397" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="141" lineNum="106" parent="globals/LoginView" pc="268447434" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="141" lineNum="108" parent="globals/LoginView" pc="268447488" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="141" lineNum="109" parent="globals/LoginView" pc="268447497" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="141" lineNum="110" parent="globals/LoginView" pc="268447550" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="142" lineNum="63" parent="globals/LoginView" pc="268447562" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="142" lineNum="64" parent="globals/LoginView" pc="268447564" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="142" lineNum="64" parent="globals/LoginView" pc="268447571" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="142" lineNum="65" parent="globals/LoginView" pc="268447606" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="142" lineNum="65" parent="globals/LoginView" pc="268447614" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="142" lineNum="66" parent="globals/LoginView" pc="268447649" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="90" parent="globals/LoginView" pc="268447681" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="91" parent="globals/LoginView" pc="268447683" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="91" parent="globals/LoginView" pc="268447690" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="92" parent="globals/LoginView" pc="268447706" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="92" parent="globals/LoginView" pc="268447714" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="93" parent="globals/LoginView" pc="268447730" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="93" parent="globals/LoginView" pc="268447738" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="94" parent="globals/LoginView" pc="268447754" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="44" parent="globals/LoginView" pc="268447767" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="45" parent="globals/LoginView" pc="268447769" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="46" parent="globals/LoginView" pc="268447780" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="47" parent="globals/LoginView" pc="268447800" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="48" parent="globals/LoginView" pc="268447811" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="49" parent="globals/LoginView" pc="268447840" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="50" parent="globals/LoginView" pc="268447874" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="51" parent="globals/LoginView" pc="268447885" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="52" parent="globals/LoginView" pc="268447894" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="53" parent="globals/LoginView" pc="268447932" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="54" parent="globals/LoginView" pc="268447943" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="97" parent="globals/LoginView" pc="268448003" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="98" parent="globals/LoginView" pc="268448005" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="99" parent="globals/LoginView" pc="268448014" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="100" parent="globals/LoginView" pc="268448052" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="146" lineNum="70" parent="globals/LoginView" pc="268448064" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="146" lineNum="71" parent="globals/LoginView" pc="268448066" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="146" lineNum="72" parent="globals/LoginView" pc="268448074" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="146" lineNum="73" parent="globals/LoginView" pc="268448084" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="146" lineNum="74" parent="globals/LoginView" pc="268448154" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="146" lineNum="75" parent="globals/LoginView" pc="268448165" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="146" lineNum="76" parent="globals/LoginView" pc="268448236" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="146" lineNum="77" parent="globals/LoginView" pc="268448247" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="33" parent="globals/LoginView" pc="268448314" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="34" parent="globals/LoginView" pc="268448317" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="35" parent="globals/LoginView" pc="268448329" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="36" parent="globals/LoginView" pc="268448337" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="37" parent="globals/LoginView" pc="268448362" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="38" parent="globals/LoginView" pc="268448374" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="39" parent="globals/LoginView" pc="268448401" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="40" parent="globals/LoginView" pc="268448413" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="148" lineNum="59" parent="globals/LoginView" pc="268448422" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="148" lineNum="60" parent="globals/LoginView" pc="268448424" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="148" lineNum="60" parent="globals/LoginView" pc="268448433" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="148" lineNum="60" parent="globals/LoginView" pc="268448445" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="149" lineNum="81" parent="globals/LoginView" pc="268448457" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="149" lineNum="82" parent="globals/LoginView" pc="268448459" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="149" lineNum="83" parent="globals/LoginView" pc="268448471" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="149" lineNum="84" parent="globals/LoginView" pc="268448479" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="149" lineNum="85" parent="globals/LoginView" pc="268448495" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="150" lineNum="74" parent="globals/DownloadedMenuDelegate" pc="268448535" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="150" lineNum="75" parent="globals/DownloadedMenuDelegate" pc="268448538" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="150" lineNum="75" parent="globals/DownloadedMenuDelegate" pc="268448550" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="150" lineNum="77" parent="globals/DownloadedMenuDelegate" pc="268448554" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="150" lineNum="78" parent="globals/DownloadedMenuDelegate" pc="268448573" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="150" lineNum="78" parent="globals/DownloadedMenuDelegate" pc="268448579" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="150" lineNum="79" parent="globals/DownloadedMenuDelegate" pc="268448586" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="150" lineNum="80" parent="globals/DownloadedMenuDelegate" pc="268448602" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="150" lineNum="82" parent="globals/DownloadedMenuDelegate" pc="268448627" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="150" lineNum="84" parent="globals/DownloadedMenuDelegate" pc="268448647" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="150" lineNum="85" parent="globals/DownloadedMenuDelegate" pc="268448658" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="151" lineNum="88" parent="globals/DownloadedMenuDelegate" pc="268448691" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="151" lineNum="89" parent="globals/DownloadedMenuDelegate" pc="268448693" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="152" lineNum="12" parent="globals/DownloadedMenuDelegate" pc="268448709" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="152" lineNum="13" parent="globals/DownloadedMenuDelegate" pc="268448711" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="16" parent="globals/DownloadedMenuDelegate" pc="268448724" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="17" parent="globals/DownloadedMenuDelegate" pc="268448727" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="21" parent="globals/DownloadedMenuDelegate" pc="268448736" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="22" parent="globals/DownloadedMenuDelegate" pc="268448769" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="23" parent="globals/DownloadedMenuDelegate" pc="268448820" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="31" parent="globals/DownloadedMenuDelegate" pc="268448824" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="32" parent="globals/DownloadedMenuDelegate" pc="268448857" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="33" parent="globals/DownloadedMenuDelegate" pc="268448871" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="39" parent="globals/DownloadedMenuDelegate" pc="268448875" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="40" parent="globals/DownloadedMenuDelegate" pc="268448908" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="41" parent="globals/DownloadedMenuDelegate" pc="268448919" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="42" parent="globals/DownloadedMenuDelegate" pc="268448970" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="49" parent="globals/DownloadedMenuDelegate" pc="268448974" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="50" parent="globals/DownloadedMenuDelegate" pc="268449007" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="51" parent="globals/DownloadedMenuDelegate" pc="268449018" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="52" parent="globals/DownloadedMenuDelegate" pc="268449038" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="53" parent="globals/DownloadedMenuDelegate" pc="268449070" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="57" parent="globals/DownloadedMenuDelegate" pc="268449074" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="58" parent="globals/DownloadedMenuDelegate" pc="268449107" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="59" parent="globals/DownloadedMenuDelegate" pc="268449126" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="59" parent="globals/DownloadedMenuDelegate" pc="268449132" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="60" parent="globals/DownloadedMenuDelegate" pc="268449139" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="61" parent="globals/DownloadedMenuDelegate" pc="268449150" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="68" parent="globals/DownloadedMenuDelegate" pc="268449154" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="154" lineNum="14" parent="globals/ErrorViewDelegate" pc="268449173" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="154" lineNum="15" parent="globals/ErrorViewDelegate" pc="268449175" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="154" lineNum="16" parent="globals/ErrorViewDelegate" pc="268449190" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="155" lineNum="10" parent="globals/ErrorViewDelegate" pc="268449192" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="155" lineNum="11" parent="globals/ErrorViewDelegate" pc="268449194" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="156" lineNum="9" parent="globals/ErrorView" pc="268449207" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="156" lineNum="10" parent="globals/ErrorView" pc="268449209" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="156" lineNum="11" parent="globals/ErrorView" pc="268449221" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="157" lineNum="14" parent="globals/ErrorView" pc="268449231" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="157" lineNum="15" parent="globals/ErrorView" pc="268449233" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="157" lineNum="16" parent="globals/ErrorView" pc="268449245" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="157" lineNum="17" parent="globals/ErrorView" pc="268449253" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="157" lineNum="18" parent="globals/ErrorView" pc="268449269" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="158" lineNum="71" parent="globals/DownloadedMenu" pc="268449309" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="158" lineNum="72" parent="globals/DownloadedMenu" pc="268449312" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="158" lineNum="73" parent="globals/DownloadedMenu" pc="268449324" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="158" lineNum="74" parent="globals/DownloadedMenu" pc="268449327" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="158" lineNum="74" parent="globals/DownloadedMenu" pc="268449344" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="158" lineNum="75" parent="globals/DownloadedMenu" pc="268449356" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="158" lineNum="76" parent="globals/DownloadedMenu" pc="268449371" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="159" lineNum="62" parent="globals/DownloadedMenu" pc="268449430" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="159" lineNum="63" parent="globals/DownloadedMenu" pc="268449433" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="159" lineNum="64" parent="globals/DownloadedMenu" pc="268449452" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="13" parent="globals/DownloadedMenu" pc="268449496" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="14" parent="globals/DownloadedMenu" pc="268449499" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="19" parent="globals/DownloadedMenu" pc="268449530" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="21" parent="globals/DownloadedMenu" pc="268449599" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="22" parent="globals/DownloadedMenu" pc="268449618" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="22" parent="globals/DownloadedMenu" pc="268449624" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="30" parent="globals/DownloadedMenu" pc="268449631" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="31" parent="globals/DownloadedMenu" pc="268449643" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="36" parent="globals/DownloadedMenu" pc="268449715" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="37" parent="globals/DownloadedMenu" pc="268449728" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="44" parent="globals/DownloadedMenu" pc="268449800" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="45" parent="globals/DownloadedMenu" pc="268449809" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="48" parent="globals/DownloadedMenu" pc="268449881" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="49" parent="globals/DownloadedMenu" pc="268449893" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="52" parent="globals/DownloadedMenu" pc="268449965" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="53" parent="globals/DownloadedMenu" pc="268449981" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="54" parent="globals/DownloadedMenu" pc="268449988" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="55" parent="globals/DownloadedMenu" pc="268450004" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="56" parent="globals/DownloadedMenu" pc="268450040" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="57" parent="globals/DownloadedMenu" pc="268450056" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="58" parent="globals/DownloadedMenu" pc="268450093" symbol="initialize"/>
+    </pcToLineNum>
+    <symbolTable>
+        <entry id="50" method="true" symbol="containsId"/>
+        <entry id="8388639" module="true" symbol="Graphics"/>
+        <entry id="8390434" method="true" symbol="getSyncConfigurationView"/>
+        <entry id="22" object="true" symbol="DownloadedMenu"/>
+        <entry field="true" id="63" symbol="&lt;globals/GroupDelegate/&lt;&gt;mType&gt;"/>
+        <entry id="8390557" method="true" symbol="resetContentIterator"/>
+        <entry id="95" method="true" symbol="isConfigured"/>
+        <entry id="71" method="true" symbol="ensureMeta"/>
+        <entry id="129" method="true" symbol="titleWithSize"/>
+        <entry id="8390211" module="true" symbol="Media"/>
+        <entry id="114" method="true" symbol="numOr"/>
+        <entry field="true" id="145" symbol="errItems"/>
+        <entry id="48" method="true" symbol="pushGroups"/>
+        <entry id="16" object="true" symbol="AbsProgressListener"/>
+        <entry id="34" object="true" symbol="LoginView"/>
+        <entry id="8388632" method="true" symbol="&lt;init&gt;"/>
+        <entry id="8390379" method="true" symbol="onThumbsUp"/>
+        <entry id="8390380" method="true" symbol="onThumbsDown"/>
+        <entry id="76" method="true" symbol="buildPlaylist"/>
+        <entry id="3" module="true" symbol="globals/BookStore"/>
+        <entry id="49" method="true" symbol="flash"/>
+        <entry field="true" id="136" symbol="byAuthor"/>
+        <entry id="100" method="true" symbol="saveLogin"/>
+        <entry field="true" id="146" symbol="errLibraries"/>
+        <entry id="56" method="true" symbol="onOpDone"/>
+        <entry id="8390335" object="true" symbol="ContentIterator"/>
+        <entry id="35" module="true" symbol="Notify"/>
+        <entry field="true" id="163" symbol="settingApiKey"/>
+        <entry id="8388826" method="true" symbol="next"/>
+        <entry field="true" id="160" symbol="playDownloaded"/>
+        <entry field="true" id="106" symbol="mCallback"/>
+        <entry id="29" object="true" symbol="LibraryMenuDelegate"/>
+        <entry field="true" id="62" symbol="&lt;globals/GroupDelegate/&lt;&gt;mLib&gt;"/>
+        <entry id="18" module="true" symbol="BookStore"/>
+        <entry field="true" id="151" symbol="fieldServer"/>
+        <entry id="17" object="true" symbol="BookMenuDelegate"/>
+        <entry id="46" method="true" symbol="onCollections"/>
+        <entry id="5" module="true" symbol="globals/Chunks"/>
+        <entry field="true" id="78" symbol="&lt;globals/ContentIterator/&lt;&gt;mPlaylist&gt;"/>
+        <entry field="true" id="133" symbol="allBooks"/>
+        <entry id="28" module="true" symbol="JobStore"/>
+        <entry id="72" method="true" symbol="pageKey"/>
+        <entry id="81" method="true" symbol="swap"/>
+        <entry id="8388791" method="true" symbol="remove"/>
+        <entry field="true" id="162" symbol="queued"/>
+        <entry id="8390336" object="true" symbol="ContentDelegate"/>
+        <entry id="15" module="true" symbol="AbsApi"/>
+        <entry field="true" id="161" symbol="queueCleared"/>
+        <entry id="38" module="true" symbol="Versions"/>
+        <entry field="true" id="8388611" module="true" symbol="Toybox"/>
+        <entry id="126" method="true" symbol="queueDelete"/>
+        <entry id="8390377" method="true" symbol="getContentIterator"/>
+        <entry id="84" method="true" symbol="list"/>
+        <entry id="8389108" method="true" symbol="onResponse"/>
+        <entry id="99" method="true" symbol="progressSeconds"/>
+        <entry id="93" method="true" symbol="getLibraries"/>
+        <entry field="true" id="156" symbol="loggingIn"/>
+        <entry id="8390373" method="true" symbol="shuffling"/>
+        <entry id="85" method="true" symbol="_noSlash"/>
+        <entry id="39" object="true" symbol="WatchShelfApp"/>
+        <entry field="true" id="132" symbol="AppName"/>
+        <entry id="8390440" symbol="contentType"/>
+        <entry id="8390459" method="true" symbol="onStopSync"/>
+        <entry id="11" module="true" symbol="globals/Rez/Strings"/>
+        <entry id="19" module="true" symbol="Browse"/>
+        <entry id="8389594" symbol="headers"/>
+        <entry field="true" id="127" symbol="&lt;globals/ErrorView/&lt;&gt;mMessage&gt;"/>
+        <entry id="6" module="true" symbol="globals/JobStore"/>
+        <entry field="true" id="157" symbol="loginFailed"/>
+        <entry field="true" id="119" symbol="&lt;globals/LoginView/&lt;&gt;mCreds&gt;"/>
+        <entry id="70" method="true" symbol="deleteBook"/>
+        <entry id="8390430" method="true" symbol="getContentDelegate"/>
+        <entry id="58" method="true" symbol="sweepOrphans"/>
+        <entry field="true" id="54" symbol="&lt;globals/SyncDelegate/&lt;&gt;mDone&gt;"/>
+        <entry id="111" method="true" symbol="onLibraries"/>
+        <entry field="true" id="150" symbol="fieldPass"/>
+        <entry id="8388648" module="true" symbol="WatchUi"/>
+        <entry id="8389081" method="true" symbol="onBack"/>
+        <entry field="true" id="152" symbol="fieldUser"/>
+        <entry field="true" id="64" symbol="&lt;globals/ContentDelegate/&lt;&gt;mIterator&gt;"/>
+        <entry id="14" module="true" symbol="globals/Versions"/>
+        <entry id="92" method="true" symbol="getGroups"/>
+        <entry id="9" module="true" symbol="globals/Rez"/>
+        <entry id="44" method="true" symbol="onAuthors"/>
+        <entry id="87" method="true" symbol="authToken"/>
+        <entry id="8388789" method="true" symbol="get"/>
+        <entry id="8390342" method="true" symbol="isSyncNeeded"/>
+        <entry field="true" id="144" symbol="errDetail"/>
+        <entry field="true" id="135" symbol="browseLibrary"/>
+        <entry id="8389124" method="true" symbol="onUpdate"/>
+        <entry field="true" id="121" symbol="&lt;globals/LoginView/&lt;&gt;mState&gt;"/>
+        <entry id="8390431" method="true" symbol="getSyncDelegate"/>
+        <entry id="30" object="true" symbol="LibraryView"/>
+        <entry id="82" method="true" symbol="toggleShuffle"/>
+        <entry field="true" id="8390516" symbol="mContext"/>
+        <entry id="80" method="true" symbol="objAt"/>
+        <entry id="8388771" module="true" object="true" symbol="Drawables"/>
+        <entry id="42" method="true" symbol="starts"/>
+        <entry field="true" id="166" symbol="settingServerUrlPrompt"/>
+        <entry id="86" method="true" symbol="_prop"/>
+        <entry id="32" module="true" symbol="Login"/>
+        <entry id="8390433" method="true" symbol="getProviderIconInfo"/>
+        <entry id="57" method="true" symbol="onTrackDownloaded"/>
+        <entry id="7" module="true" symbol="globals/Login"/>
+        <entry field="true" id="158" symbol="pickBook"/>
+        <entry field="true" id="134" symbol="alreadyDownloaded"/>
+        <entry field="true" id="61" symbol="username"/>
+        <entry id="8389850" method="true" symbol="count"/>
+        <entry field="true" id="164" symbol="settingApiKeyPrompt"/>
+        <entry field="true" id="60" symbol="server"/>
+        <entry id="8390442" method="true" symbol="shuffle"/>
+        <entry field="true" id="79" symbol="&lt;globals/ContentIterator/&lt;&gt;mShuffling&gt;"/>
+        <entry id="8390337" object="true" symbol="SyncDelegate"/>
+        <entry id="40" method="true" symbol="at"/>
+        <entry id="8" module="true" symbol="globals/Notify"/>
+        <entry id="123" method="true" symbol="onLogin"/>
+        <entry id="68" method="true" symbol="addRefIds"/>
+        <entry field="true" id="142" symbol="downloaded"/>
+        <entry id="37" module="true" symbol="Store"/>
+        <entry id="13" module="true" symbol="globals/Store"/>
+        <entry id="8388637" module="true" symbol="Communications"/>
+        <entry id="101" method="true" symbol="serverUrl"/>
+        <entry id="24" object="true" symbol="ErrorView"/>
+        <entry id="33" object="true" symbol="LoginCreds"/>
+        <entry id="10" module="true" symbol="globals/Rez/Drawables"/>
+        <entry id="21" module="true" symbol="Chunks"/>
+        <entry id="8390371" method="true" symbol="peekNext"/>
+        <entry field="true" id="148" symbol="errNone"/>
+        <entry id="41" method="true" symbol="same"/>
+        <entry id="83" method="true" symbol="clearAll"/>
+        <entry field="true" id="137" symbol="byCollection"/>
+        <entry id="8390372" method="true" symbol="peekPrevious"/>
+        <entry id="8389844" symbol="responseType"/>
+        <entry field="true" id="109" symbol="&lt;globals/LibraryView/&lt;&gt;mMessage&gt;"/>
+        <entry field="true" id="8392276" symbol="skipForwardTimeDelta"/>
+        <entry id="8392335" module="true" object="true" symbol="Settings"/>
+        <entry field="true" id="159" symbol="pickLibrary"/>
+        <entry id="45" method="true" symbol="onBooks"/>
+        <entry id="69" method="true" symbol="addToIndex"/>
+        <entry id="97" method="true" symbol="logout"/>
+        <entry id="8388786" method="true" symbol="method"/>
+        <entry id="124" method="true" symbol="openField"/>
+        <entry field="true" id="155" symbol="logOut"/>
+        <entry id="8388644" module="true" symbol="System"/>
+        <entry id="8390382" method="true" symbol="onSong"/>
+        <entry id="96" method="true" symbol="login"/>
+        <entry field="true" id="120" symbol="&lt;globals/LoginView/&lt;&gt;mMessage&gt;"/>
+        <entry id="8389619" method="true" symbol="onSelect"/>
+        <entry id="8388769" module="true" object="true" symbol="Rez"/>
+        <entry field="true" id="43" symbol="&lt;globals/BrowseDelegate/&lt;&gt;mLib&gt;"/>
+        <entry field="true" id="59" symbol="password"/>
+        <entry id="25" object="true" symbol="ErrorViewDelegate"/>
+        <entry id="98" method="true" symbol="patchProgress"/>
+        <entry id="8389540" method="true" symbol="onTextEntered"/>
+        <entry id="8390432" method="true" symbol="getPlaybackConfigurationView"/>
+        <entry id="94" method="true" symbol="getSeries"/>
+        <entry id="108" method="true" symbol="showBooks"/>
+        <entry field="true" id="8392277" symbol="skipBackwardTimeDelta"/>
+        <entry field="true" id="105" symbol="&lt;globals/FieldDelegate/&lt;&gt;mView&gt;"/>
+        <entry id="8388640" module="true" symbol="Lang"/>
+        <entry field="true" id="165" symbol="settingServerUrl"/>
+        <entry id="117" method="true" symbol="cancelFlow"/>
+        <entry field="true" id="153" symbol="loading"/>
+        <entry id="23" object="true" symbol="DownloadedMenuDelegate"/>
+        <entry id="8390784" method="true" symbol="onRepeat"/>
+        <entry id="8390374" method="true" symbol="canSkip"/>
+        <entry field="true" id="122" symbol="&lt;globals/LoginView/&lt;&gt;mTimer&gt;"/>
+        <entry id="125" method="true" symbol="setField"/>
+        <entry id="8388610" symbol="statics"/>
+        <entry id="89" method="true" symbol="getBookList"/>
+        <entry id="8389123" method="true" symbol="onShow"/>
+        <entry id="12" module="true" symbol="globals/Settings"/>
+        <entry id="112" method="true" symbol="inBookIndex"/>
+        <entry id="31" object="true" symbol="LibraryViewDelegate"/>
+        <entry id="26" object="true" symbol="FieldDelegate"/>
+        <entry id="8390369" method="true" symbol="getPlaybackProfile"/>
+        <entry id="8389835" method="true" symbol="makeWebRequest"/>
+        <entry id="73" method="true" symbol="removeFromIndex"/>
+        <entry id="8390370" method="true" symbol="previous"/>
+        <entry id="8390522" method="true" symbol="key"/>
+        <entry field="true" id="130" symbol="launcher"/>
+        <entry field="true" id="110" symbol="&lt;globals/LibraryView/&lt;&gt;mStarted&gt;"/>
+        <entry id="8389350" module="true" symbol="globals"/>
+        <entry field="true" id="139" symbol="clearQueue"/>
+        <entry field="true" id="149" symbol="errTooManyFiles"/>
+        <entry id="116" method="true" symbol="plannedChunks"/>
+        <entry id="8388770" module="true" object="true" symbol="Strings"/>
+        <entry id="8391940" method="true" symbol="showToast"/>
+        <entry id="20" object="true" symbol="BrowseDelegate"/>
+        <entry id="8388702" method="true" symbol="initialize"/>
+        <entry field="true" id="113" symbol="&lt;globals/BookMenuDelegate/&lt;&gt;mItemId&gt;"/>
+        <entry id="51" method="true" symbol="deleteQueued"/>
+        <entry id="67" method="true" symbol="addLookup"/>
+        <entry field="true" id="154" symbol="logIn"/>
+        <entry field="true" id="65" symbol="&lt;globals/ContentDelegate/&lt;&gt;mProgressLookup&gt;"/>
+        <entry field="true" id="141" symbol="deleting"/>
+        <entry id="36" object="true" symbol="RequestDelegate"/>
+        <entry id="53" method="true" symbol="downloadNext"/>
+        <entry id="2" module="true" symbol="globals/AbsApi"/>
+        <entry id="8388641" module="true" symbol="Math"/>
+        <entry id="8389541" method="true" symbol="onCancel"/>
+        <entry id="66" method="true" symbol="syncProgress"/>
+        <entry id="8390341" method="true" symbol="onStartSync"/>
+        <entry id="107" method="true" symbol="onWebResponse"/>
+        <entry id="88" method="true" symbol="getAuthors"/>
+        <entry field="true" id="55" symbol="&lt;globals/SyncDelegate/&lt;&gt;mTotal&gt;"/>
+        <entry id="115" method="true" symbol="onFiles"/>
+        <entry id="74" method="true" symbol="saveChunk"/>
+        <entry id="8388788" method="true" symbol="put"/>
+        <entry id="91" method="true" symbol="getFiles"/>
+        <entry id="103" method="true" symbol="sidecarChunkUrl"/>
+        <entry id="8388646" module="true" object="true" symbol="Timer"/>
+        <entry id="4" module="true" symbol="globals/Browse"/>
+        <entry id="102" method="true" symbol="sidecarBase"/>
+        <entry id="47" method="true" symbol="onSeries"/>
+        <entry field="true" id="147" symbol="errNoAudio"/>
+        <entry id="8388698" method="true" symbol="start"/>
+        <entry id="52" method="true" symbol="deletes"/>
+        <entry id="8390381" method="true" symbol="onShuffle"/>
+        <entry id="27" object="true" symbol="GroupDelegate"/>
+        <entry field="true" id="8389866" method="true" symbol="total"/>
+        <entry field="true" id="77" symbol="&lt;globals/ContentIterator/&lt;&gt;mIndex&gt;"/>
+        <entry field="true" id="143" symbol="downloadsFull"/>
+        <entry id="8390441" object="true" symbol="mediaEncoding"/>
+        <entry id="128" method="true" symbol="hasQueued"/>
+        <entry field="true" id="138" symbol="bySeries"/>
+        <entry field="true" id="140" symbol="deleteAllDownloads"/>
+        <entry id="8389125" method="true" symbol="onHide"/>
+        <entry field="true" id="131" symbol="providerIcon"/>
+        <entry id="118" method="true" symbol="labelFor"/>
+        <entry id="75" method="true" symbol="after"/>
+        <entry id="8388635" module="true" symbol="Application"/>
+        <entry field="true" id="8389642" symbol="title"/>
+        <entry field="true" id="104" symbol="&lt;globals/FieldDelegate/&lt;&gt;mField&gt;"/>
+        <entry id="90" method="true" symbol="getCollections"/>
+    </symbolTable>
+    <localVars>
+        <entry arg="true" endPc="268435798" name="durs" stackId="1" startPc="268435672"/>
+        <entry endPc="268435798" name="n" stackId="2" startPc="268435683"/>
+        <entry endPc="268435795" name="f" stackId="3" startPc="268435702"/>
+        <entry endPc="268435785" name="d" stackId="4" startPc="268435702"/>
+        <entry endPc="268435785" name="pos" stackId="5" startPc="268435702"/>
+        <entry endPc="268435782" name="size" stackId="6" startPc="268435733"/>
+        <entry endPc="268435782" name="end" stackId="7" startPc="268435733"/>
+        <entry arg="true" endPc="268435900" name="dursA" stackId="1" startPc="268435799"/>
+        <entry arg="true" endPc="268435900" name="dursB" stackId="2" startPc="268435799"/>
+        <entry endPc="268435898" name="i" stackId="3" startPc="268435870"/>
+        <entry arg="true" endPc="268436088" name="durs" stackId="1" startPc="268435901"/>
+        <entry arg="true" endPc="268436088" name="k" stackId="2" startPc="268435901"/>
+        <entry endPc="268436088" name="n" stackId="3" startPc="268435912"/>
+        <entry endPc="268436088" name="bookOffset" stackId="4" startPc="268435912"/>
+        <entry endPc="268436086" name="f" stackId="5" startPc="268435934"/>
+        <entry endPc="268436076" name="d" stackId="6" startPc="268435934"/>
+        <entry endPc="268436076" name="pos" stackId="7" startPc="268435934"/>
+        <entry endPc="268436066" name="size" stackId="8" startPc="268435965"/>
+        <entry endPc="268436066" name="end" stackId="9" startPc="268435965"/>
+        <entry arg="true" endPc="268436239" name="durs" stackId="1" startPc="268436089"/>
+        <entry endPc="268436239" name="out" stackId="2" startPc="268436100"/>
+        <entry endPc="268436239" name="bookOffset" stackId="3" startPc="268436100"/>
+        <entry endPc="268436236" name="f" stackId="4" startPc="268436123"/>
+        <entry endPc="268436226" name="d" stackId="5" startPc="268436123"/>
+        <entry endPc="268436226" name="pos" stackId="6" startPc="268436123"/>
+        <entry endPc="268436216" name="size" stackId="7" startPc="268436154"/>
+        <entry endPc="268436216" name="end" stackId="8" startPc="268436154"/>
+        <entry arg="true" endPc="268436265" name="code" stackId="1" startPc="268436240"/>
+        <entry arg="true" endPc="268436265" name="data" stackId="2" startPc="268436240"/>
+        <entry arg="true" endPc="268436309" name="code" stackId="1" startPc="268436284"/>
+        <entry arg="true" endPc="268436309" name="data" stackId="2" startPc="268436284"/>
+        <entry arg="true" endPc="268436676" name="code" stackId="1" startPc="268436310"/>
+        <entry arg="true" endPc="268436676" name="data" stackId="2" startPc="268436310"/>
+        <entry arg="true" endPc="268436676" name="key" stackId="3" startPc="268436310"/>
+        <entry arg="true" endPc="268436676" name="filterType" stackId="4" startPc="268436310"/>
+        <entry endPc="268436675" name="groups" stackId="5" startPc="268436313"/>
+        <entry endPc="268436675" name="m" stackId="6" startPc="268436313"/>
+        <entry endPc="268436633" name="i" stackId="7" startPc="268436528"/>
+        <entry endPc="268436623" name="g" stackId="8" startPc="268436528"/>
+        <entry endPc="268436623" name="sub" stackId="9" startPc="268436528"/>
+        <entry arg="true" endPc="268436696" name="code" stackId="1" startPc="268436677"/>
+        <entry arg="true" endPc="268436696" name="data" stackId="2" startPc="268436677"/>
+        <entry arg="true" endPc="268436722" name="code" stackId="1" startPc="268436697"/>
+        <entry arg="true" endPc="268436722" name="data" stackId="2" startPc="268436697"/>
+        <entry arg="true" endPc="268436746" name="libId" stackId="1" startPc="268436723"/>
+        <entry arg="true" endPc="268436945" name="item" stackId="1" startPc="268436747"/>
+        <entry endPc="268436944" name="mode" stackId="2" startPc="268436750"/>
+        <entry arg="true" endPc="268437063" name="stringRezId" stackId="1" startPc="268436946"/>
+        <entry endPc="268437321" name="toDelete" stackId="1" startPc="268437067"/>
+        <entry endPc="268437118" name="i" stackId="2" startPc="268437091"/>
+        <entry endPc="268437321" name="jobIds" stackId="3" startPc="268437067"/>
+        <entry endPc="268437275" name="i" stackId="4" startPc="268437161"/>
+        <entry endPc="268437265" name="job" stackId="5" startPc="268437161"/>
+        <entry endPc="268437265" name="left" stackId="6" startPc="268437161"/>
+        <entry endPc="268437358" name="d" stackId="1" startPc="268437326"/>
+        <entry endPc="268437744" name="jobIds" stackId="1" startPc="268437362"/>
+        <entry endPc="268437744" name="itemId" stackId="2" startPc="268437362"/>
+        <entry endPc="268437744" name="job" stackId="3" startPc="268437362"/>
+        <entry endPc="268437744" name="c" stackId="4" startPc="268437362"/>
+        <entry endPc="268437744" name="options" stackId="5" startPc="268437362"/>
+        <entry endPc="268437744" name="context" stackId="6" startPc="268437362"/>
+        <entry endPc="268437744" name="delegate" stackId="7" startPc="268437362"/>
+        <entry endPc="268437744" name="url" stackId="8" startPc="268437362"/>
+        <entry endPc="268437821" name="pct" stackId="1" startPc="268437749"/>
+        <entry arg="true" endPc="268438039" name="toDelete" stackId="1" startPc="268437823"/>
+        <entry endPc="268437910" name="i" stackId="2" startPc="268437858"/>
+        <entry endPc="268438038" name="fresh" stackId="3" startPc="268437826"/>
+        <entry endPc="268438038" name="remaining" stackId="4" startPc="268437826"/>
+        <entry endPc="268437985" name="i" stackId="5" startPc="268437939"/>
+        <entry arg="true" endPc="268438389" name="code" stackId="1" startPc="268438040"/>
+        <entry arg="true" endPc="268438389" name="data" stackId="2" startPc="268438040"/>
+        <entry arg="true" endPc="268438389" name="context" stackId="3" startPc="268438040"/>
+        <entry endPc="268438388" name="itemId" stackId="4" startPc="268438043"/>
+        <entry endPc="268438388" name="refId" stackId="5" startPc="268438043"/>
+        <entry endPc="268438388" name="job" stackId="6" startPc="268438043"/>
+        <entry endPc="268438388" name="k" stackId="7" startPc="268438043"/>
+        <entry arg="true" endPc="268438443" name="arr" stackId="1" startPc="268438390"/>
+        <entry arg="true" endPc="268438443" name="itemId" stackId="2" startPc="268438390"/>
+        <entry endPc="268438441" name="i" stackId="3" startPc="268438409"/>
+        <entry endPc="268438809" name="known" stackId="1" startPc="268438475"/>
+        <entry endPc="268438809" name="index" stackId="2" startPc="268438475"/>
+        <entry endPc="268438556" name="b" stackId="3" startPc="268438527"/>
+        <entry endPc="268438809" name="jobIds" stackId="4" startPc="268438475"/>
+        <entry endPc="268438636" name="i" stackId="5" startPc="268438585"/>
+        <entry endPc="268438809" name="orphans" stackId="6" startPc="268438475"/>
+        <entry endPc="268438809" name="iter" stackId="7" startPc="268438475"/>
+        <entry endPc="268438738" name="ref" stackId="8" startPc="268438674"/>
+        <entry endPc="268438809" name="i" stackId="9" startPc="268438758"/>
+        <entry arg="true" endPc="268438959" name="code" stackId="1" startPc="268438940"/>
+        <entry arg="true" endPc="268438959" name="data" stackId="2" startPc="268438940"/>
+        <entry arg="true" endPc="268438992" name="libId" stackId="1" startPc="268438960"/>
+        <entry arg="true" endPc="268438992" name="filterType" stackId="2" startPc="268438960"/>
+        <entry arg="true" endPc="268439038" name="item" stackId="1" startPc="268438993"/>
+        <entry arg="true" endPc="268439074" name="code" stackId="1" startPc="268439039"/>
+        <entry arg="true" endPc="268439074" name="data" stackId="2" startPc="268439039"/>
+        <entry arg="true" endPc="268439130" name="item" stackId="1" startPc="268439108"/>
+        <entry arg="true" endPc="268439249" name="args" stackId="1" startPc="268439229"/>
+        <entry endPc="268439453" name="version" stackId="1" startPc="268439274"/>
+        <entry endPc="268439438" name="server" stackId="2" startPc="268439301"/>
+        <entry endPc="268439438" name="token" stackId="3" startPc="268439301"/>
+        <entry arg="true" endPc="268439775" name="refId" stackId="1" startPc="268439527"/>
+        <entry arg="true" endPc="268439775" name="positionInChapter" stackId="2" startPc="268439527"/>
+        <entry endPc="268439721" name="index" stackId="3" startPc="268439557"/>
+        <entry endPc="268439721" name="b" stackId="4" startPc="268439614"/>
+        <entry endPc="268439711" name="perBook" stackId="5" startPc="268439614"/>
+        <entry endPc="268439711" name="refIds" stackId="6" startPc="268439614"/>
+        <entry endPc="268439711" name="i" stackId="7" startPc="268439665"/>
+        <entry endPc="268439774" name="hit" stackId="8" startPc="268439530"/>
+        <entry endPc="268439774" name="absolute" stackId="9" startPc="268439530"/>
+        <entry arg="true" endPc="268439859" name="refId" stackId="1" startPc="268439809"/>
+        <entry arg="true" endPc="268439859" name="songEvent" stackId="2" startPc="268439809"/>
+        <entry arg="true" endPc="268439859" name="playbackPosition" stackId="3" startPc="268439809"/>
+        <entry arg="true" endPc="268440137" name="itemId" stackId="1" startPc="268439896"/>
+        <entry endPc="268440136" name="last" stackId="2" startPc="268439907"/>
+        <entry endPc="268440113" name="p" stackId="3" startPc="268439963"/>
+        <entry endPc="268440103" name="arr" stackId="4" startPc="268439963"/>
+        <entry endPc="268440075" name="i" stackId="5" startPc="268440012"/>
+        <entry arg="true" endPc="268440261" name="itemId" stackId="1" startPc="268440138"/>
+        <entry endPc="268440260" name="index" stackId="2" startPc="268440149"/>
+        <entry endPc="268440228" name="i" stackId="3" startPc="268440197"/>
+        <entry arg="true" endPc="268440389" name="itemId" stackId="1" startPc="268440262"/>
+        <entry endPc="268440388" name="index" stackId="2" startPc="268440273"/>
+        <entry endPc="268440388" name="out" stackId="3" startPc="268440273"/>
+        <entry endPc="268440368" name="i" stackId="4" startPc="268440322"/>
+        <entry arg="true" endPc="268440422" name="itemId" stackId="1" startPc="268440390"/>
+        <entry arg="true" endPc="268440506" name="itemId" stackId="1" startPc="268440423"/>
+        <entry endPc="268440506" name="total" stackId="2" startPc="268440434"/>
+        <entry endPc="268440506" name="p" stackId="3" startPc="268440434"/>
+        <entry endPc="268440500" name="arr" stackId="4" startPc="268440444"/>
+        <entry arg="true" endPc="268440618" name="itemId" stackId="1" startPc="268440507"/>
+        <entry arg="true" endPc="268440618" name="out" stackId="2" startPc="268440507"/>
+        <entry endPc="268440617" name="p" stackId="3" startPc="268440518"/>
+        <entry endPc="268440614" name="arr" stackId="4" startPc="268440525"/>
+        <entry endPc="268440607" name="i" stackId="5" startPc="268440577"/>
+        <entry arg="true" endPc="268440815" name="itemId" stackId="1" startPc="268440619"/>
+        <entry arg="true" endPc="268440815" name="order" stackId="2" startPc="268440619"/>
+        <entry arg="true" endPc="268440815" name="out" stackId="3" startPc="268440619"/>
+        <entry endPc="268440814" name="meta" stackId="4" startPc="268440630"/>
+        <entry endPc="268440814" name="starts" stackId="5" startPc="268440630"/>
+        <entry endPc="268440814" name="k" stackId="6" startPc="268440630"/>
+        <entry endPc="268440814" name="p" stackId="7" startPc="268440630"/>
+        <entry endPc="268440811" name="arr" stackId="8" startPc="268440684"/>
+        <entry endPc="268440804" name="i" stackId="9" startPc="268440738"/>
+        <entry arg="true" endPc="268441051" name="itemId" stackId="1" startPc="268440816"/>
+        <entry arg="true" endPc="268441051" name="k" stackId="2" startPc="268440816"/>
+        <entry arg="true" endPc="268441051" name="refId" stackId="3" startPc="268440816"/>
+        <entry endPc="268441050" name="p" stackId="4" startPc="268440827"/>
+        <entry endPc="268441050" name="idx" stackId="5" startPc="268440827"/>
+        <entry endPc="268441050" name="arr" stackId="6" startPc="268440827"/>
+        <entry endPc="268440981" name="old" stackId="7" startPc="268440904"/>
+        <entry arg="true" endPc="268441079" name="itemId" stackId="1" startPc="268441052"/>
+        <entry arg="true" endPc="268441079" name="p" stackId="2" startPc="268441052"/>
+        <entry arg="true" endPc="268441098" name="itemId" stackId="1" startPc="268441080"/>
+        <entry arg="true" endPc="268441170" name="itemId" stackId="1" startPc="268441099"/>
+        <entry arg="true" endPc="268441170" name="title" stackId="2" startPc="268441099"/>
+        <entry arg="true" endPc="268441170" name="durs" stackId="3" startPc="268441099"/>
+        <entry arg="true" endPc="268441378" name="idx" stackId="1" startPc="268441230"/>
+        <entry endPc="268441368" name="e" stackId="2" startPc="268441311"/>
+        <entry arg="true" endPc="268441458" name="arr" stackId="1" startPc="268441425"/>
+        <entry arg="true" endPc="268441458" name="j" stackId="2" startPc="268441425"/>
+        <entry endPc="268441457" name="tmp" stackId="3" startPc="268441428"/>
+        <entry endPc="268441654" name="profile" stackId="1" startPc="268441529"/>
+        <entry arg="true" endPc="268441760" name="orderA" stackId="1" startPc="268441736"/>
+        <entry arg="true" endPc="268441760" name="startA" stackId="2" startPc="268441736"/>
+        <entry arg="true" endPc="268441760" name="orderB" stackId="3" startPc="268441736"/>
+        <entry arg="true" endPc="268441760" name="startB" stackId="4" startPc="268441736"/>
+        <entry endPc="268441850" name="i" stackId="1" startPc="268441787"/>
+        <entry endPc="268441840" name="j" stackId="2" startPc="268441787"/>
+        <entry endPc="268441840" name="tmp" stackId="3" startPc="268441787"/>
+        <entry endPc="268442241" name="orders" stackId="1" startPc="268441863"/>
+        <entry endPc="268442241" name="starts" stackId="2" startPc="268441863"/>
+        <entry endPc="268442241" name="lookup" stackId="3" startPc="268441863"/>
+        <entry endPc="268442241" name="index" stackId="4" startPc="268441863"/>
+        <entry endPc="268441963" name="b" stackId="5" startPc="268441932"/>
+        <entry endPc="268442241" name="iter" stackId="6" startPc="268441863"/>
+        <entry endPc="268442096" name="ref" stackId="7" startPc="268441997"/>
+        <entry endPc="268442093" name="refId" stackId="8" startPc="268442013"/>
+        <entry endPc="268442093" name="info" stackId="9" startPc="268442013"/>
+        <entry endPc="268442233" name="i" stackId="10" startPc="268442121"/>
+        <entry endPc="268442223" name="j" stackId="11" startPc="268442121"/>
+        <entry arg="true" endPc="268442275" name="itemId" stackId="1" startPc="268442243"/>
+        <entry endPc="268442319" name="index" stackId="1" startPc="268442287"/>
+        <entry arg="true" endPc="268442338" name="itemId" stackId="1" startPc="268442320"/>
+        <entry arg="true" endPc="268442463" name="itemId" stackId="1" startPc="268442339"/>
+        <entry arg="true" endPc="268442463" name="job" stackId="2" startPc="268442339"/>
+        <entry endPc="268442462" name="index" stackId="3" startPc="268442350"/>
+        <entry endPc="268442430" name="i" stackId="4" startPc="268442399"/>
+        <entry arg="true" endPc="268442626" name="itemId" stackId="1" startPc="268442464"/>
+        <entry endPc="268442625" name="index" stackId="2" startPc="268442475"/>
+        <entry endPc="268442625" name="out" stackId="3" startPc="268442475"/>
+        <entry endPc="268442549" name="i" stackId="4" startPc="268442503"/>
+        <entry endPc="268442685" name="index" stackId="1" startPc="268442638"/>
+        <entry endPc="268442685" name="i" stackId="2" startPc="268442662"/>
+        <entry endPc="268442844" name="v" stackId="1" startPc="268442799"/>
+        <entry arg="true" endPc="268442903" name="server" stackId="1" startPc="268442845"/>
+        <entry arg="true" endPc="268442903" name="token" stackId="2" startPc="268442845"/>
+        <entry arg="true" endPc="268442932" name="libId" stackId="1" startPc="268442904"/>
+        <entry arg="true" endPc="268442932" name="cb" stackId="2" startPc="268442904"/>
+        <entry arg="true" endPc="268443043" name="server" stackId="1" startPc="268442950"/>
+        <entry arg="true" endPc="268443043" name="username" stackId="2" startPc="268442950"/>
+        <entry arg="true" endPc="268443043" name="password" stackId="3" startPc="268442950"/>
+        <entry arg="true" endPc="268443043" name="cb" stackId="4" startPc="268442950"/>
+        <entry arg="true" endPc="268443126" name="itemId" stackId="1" startPc="268443044"/>
+        <entry arg="true" endPc="268443126" name="cb" stackId="2" startPc="268443044"/>
+        <entry arg="true" endPc="268443195" name="key" stackId="1" startPc="268443127"/>
+        <entry endPc="268443195" name="v" stackId="2" startPc="268443138"/>
+        <entry arg="true" endPc="268443305" name="libId" stackId="1" startPc="268443196"/>
+        <entry arg="true" endPc="268443305" name="filterType" stackId="2" startPc="268443196"/>
+        <entry arg="true" endPc="268443305" name="filterId" stackId="3" startPc="268443196"/>
+        <entry arg="true" endPc="268443305" name="cb" stackId="4" startPc="268443196"/>
+        <entry endPc="268443304" name="params" stackId="5" startPc="268443207"/>
+        <entry arg="true" endPc="268443506" name="itemId" stackId="1" startPc="268443353"/>
+        <entry arg="true" endPc="268443506" name="currentTimeSec" stackId="2" startPc="268443353"/>
+        <entry arg="true" endPc="268443506" name="durationSec" stackId="3" startPc="268443353"/>
+        <entry endPc="268443505" name="params" stackId="4" startPc="268443364"/>
+        <entry arg="true" endPc="268443535" name="libId" stackId="1" startPc="268443507"/>
+        <entry arg="true" endPc="268443535" name="cb" stackId="2" startPc="268443507"/>
+        <entry arg="true" endPc="268443588" name="detail" stackId="1" startPc="268443536"/>
+        <entry endPc="268443588" name="p" stackId="2" startPc="268443547"/>
+        <entry arg="true" endPc="268443617" name="libId" stackId="1" startPc="268443589"/>
+        <entry arg="true" endPc="268443617" name="cb" stackId="2" startPc="268443589"/>
+        <entry arg="true" endPc="268443693" name="itemId" stackId="1" startPc="268443618"/>
+        <entry arg="true" endPc="268443693" name="ino" stackId="2" startPc="268443618"/>
+        <entry arg="true" endPc="268443693" name="startSec" stackId="3" startPc="268443618"/>
+        <entry arg="true" endPc="268443693" name="endSec" stackId="4" startPc="268443618"/>
+        <entry arg="true" endPc="268443796" name="url" stackId="1" startPc="268443694"/>
+        <entry endPc="268443943" name="v" stackId="1" startPc="268443808"/>
+        <entry arg="true" endPc="268444018" name="callback" stackId="1" startPc="268443944"/>
+        <entry arg="true" endPc="268444098" name="path" stackId="1" startPc="268444019"/>
+        <entry arg="true" endPc="268444098" name="libId" stackId="2" startPc="268444019"/>
+        <entry arg="true" endPc="268444098" name="cb" stackId="3" startPc="268444019"/>
+        <entry arg="true" endPc="268444123" name="text" stackId="1" startPc="268444099"/>
+        <entry arg="true" endPc="268444123" name="changed" stackId="2" startPc="268444099"/>
+        <entry arg="true" endPc="268444172" name="view" stackId="1" startPc="268444140"/>
+        <entry arg="true" endPc="268444172" name="field" stackId="2" startPc="268444140"/>
+        <entry arg="true" endPc="268444207" name="url" stackId="1" startPc="268444173"/>
+        <entry arg="true" endPc="268444207" name="params" stackId="2" startPc="268444173"/>
+        <entry arg="true" endPc="268444207" name="options" stackId="3" startPc="268444173"/>
+        <entry arg="true" endPc="268444228" name="callback" stackId="1" startPc="268444208"/>
+        <entry arg="true" endPc="268444228" name="context" stackId="2" startPc="268444208"/>
+        <entry arg="true" endPc="268444254" name="code" stackId="1" startPc="268444229"/>
+        <entry arg="true" endPc="268444254" name="data" stackId="2" startPc="268444229"/>
+        <entry arg="true" endPc="268444653" name="libId" stackId="1" startPc="268444255"/>
+        <entry endPc="268444652" name="m" stackId="2" startPc="268444266"/>
+        <entry arg="true" endPc="268445025" name="code" stackId="1" startPc="268444654"/>
+        <entry arg="true" endPc="268445025" name="data" stackId="2" startPc="268444654"/>
+        <entry endPc="268445024" name="books" stackId="3" startPc="268444665"/>
+        <entry endPc="268445024" name="m" stackId="4" startPc="268444665"/>
+        <entry endPc="268444985" name="i" stackId="5" startPc="268444912"/>
+        <entry endPc="268444975" name="b" stackId="6" startPc="268444912"/>
+        <entry arg="true" endPc="268445356" name="code" stackId="1" startPc="268445026"/>
+        <entry arg="true" endPc="268445356" name="data" stackId="2" startPc="268445026"/>
+        <entry endPc="268445288" name="libs" stackId="3" startPc="268445056"/>
+        <entry endPc="268445288" name="menu" stackId="4" startPc="268445056"/>
+        <entry endPc="268445253" name="i" stackId="5" startPc="268445148"/>
+        <entry endPc="268445243" name="lib" stackId="6" startPc="268445148"/>
+        <entry arg="true" endPc="268445573" name="dc" stackId="1" startPc="268445496"/>
+        <entry arg="true" endPc="268445653" name="itemId" stackId="1" startPc="268445608"/>
+        <entry endPc="268445653" name="index" stackId="2" startPc="268445611"/>
+        <entry arg="true" endPc="268445725" name="arr" stackId="1" startPc="268445672"/>
+        <entry arg="true" endPc="268445725" name="itemId" stackId="2" startPc="268445672"/>
+        <entry endPc="268445723" name="i" stackId="3" startPc="268445691"/>
+        <entry arg="true" endPc="268446039" name="excludeId" stackId="1" startPc="268445726"/>
+        <entry endPc="268446039" name="total" stackId="2" startPc="268445729"/>
+        <entry endPc="268446039" name="doomed" stackId="3" startPc="268445729"/>
+        <entry endPc="268446039" name="jobIds" stackId="4" startPc="268445729"/>
+        <entry endPc="268445896" name="i" stackId="5" startPc="268445792"/>
+        <entry endPc="268445886" name="job" stackId="6" startPc="268445792"/>
+        <entry endPc="268446039" name="index" stackId="7" startPc="268445729"/>
+        <entry endPc="268446036" name="i" stackId="8" startPc="268445945"/>
+        <entry arg="true" endPc="268447284" name="code" stackId="1" startPc="268446063"/>
+        <entry arg="true" endPc="268447284" name="data" stackId="2" startPc="268446063"/>
+        <entry endPc="268447283" name="files" stackId="3" startPc="268446066"/>
+        <entry endPc="268447283" name="title" stackId="4" startPc="268446066"/>
+        <entry endPc="268447283" name="inos" stackId="5" startPc="268446066"/>
+        <entry endPc="268447283" name="durs" stackId="6" startPc="268446066"/>
+        <entry endPc="268446356" name="f" stackId="7" startPc="268446273"/>
+        <entry endPc="268446346" name="dur" stackId="8" startPc="268446273"/>
+        <entry endPc="268447283" name="expected" stackId="9" startPc="268446066"/>
+        <entry endPc="268447283" name="meta" stackId="10" startPc="268446066"/>
+        <entry endPc="268447283" name="drifted" stackId="11" startPc="268446066"/>
+        <entry endPc="268447283" name="oldJob" stackId="12" startPc="268446066"/>
+        <entry endPc="268447283" name="gen" stackId="13" startPc="268446066"/>
+        <entry endPc="268447283" name="doomed" stackId="14" startPc="268446066"/>
+        <entry endPc="268447146" name="kept" stackId="15" startPc="268447056"/>
+        <entry endPc="268447126" name="i" stackId="16" startPc="268447077"/>
+        <entry endPc="268447283" name="have" stackId="17" startPc="268446066"/>
+        <entry arg="true" endPc="268447301" name="v" stackId="1" startPc="268447285"/>
+        <entry arg="true" endPc="268447301" name="dflt" stackId="2" startPc="268447285"/>
+        <entry arg="true" endPc="268447349" name="item" stackId="1" startPc="268447302"/>
+        <entry arg="true" endPc="268447561" name="code" stackId="1" startPc="268447350"/>
+        <entry arg="true" endPc="268447561" name="data" stackId="2" startPc="268447350"/>
+        <entry arg="true" endPc="268447680" name="state" stackId="1" startPc="268447562"/>
+        <entry arg="true" endPc="268447766" name="field" stackId="1" startPc="268447681"/>
+        <entry arg="true" endPc="268447766" name="text" stackId="2" startPc="268447681"/>
+        <entry endPc="268448420" name="s" stackId="1" startPc="268448317"/>
+        <entry arg="true" endPc="268448534" name="dc" stackId="1" startPc="268448457"/>
+        <entry arg="true" endPc="268448690" name="itemIds" stackId="1" startPc="268448535"/>
+        <entry endPc="268448689" name="deleteList" stackId="2" startPc="268448538"/>
+        <entry endPc="268448626" name="i" stackId="3" startPc="268448602"/>
+        <entry arg="true" endPc="268449172" name="item" stackId="1" startPc="268448724"/>
+        <entry endPc="268449171" name="id" stackId="2" startPc="268448727"/>
+        <entry endPc="268449150" name="index" stackId="3" startPc="268449107"/>
+        <entry arg="true" endPc="268449230" name="message" stackId="1" startPc="268449207"/>
+        <entry arg="true" endPc="268449308" name="dc" stackId="1" startPc="268449231"/>
+        <entry endPc="268449429" name="stats" stackId="1" startPc="268449312"/>
+        <entry endPc="268449429" name="used" stackId="2" startPc="268449312"/>
+        <entry endPc="268449429" name="mb" stackId="3" startPc="268449312"/>
+        <entry endPc="268449495" name="deleteList" stackId="1" startPc="268449433"/>
+        <entry endPc="268450140" name="index" stackId="1" startPc="268449499"/>
+        <entry endPc="268450140" name="i" stackId="2" startPc="268449981"/>
+        <entry endPc="268450130" name="itemId" stackId="3" startPc="268449981"/>
+        <entry endPc="268450130" name="meta" stackId="4" startPc="268449981"/>
+        <entry endPc="268450130" name="title" stackId="5" startPc="268449981"/>
+        <entry endPc="268450130" name="count" stackId="6" startPc="268449981"/>
+        <entry endPc="268450130" name="sub" stackId="7" startPc="268449981"/>
+    </localVars>
+    <deviceInfo deviceVersion="e6263c2a80ff43933f83afa71f1f6645dc2cb4a3" partNumber="006-B4533-00"/>
+    <annotations>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="queued"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldServer"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="downloadsFull"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="byAuthor"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errNone"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="AppName"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errNoAudio"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="deleteAllDownloads"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingApiKeyPrompt"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldUser"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingServerUrlPrompt"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errTooManyFiles"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loggingIn"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingServerUrl"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="deleting"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errItems"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldPass"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingApiKey"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="clearQueue"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="logIn"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="browseLibrary"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="pickBook"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="alreadyDownloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="bySeries"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loginFailed"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="byCollection"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errLibraries"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="pickLibrary"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="playDownloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loading"/>
+        <annotationEntry annotation="initialized" class="Drawables" module="globals/Rez" symbol="providerIcon"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errDetail"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="allBooks"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="logOut"/>
+        <annotationEntry annotation="initialized" class="Drawables" module="globals/Rez" symbol="launcher"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="downloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="queueCleared"/>
+    </annotations>
+    <dataEntryOffsetMappings>
+        <dataEntry label="globals" offset="139" parentId="" symbolId="globals" type="module"/>
+        <dataEntry label="globals/Chunks" offset="440" parentId="globals" symbolId="Chunks" type="module"/>
+        <dataEntry label="globals/BrowseDelegate" offset="502" parentId="globals" symbolId="BrowseDelegate" type="class"/>
+        <dataEntry label="globals/Notify" offset="618" parentId="globals" symbolId="Notify" type="module"/>
+        <dataEntry label="globals/SyncDelegate" offset="653" parentId="globals" symbolId="SyncDelegate" type="class"/>
+        <dataEntry label="globals/Rez" offset="805" parentId="globals" symbolId="Rez" type="module"/>
+        <dataEntry label="globals/LoginCreds" offset="849" parentId="globals" symbolId="LoginCreds" type="class"/>
+        <dataEntry label="globals/GroupDelegate" offset="920" parentId="globals" symbolId="GroupDelegate" type="class"/>
+        <dataEntry label="globals/Store" offset="1009" parentId="globals" symbolId="Store" type="module"/>
+        <dataEntry label="globals/AbsProgressListener" offset="1035" parentId="globals" symbolId="AbsProgressListener" type="class"/>
+        <dataEntry label="globals/LibraryMenuDelegate" offset="1088" parentId="globals" symbolId="LibraryMenuDelegate" type="class"/>
+        <dataEntry label="globals/WatchShelfApp" offset="1150" parentId="globals" symbolId="WatchShelfApp" type="class"/>
+        <dataEntry label="globals/Settings" offset="1239" parentId="globals" symbolId="Settings" type="module"/>
+        <dataEntry label="globals/ContentDelegate" offset="1265" parentId="globals" symbolId="ContentDelegate" type="class"/>
+        <dataEntry label="globals/BookStore" offset="1399" parentId="globals" symbolId="BookStore" type="module"/>
+        <dataEntry label="globals/ContentIterator" offset="1524" parentId="globals" symbolId="ContentIterator" type="class"/>
+        <dataEntry label="globals/JobStore" offset="1721" parentId="globals" symbolId="JobStore" type="module"/>
+        <dataEntry label="globals/Login" offset="1801" parentId="globals" symbolId="Login" type="module"/>
+        <dataEntry label="globals/AbsApi" offset="1836" parentId="globals" symbolId="AbsApi" type="module"/>
+        <dataEntry label="globals/FieldDelegate" offset="2033" parentId="globals" symbolId="FieldDelegate" type="class"/>
+        <dataEntry label="globals/RequestDelegate" offset="2113" parentId="globals" symbolId="RequestDelegate" type="class"/>
+        <dataEntry label="globals/Browse" offset="2193" parentId="globals" symbolId="Browse" type="module"/>
+        <dataEntry label="globals/Versions" offset="2237" parentId="globals" symbolId="Versions" type="module"/>
+        <dataEntry label="globals/LibraryView" offset="2263" parentId="globals" symbolId="LibraryView" type="class"/>
+        <dataEntry label="globals/LibraryViewDelegate" offset="2352" parentId="globals" symbolId="LibraryViewDelegate" type="class"/>
+        <dataEntry label="globals/BookMenuDelegate" offset="2405" parentId="globals" symbolId="BookMenuDelegate" type="class"/>
+        <dataEntry label="globals/LoginView" offset="2521" parentId="globals" symbolId="LoginView" type="class"/>
+        <dataEntry label="globals/DownloadedMenuDelegate" offset="2673" parentId="globals" symbolId="DownloadedMenuDelegate" type="class"/>
+        <dataEntry label="globals/ErrorViewDelegate" offset="2744" parentId="globals" symbolId="ErrorViewDelegate" type="class"/>
+        <dataEntry label="globals/ErrorView" offset="2797" parentId="globals" symbolId="ErrorView" type="class"/>
+        <dataEntry label="globals/DownloadedMenu" offset="2859" parentId="globals" symbolId="DownloadedMenu" type="class"/>
+        <dataEntry label="globals/Rez/Drawables" offset="2921" parentId="Rez" symbolId="Drawables" type="module"/>
+        <dataEntry label="globals/Rez/Strings" offset="2965" parentId="Rez" symbolId="Strings" type="module"/>
+    </dataEntryOffsetMappings>
+    <functions>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Chunks">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435471" name="&lt;init&gt;" parent="BrowseDelegate" startPc="268435460">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Notify">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435483" name="&lt;init&gt;" parent="SyncDelegate" startPc="268435472">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435503" name="&lt;init&gt;" parent="Rez" startPc="268435484">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="LoginCreds">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435515" name="&lt;init&gt;" parent="GroupDelegate" startPc="268435504">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Store">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="AbsProgressListener">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435527" name="&lt;init&gt;" parent="LibraryMenuDelegate" startPc="268435516">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435539" name="&lt;init&gt;" parent="WatchShelfApp" startPc="268435528">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Settings">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435551" name="&lt;init&gt;" parent="ContentDelegate" startPc="268435540">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="BookStore">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435563" name="&lt;init&gt;" parent="ContentIterator" startPc="268435552">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="JobStore">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Login">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="AbsApi">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435575" name="&lt;init&gt;" parent="FieldDelegate" startPc="268435564">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="RequestDelegate">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Browse">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Versions">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435587" name="&lt;init&gt;" parent="LibraryView" startPc="268435576">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435599" name="&lt;init&gt;" parent="LibraryViewDelegate" startPc="268435588">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435611" name="&lt;init&gt;" parent="BookMenuDelegate" startPc="268435600">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435623" name="&lt;init&gt;" parent="LoginView" startPc="268435612">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435635" name="&lt;init&gt;" parent="DownloadedMenuDelegate" startPc="268435624">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435647" name="&lt;init&gt;" parent="ErrorViewDelegate" startPc="268435636">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435659" name="&lt;init&gt;" parent="ErrorView" startPc="268435648">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435671" name="&lt;init&gt;" parent="DownloadedMenu" startPc="268435660">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435798" name="total" parent="Chunks" startPc="268435672">
+            <param id="durs"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435900" name="same" parent="Chunks" startPc="268435799">
+            <param id="dursA"/>
+            <param id="dursB"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436088" name="at" parent="Chunks" startPc="268435901">
+            <param id="durs"/>
+            <param id="k"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436239" name="starts" parent="Chunks" startPc="268436089">
+            <param id="durs"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436265" name="onSeries" parent="BrowseDelegate" startPc="268436240">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436283" name="onBack" parent="BrowseDelegate" startPc="268436266">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436309" name="onAuthors" parent="BrowseDelegate" startPc="268436284">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436676" name="pushGroups" parent="BrowseDelegate" startPc="268436310">
+            <param id="code"/>
+            <param id="data"/>
+            <param id="key"/>
+            <param id="filterType"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436696" name="onBooks" parent="BrowseDelegate" startPc="268436677">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436722" name="onCollections" parent="BrowseDelegate" startPc="268436697">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436746" name="initialize" parent="BrowseDelegate" startPc="268436723">
+            <param id="libId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436945" name="onSelect" parent="BrowseDelegate" startPc="268436747">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437063" name="flash" parent="Notify" startPc="268436946">
+            <param id="stringRezId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437322" name="onStartSync" parent="SyncDelegate" startPc="268437064">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437358" name="deletes" parent="SyncDelegate" startPc="268437323">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437745" name="downloadNext" parent="SyncDelegate" startPc="268437359">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437822" name="onOpDone" parent="SyncDelegate" startPc="268437746">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438039" name="deleteQueued" parent="SyncDelegate" startPc="268437823">
+            <param id="toDelete"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438389" name="onTrackDownloaded" parent="SyncDelegate" startPc="268438040">
+            <param id="code"/>
+            <param id="data"/>
+            <param id="context"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438443" name="containsId" parent="SyncDelegate" startPc="268438390">
+            <param id="arr"/>
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438471" name="onStopSync" parent="SyncDelegate" startPc="268438444">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438810" name="sweepOrphans" parent="SyncDelegate" startPc="268438472">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438841" name="initialize" parent="SyncDelegate" startPc="268438811">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438882" name="isSyncNeeded" parent="SyncDelegate" startPc="268438842">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Drawables">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Strings">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438921" name="initialize" parent="LoginCreds" startPc="268438883">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438939" name="onBack" parent="GroupDelegate" startPc="268438922">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438959" name="onBooks" parent="GroupDelegate" startPc="268438940">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438992" name="initialize" parent="GroupDelegate" startPc="268438960">
+            <param id="libId"/>
+            <param id="filterType"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439038" name="onSelect" parent="GroupDelegate" startPc="268438993">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439074" name="onResponse" parent="AbsProgressListener" startPc="268439039">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="initialize" parent="AbsProgressListener">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439092" name="onBack" parent="LibraryMenuDelegate" startPc="268439075">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439107" name="initialize" parent="LibraryMenuDelegate" startPc="268439093">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439130" name="onSelect" parent="LibraryMenuDelegate" startPc="268439108">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439179" name="getProviderIconInfo" parent="WatchShelfApp" startPc="268439131">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439228" name="getPlaybackConfigurationView" parent="WatchShelfApp" startPc="268439180">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439249" name="getContentDelegate" parent="WatchShelfApp" startPc="268439229">
+            <param id="args"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439270" name="getSyncDelegate" parent="WatchShelfApp" startPc="268439250">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439454" name="initialize" parent="WatchShelfApp" startPc="268439271">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439503" name="getSyncConfigurationView" parent="WatchShelfApp" startPc="268439455">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439518" name="onShuffle" parent="ContentDelegate" startPc="268439504">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439526" name="getContentIterator" parent="ContentDelegate" startPc="268439519">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439775" name="syncProgress" parent="ContentDelegate" startPc="268439527">
+            <param id="refId"/>
+            <param id="positionInChapter"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439778" name="onThumbsUp" parent="ContentDelegate" startPc="268439776">
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439808" name="initialize" parent="ContentDelegate" startPc="268439779">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439859" name="onSong" parent="ContentDelegate" startPc="268439809">
+            <param id="refId"/>
+            <param id="songEvent"/>
+            <param id="playbackPosition"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="onRepeat" parent="ContentDelegate">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439892" name="resetContentIterator" parent="ContentDelegate" startPc="268439860">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439895" name="onThumbsDown" parent="ContentDelegate" startPc="268439893">
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440137" name="deleteBook" parent="BookStore" startPc="268439896">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440261" name="addToIndex" parent="BookStore" startPc="268440138">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440389" name="removeFromIndex" parent="BookStore" startPc="268440262">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440422" name="get" parent="BookStore" startPc="268440390">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440506" name="count" parent="BookStore" startPc="268440423">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440618" name="addRefIds" parent="BookStore" startPc="268440507">
+            <param id="itemId"/>
+            <param id="out"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440815" name="addLookup" parent="BookStore" startPc="268440619">
+            <param id="itemId"/>
+            <param id="order"/>
+            <param id="out"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441051" name="saveChunk" parent="BookStore" startPc="268440816">
+            <param id="itemId"/>
+            <param id="k"/>
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441079" name="pageKey" parent="BookStore" startPc="268441052">
+            <param id="itemId"/>
+            <param id="p"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441098" name="key" parent="BookStore" startPc="268441080">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441170" name="ensureMeta" parent="BookStore" startPc="268441099">
+            <param id="itemId"/>
+            <param id="title"/>
+            <param id="durs"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441229" name="next" parent="ContentIterator" startPc="268441171">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441378" name="objAt" parent="ContentIterator" startPc="268441230">
+            <param id="idx"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441424" name="previous" parent="ContentIterator" startPc="268441379">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441458" name="swap" parent="ContentIterator" startPc="268441425">
+            <param id="arr"/>
+            <param id="j"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441477" name="peekPrevious" parent="ContentIterator" startPc="268441459">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441481" name="canSkip" parent="ContentIterator" startPc="268441478">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441525" name="toggleShuffle" parent="ContentIterator" startPc="268441482">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441654" name="getPlaybackProfile" parent="ContentIterator" startPc="268441526">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441673" name="peekNext" parent="ContentIterator" startPc="268441655">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441689" name="get" parent="ContentIterator" startPc="268441674">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441697" name="shuffling" parent="ContentIterator" startPc="268441690">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441735" name="initialize" parent="ContentIterator" startPc="268441698">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441760" name="after" parent="ContentIterator" startPc="268441736">
+            <param id="orderA"/>
+            <param id="startA"/>
+            <param id="orderB"/>
+            <param id="startB"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441859" name="shuffle" parent="ContentIterator" startPc="268441761">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442242" name="buildPlaylist" parent="ContentIterator" startPc="268441860">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442275" name="get" parent="JobStore" startPc="268442243">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442319" name="list" parent="JobStore" startPc="268442276">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442338" name="key" parent="JobStore" startPc="268442320">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442463" name="put" parent="JobStore" startPc="268442339">
+            <param id="itemId"/>
+            <param id="job"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442626" name="remove" parent="JobStore" startPc="268442464">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442686" name="clearAll" parent="JobStore" startPc="268442627">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442756" name="start" parent="Login" startPc="268442687">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442787" name="isConfigured" parent="AbsApi" startPc="268442757">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442844" name="authToken" parent="AbsApi" startPc="268442788">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442903" name="saveLogin" parent="AbsApi" startPc="268442845">
+            <param id="server"/>
+            <param id="token"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442932" name="getCollections" parent="AbsApi" startPc="268442904">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442949" name="sidecarBase" parent="AbsApi" startPc="268442933">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443043" name="login" parent="AbsApi" startPc="268442950">
+            <param id="server"/>
+            <param id="username"/>
+            <param id="password"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443126" name="getFiles" parent="AbsApi" startPc="268443044">
+            <param id="itemId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443195" name="_prop" parent="AbsApi" startPc="268443127">
+            <param id="key"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443305" name="getBookList" parent="AbsApi" startPc="268443196">
+            <param id="libId"/>
+            <param id="filterType"/>
+            <param id="filterId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443352" name="logout" parent="AbsApi" startPc="268443306">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443506" name="patchProgress" parent="AbsApi" startPc="268443353">
+            <param id="itemId"/>
+            <param id="currentTimeSec"/>
+            <param id="durationSec"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443535" name="getSeries" parent="AbsApi" startPc="268443507">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443588" name="progressSeconds" parent="AbsApi" startPc="268443536">
+            <param id="detail"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443617" name="getAuthors" parent="AbsApi" startPc="268443589">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443693" name="sidecarChunkUrl" parent="AbsApi" startPc="268443618">
+            <param id="itemId"/>
+            <param id="ino"/>
+            <param id="startSec"/>
+            <param id="endSec"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443796" name="_noSlash" parent="AbsApi" startPc="268443694">
+            <param id="url"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443943" name="serverUrl" parent="AbsApi" startPc="268443797">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444018" name="getLibraries" parent="AbsApi" startPc="268443944">
+            <param id="callback"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444098" name="getGroups" parent="AbsApi" startPc="268444019">
+            <param id="path"/>
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444123" name="onTextEntered" parent="FieldDelegate" startPc="268444099">
+            <param id="text"/>
+            <param id="changed"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444139" name="onCancel" parent="FieldDelegate" startPc="268444124">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444172" name="initialize" parent="FieldDelegate" startPc="268444140">
+            <param id="view"/>
+            <param id="field"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444207" name="makeWebRequest" parent="RequestDelegate" startPc="268444173">
+            <param id="url"/>
+            <param id="params"/>
+            <param id="options"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444228" name="initialize" parent="RequestDelegate" startPc="268444208">
+            <param id="callback"/>
+            <param id="context"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444254" name="onWebResponse" parent="RequestDelegate" startPc="268444229">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444653" name="start" parent="Browse" startPc="268444255">
+            <param id="libId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445025" name="showBooks" parent="Browse" startPc="268444654">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445356" name="onLibraries" parent="LibraryView" startPc="268445026">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445434" name="onShow" parent="LibraryView" startPc="268445357">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445495" name="initialize" parent="LibraryView" startPc="268445435">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445573" name="onUpdate" parent="LibraryView" startPc="268445496">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445592" name="onBack" parent="LibraryViewDelegate" startPc="268445574">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445607" name="initialize" parent="LibraryViewDelegate" startPc="268445593">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445653" name="inBookIndex" parent="BookMenuDelegate" startPc="268445608">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445671" name="onBack" parent="BookMenuDelegate" startPc="268445654">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445725" name="containsId" parent="BookMenuDelegate" startPc="268445672">
+            <param id="arr"/>
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446039" name="plannedChunks" parent="BookMenuDelegate" startPc="268445726">
+            <param id="excludeId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446062" name="initialize" parent="BookMenuDelegate" startPc="268446040">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447284" name="onFiles" parent="BookMenuDelegate" startPc="268446063">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447301" name="numOr" parent="BookMenuDelegate" startPc="268447285">
+            <param id="v"/>
+            <param id="dflt"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447349" name="onSelect" parent="BookMenuDelegate" startPc="268447302">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447561" name="onLogin" parent="LoginView" startPc="268447350">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447680" name="labelFor" parent="LoginView" startPc="268447562">
+            <param id="state"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447766" name="setField" parent="LoginView" startPc="268447681">
+            <param id="field"/>
+            <param id="text"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448002" name="onShow" parent="LoginView" startPc="268447767">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448063" name="cancelFlow" parent="LoginView" startPc="268448003">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448313" name="openField" parent="LoginView" startPc="268448064">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448421" name="initialize" parent="LoginView" startPc="268448314">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448456" name="onHide" parent="LoginView" startPc="268448422">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448534" name="onUpdate" parent="LoginView" startPc="268448457">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448690" name="queueDelete" parent="DownloadedMenuDelegate" startPc="268448535">
+            <param id="itemIds"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448708" name="onBack" parent="DownloadedMenuDelegate" startPc="268448691">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448723" name="initialize" parent="DownloadedMenuDelegate" startPc="268448709">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449172" name="onSelect" parent="DownloadedMenuDelegate" startPc="268448724">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449191" name="onBack" parent="ErrorViewDelegate" startPc="268449173">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449206" name="initialize" parent="ErrorViewDelegate" startPc="268449192">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449230" name="initialize" parent="ErrorView" startPc="268449207">
+            <param id="message"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449308" name="onUpdate" parent="ErrorView" startPc="268449231">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449429" name="titleWithSize" parent="DownloadedMenu" startPc="268449309">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449495" name="hasQueued" parent="DownloadedMenu" startPc="268449430">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268450141" name="initialize" parent="DownloadedMenu" startPc="268449496">
+            <documentation/>
+        </functionEntry>
+    </functions>
+</debugInfo>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -6,8 +6,10 @@
     <string id="pickLibrary">Choose Library</string>
     <string id="pickBook">Choose Book</string>
     <string id="downloaded">Downloaded</string>
-    <string id="queued">Queued.\nSyncing...</string>
-    <string id="deleting">Removing...</string>
+    <string id="queued">Queued</string>
+    <string id="deleting">Removing</string>
+    <string id="downloadsFull">Downloads full.\nDelete a book first.</string>
+    <string id="errTooManyFiles">This book has\ntoo many files</string>
     <string id="clearQueue">Clear queue</string>
     <string id="queueCleared">Queue cleared</string>
     <string id="deleteAllDownloads">Delete all downloads</string>

--- a/source/BookMenuDelegate.mc
+++ b/source/BookMenuDelegate.mc
@@ -3,11 +3,12 @@ using Toybox.Communications;
 using Toybox.WatchUi;
 
 // Picked a book -> get its lean file list from the sidecar, store ONE small
-// per-book job (file inos + durations + title + resume cursor), and run a
-// background sync. Chunk boundaries are derived by the Chunks module at
-// download time - never stored per-chunk (see Constants.mc for the OOM
-// post-mortem that forced this). Everything goes through the sidecar because
-// most books here are single 200MB-1GB files the watch cannot download whole.
+// per-book job (file inos + durations + title + resume cursor) via JobStore,
+// and run a background sync. Chunk boundaries are derived by the Chunks
+// module at download time - never stored per-chunk (see Constants.mc for the
+// OOM post-mortem that forced this). Everything goes through the sidecar
+// because most books here are single 200MB-1GB files the watch cannot
+// download whole.
 class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
 
     private var mItemId;
@@ -48,30 +49,145 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
             return;
         }
 
+        // GATE ORDER MATTERS: every early-return gate below runs BEFORE the
+        // destructive drift wipe. Wiping first and then rejecting (e.g. on
+        // the cap) would strand a live job pointing at deleted pages - the
+        // sync then resumes it mid-book, pads the missing head with nulls,
+        // and the book "completes" with silent holes (or, past page 0, its
+        // fresh downloads get orphan-swept and its pages leak). Nothing is
+        // destroyed until this selection is definitely going to queue.
+
+        // Job values are O(files); past ~600 files the single job value
+        // approaches the 32KB Storage cap (long inode strings included).
+        if (inos.size() > JobStore.MAX_FILES) {
+            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errTooManyFiles)),
+                new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
+            return;
+        }
+
+        // Duration drift: this book was downloaded (fully or partly) against
+        // DIFFERENT per-file durations (server re-transcoded/replaced files),
+        // so its recorded start offsets no longer match the boundaries new
+        // chunks would be cut at - it must restart clean. Same treatment for
+        // a corrupt partial: records exist but the book isn't indexed AND
+        // isn't queued (a crash artifact whose audio the orphan sweep may
+        // already have evicted).
+        var meta = BookStore.get(mItemId);
+        var drifted = false;
+        if (meta != null) {
+            drifted = !Chunks.same(meta["durs"], durs)
+                || (!inBookIndex(mItemId) && !containsId(JobStore.list(), mItemId));
+        }
+
         // Re-selecting an already-fully-downloaded book must not silently queue
-        // a full re-download - tell the user it's already there instead.
-        var have = BookStore.count(mItemId);
-        if (have >= expected) {
+        // a full re-download - tell the user it's already there instead. A
+        // drifted book is never "already there": its data is scheduled to go.
+        if (!drifted && (BookStore.count(mItemId) >= expected)) {
             WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.alreadyDownloaded)),
                 new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }
 
+        // Total-chunk cap: playback builds O(total chunks) structures inside
+        // the 512KB audioContentProvider ceiling, so the watch-wide total
+        // (downloaded + queued, all books) is bounded - see Chunks.MAX_TOTAL.
+        if (plannedChunks(mItemId) + expected > Chunks.MAX_TOTAL) {
+            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.downloadsFull)),
+                new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
+            return;
+        }
+
+        // Read the superseded job's generation BEFORE the wipe removes it, so
+        // "gen" always increments across a drift wipe too - an in-flight chunk
+        // dispatched under the old job can then never collide with the new one.
+        var oldJob = JobStore.get(mItemId);
+        var gen = ((oldJob != null) && (oldJob["gen"] != null)) ? oldJob["gen"] + 1 : 1;
+
+        // All gates passed - NOW it is safe to destroy the drifted book's
+        // state. JOB FIRST: deleteBook is hundreds of Storage ops, and a
+        // hard kill mid-wipe with the job still queued would leave that job
+        // resuming over truncated pages (null-padded silent holes). With the
+        // job already gone, a mid-wipe crash decays to a benign partial that
+        // the stranded/orphan machinery cleans up.
+        if (drifted) {
+            JobStore.remove(mItemId);
+            BookStore.deleteBook(mItemId);
+            BookStore.removeFromIndex(mItemId);
+        }
+
+        // Queueing a book un-dooms it: if it's still sitting in DELETE_LIST
+        // from an earlier delete, the next sync's cancel-then-delete pass
+        // would silently eat this fresh job and wipe the book right after
+        // the user saw "Queued" - the newer intent (download) wins.
+        var doomed = Application.Storage.getValue(Store.DELETE_LIST);
+        if ((doomed != null) && containsId(doomed, mItemId)) {
+            var kept = [];
+            for (var i = 0; i < doomed.size(); ++i) {
+                if (!doomed[i].equals(mItemId)) { kept.add(doomed[i]); }
+            }
+            Application.Storage.setValue(Store.DELETE_LIST, kept);
+        }
+
         // One small job per book. "done" starts at the already-downloaded chunk
         // count so an interrupted book resumes where it left off (chunks always
-        // download in order, so count == next index).
-        var jobs = Application.Storage.getValue(Store.SYNC_JOBS);
-        if (jobs == null) { jobs = {}; }
-        jobs[mItemId] = {
+        // download in order, so count == next index). "gen" increments on every
+        // re-queue so an in-flight chunk from a superseded job can never be
+        // recorded into the new one, even at the same cursor value.
+        var have = drifted ? 0 : BookStore.count(mItemId);
+        JobStore.put(mItemId, {
             "inos"  => inos,
             "durs"  => durs,
             "title" => title,
-            "done"  => have
-        };
-        Application.Storage.setValue(Store.SYNC_JOBS, jobs);
+            "done"  => have,
+            "gen"   => gen
+        });
 
-        WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.queued)), new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
+        Notify.flash(Rez.Strings.queued);
         Communications.startSync();
+    }
+
+    // Chunks already committed to the watch (downloaded or queued, all books),
+    // excluding `excludeId` (the book being re-queued - its own chunks are
+    // accounted for by the caller's `expected`) and any book queued for
+    // DELETION (its chunks are scheduled to go - counting them would reject
+    // the exact "delete a book, then queue a replacement" flow the
+    // "Downloads full" message tells the user to perform). Queued books count
+    // at their FULL size since they will finish; non-queued downloaded books
+    // count at their recorded size.
+    function plannedChunks(excludeId) {
+        var total = 0;
+
+        var doomed = Application.Storage.getValue(Store.DELETE_LIST);
+        if (doomed == null) { doomed = []; }
+
+        var jobIds = JobStore.list();
+        for (var i = 0; i < jobIds.size(); ++i) {
+            if (jobIds[i].equals(excludeId) || containsId(doomed, jobIds[i])) { continue; }
+            var job = JobStore.get(jobIds[i]);
+            if (job != null) { total += Chunks.total(job["durs"]); }
+        }
+
+        var index = Application.Storage.getValue(Store.BOOK_INDEX);
+        if (index == null) { index = []; }
+        for (var i = 0; i < index.size(); ++i) {
+            if (index[i].equals(excludeId) || containsId(jobIds, index[i])
+                || containsId(doomed, index[i])) { continue; }
+            total += BookStore.count(index[i]);
+        }
+        return total;
+    }
+
+    function containsId(arr, itemId) {
+        for (var i = 0; i < arr.size(); ++i) {
+            if (arr[i].equals(itemId)) { return true; }
+        }
+        return false;
+    }
+
+    function inBookIndex(itemId) {
+        var index = Application.Storage.getValue(Store.BOOK_INDEX);
+        if (index == null) { return false; }
+        return containsId(index, itemId);
     }
 
     function numOr(v, dflt) {

--- a/source/BookStore.mc
+++ b/source/BookStore.mc
@@ -101,6 +101,42 @@ module BookStore {
         Application.Storage.deleteValue(key(itemId));
     }
 
+    // ---- BOOK_INDEX maintenance (the menu/playback book list) -------------
+
+    function addToIndex(itemId) {
+        var index = Application.Storage.getValue(Store.BOOK_INDEX);
+        if (index == null) { index = []; }
+        for (var i = 0; i < index.size(); ++i) {
+            if (index[i].equals(itemId)) { return; }
+        }
+        index.add(itemId);
+        Application.Storage.setValue(Store.BOOK_INDEX, index);
+    }
+
+    function removeFromIndex(itemId) {
+        var index = Application.Storage.getValue(Store.BOOK_INDEX);
+        if (index == null) { return; }
+        var out = [];
+        for (var i = 0; i < index.size(); ++i) {
+            if (!index[i].equals(itemId)) { out.add(index[i]); }
+        }
+        Application.Storage.setValue(Store.BOOK_INDEX, out);
+    }
+
+    // Add every recorded refId of a book to `out` as { refId => true } - a
+    // membership set for the end-of-sync orphan sweep.
+    function addRefIds(itemId, out) {
+        var p = 0;
+        while (true) {
+            var arr = Application.Storage.getValue(pageKey(itemId, p));
+            if (arr == null) { return; }
+            for (var i = 0; i < arr.size(); ++i) {
+                if (arr[i] != null) { out[arr[i]] = true; }
+            }
+            p += 1;
+        }
+    }
+
     // Build { refId => [bookOrder, bookAbsoluteStartSeconds] } for one book
     // into `out` (a shared lookup dict used by playback). bookOrder is the
     // caller-supplied position of this book (its BOOK_INDEX slot) - playback

--- a/source/Chunks.mc
+++ b/source/Chunks.mc
@@ -13,6 +13,27 @@ module Chunks {
     const FIRST = 15;    // seconds, global chunk 0 only
     const LEN   = 180;   // seconds, every other chunk
 
+    // Cap on TOTAL chunks on the watch (downloaded + queued, all books).
+    // Playback builds O(total chunks) lookup structures inside the 512KB
+    // audioContentProvider ceiling - validated safe at 1200 chunks in the
+    // simulator; ~2500+ would re-approach the ceiling and resurrect the
+    // uncatchable OOM this design exists to kill. 1500 chunks ~= 75 hours of
+    // audio, plenty for a watch.
+    const MAX_TOTAL = 1500;
+
+    // True if two per-file duration arrays describe the same audio. Used to
+    // detect server-side duration drift on a partially-downloaded book -
+    // resumed chunk boundaries derive from the NEW durs while recorded start
+    // offsets derive from the OLD ones, so a drifted book must restart clean.
+    function same(dursA, dursB) {
+        if ((dursA == null) || (dursB == null)) { return dursA == dursB; }
+        if (dursA.size() != dursB.size()) { return false; }
+        for (var i = 0; i < dursA.size(); ++i) {
+            if (dursA[i] != dursB[i]) { return false; }
+        }
+        return true;
+    }
+
     // Total chunk count across a book's files. durs = [seconds, ...].
     function total(durs) {
         var n = 0;

--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -18,13 +18,12 @@ using Toybox.Application;
 // module, and per-chunk refIds live in one small per-book value.
 // ---------------------------------------------------------------------------
 module Store {
-    // { itemId => { "inos" => [str], "durs" => [num], "title" => str,
-    //   "done" => num } } - one small job per QUEUED book; chunk boundaries
-    // derived on the fly, "done" is the resume cursor. ALWAYS read fresh and
-    // read-modify-written per event, never held across events: a long-lived
-    // in-memory snapshot persisted wholesale silently clobbers queue writes
-    // made while a (background) sync is running.
-    const SYNC_JOBS   = "syncJobs";
+    // Queued download jobs live in JobStore (one job per key + a small
+    // index) - O(files) inos/durs arrays per job must not share one value.
+    // ALWAYS read queue state fresh per event, never held across events: a
+    // long-lived in-memory snapshot persisted wholesale silently clobbers
+    // queue writes made while a (background) sync is running.
+    //
     // [ itemId, ... ] - books queued for DELETION (whole books only; the UI
     // has no per-chunk delete).
     const DELETE_LIST = "deleteList";
@@ -49,10 +48,11 @@ module Settings {
 module Versions {
     enum {
         V1 = 0,
-        V2 = 1   // per-chunk SYNC_LIST/TRACKS dicts -> per-book jobs + BookStore
+        V2 = 1,  // per-chunk SYNC_LIST/TRACKS dicts -> per-book jobs + BookStore
+        V3 = 2   // single SYNC_JOBS dict -> JobStore (one job per key + index)
     }
-    const current = V2;
+    const current = V3;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b26";
+    const tag = "b27";
 }

--- a/source/DownloadedMenu.mc
+++ b/source/DownloadedMenu.mc
@@ -60,9 +60,8 @@ class DownloadedMenu extends WatchUi.Menu2 {
     }
 
     function hasQueued() {
-        var jobs = Application.Storage.getValue(Store.SYNC_JOBS);
         var deleteList = Application.Storage.getValue(Store.DELETE_LIST);
-        return ((jobs != null) && (jobs.size() > 0))
+        return (JobStore.list().size() > 0)
             || ((deleteList != null) && (deleteList.size() > 0));
     }
 

--- a/source/DownloadedMenuDelegate.mc
+++ b/source/DownloadedMenuDelegate.mc
@@ -47,9 +47,9 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
         // finishes) WITHOUT starting a sync - we want to drop them, not process
         // them.
         if ((id instanceof Toybox.Lang.String) && id.equals("clearqueue")) {
-            Application.Storage.setValue(Store.SYNC_JOBS, {});
+            JobStore.clearAll();
             Application.Storage.setValue(Store.DELETE_LIST, []);
-            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.queueCleared)), new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
+            Notify.flash(Rez.Strings.queueCleared);
             return;
         }
 
@@ -82,7 +82,7 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
         Application.Storage.setValue(Store.DELETE_LIST, deleteList);
 
         Communications.startSync();
-        WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.deleting)), new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
+        Notify.flash(Rez.Strings.deleting);
     }
 
     function onBack() {

--- a/source/JobStore.mc
+++ b/source/JobStore.mc
@@ -1,0 +1,82 @@
+using Toybox.Application;
+
+// Persistent store for QUEUED download jobs - one job per Storage key, plus a
+// small index, mirroring BookStore's layout:
+//
+//   "jobidx"        => [ itemId, ... ]
+//   "job:" + itemId => { "inos" => [str], "durs" => [num], "title" => str,
+//                        "done" => num }
+//
+// One-job-per-key matters for the same reason BookStore pages do: a
+// chapterized book can be hundreds of per-chapter files, so a job's
+// inos+durs arrays are O(files) (~15KB at 700 files). Several such books in
+// ONE value would cross the documented 32KB-per-value cap - the same crash
+// class the b26 redesign eliminated for chunks (see Constants.mc).
+//
+// Crash-window discipline: put() writes the value BEFORE the index entry,
+// remove() drops the index entry BEFORE the value - an interruption can only
+// leave an unindexed (invisible, overwritten-on-retry) value, never an index
+// entry pointing at data mid-delete. A stray index entry with no value is
+// self-healed by callers treating get()==null as "remove and move on".
+module JobStore {
+
+    const INDEX = "jobidx";
+
+    // A job's inos+durs arrays are O(files) inside ONE Storage value; past
+    // this many files the value approaches the 32KB cap (ABS inode strings
+    // can be 19-20 digits on 64-bit filesystems: ~33B/file serialized ->
+    // 600 files ~= 20KB, comfortable margin). BookMenuDelegate rejects
+    // bigger books at queue time.
+    const MAX_FILES = 600;
+
+    function key(itemId) {
+        return "job:" + itemId;
+    }
+
+    // Fresh copy of the queued itemIds ([] if none). Read fresh at every use -
+    // never hold across events (see the lost-update post-mortem in
+    // Constants.mc).
+    function list() {
+        var index = Application.Storage.getValue(INDEX);
+        return (index == null) ? [] : index;
+    }
+
+    function get(itemId) {
+        return Application.Storage.getValue(key(itemId));
+    }
+
+    function put(itemId, job) {
+        Application.Storage.setValue(key(itemId), job);
+        var index = list();
+        for (var i = 0; i < index.size(); ++i) {
+            if (index[i].equals(itemId)) { return; }
+        }
+        index.add(itemId);
+        Application.Storage.setValue(INDEX, index);
+    }
+
+    function remove(itemId) {
+        var index = list();
+        var out = [];
+        for (var i = 0; i < index.size(); ++i) {
+            if (!index[i].equals(itemId)) { out.add(index[i]); }
+        }
+        if (out.size() > 0) {
+            Application.Storage.setValue(INDEX, out);
+        } else {
+            Application.Storage.deleteValue(INDEX);
+        }
+        Application.Storage.deleteValue(key(itemId));
+    }
+
+    // Clear via per-entry remove() so every intermediate state keeps the
+    // index-before-value discipline: a crash mid-clear leaves a valid,
+    // smaller queue - never an index full of entries whose values are gone
+    // (which would make isSyncNeeded() true forever with nothing to heal it).
+    function clearAll() {
+        var index = list();
+        for (var i = 0; i < index.size(); ++i) {
+            remove(index[i]);
+        }
+    }
+}

--- a/source/Notify.mc
+++ b/source/Notify.mc
@@ -1,0 +1,17 @@
+using Toybox.WatchUi;
+
+// Transient status feedback ("Queued", "Removing", "Queue cleared"). A toast
+// self-dismisses, so the user is never left staring at a stuck status screen
+// waiting on a Back press (the old pushView pattern sat there indefinitely
+// after the sync finished - a reported complaint). Falls back to the old
+// ErrorView push on firmware without showToast.
+module Notify {
+    function flash(stringRezId) {
+        if (WatchUi has :showToast) {
+            WatchUi.showToast(stringRezId, null);
+        } else {
+            WatchUi.pushView(new ErrorView(WatchUi.loadResource(stringRezId)),
+                new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
+        }
+    }
+}

--- a/source/SyncDelegate.mc
+++ b/source/SyncDelegate.mc
@@ -4,13 +4,13 @@ using Toybox.Media;
 
 // Downloads queued books to the device media cache, one derived chunk at a
 // time. One chunk == one Media track, so the native player gives real chapter
-// navigation. Works from the per-book jobs in Store.SYNC_JOBS - chunk
-// boundaries come from Chunks.at(), and each downloaded refId is recorded via
+// navigation. Works from the per-book jobs in JobStore - chunk boundaries
+// come from Chunks.at(), and each downloaded refId is recorded via
 // BookStore.saveChunk (position == chunk index, overwrite-safe). Nothing here
-// is ever O(chunks) in a single Storage value (see Constants.mc for the OOM
-// post-mortem).
+// is ever O(chunks) - or O(queued books x files) - in a single Storage value
+// (see Constants.mc for the OOM post-mortem).
 //
-// STORAGE DISCIPLINE: Store.SYNC_JOBS is read FRESH at every step and only
+// STORAGE DISCIPLINE: queue state is read FRESH at every step and only
 // read-modify-written - never held in a long-lived field and persisted
 // wholesale. A snapshot design silently clobbered any queue change made while
 // a sync was running (book queued mid-sync erased after "Queued!" was shown;
@@ -37,11 +37,6 @@ class SyncDelegate extends Communications.SyncDelegate {
         mDone = 0;
     }
 
-    function jobs() {
-        var j = Application.Storage.getValue(Store.SYNC_JOBS);
-        return (j == null) ? {} : j;
-    }
-
     function deletes() {
         var d = Application.Storage.getValue(Store.DELETE_LIST);
         return (d == null) ? [] : d;
@@ -49,7 +44,7 @@ class SyncDelegate extends Communications.SyncDelegate {
 
     // The system only starts a sync when this is true.
     function isSyncNeeded() {
-        return (jobs().size() != 0) || (deletes().size() != 0);
+        return (JobStore.list().size() != 0) || (deletes().size() != 0);
     }
 
     function onStartSync() {
@@ -58,25 +53,22 @@ class SyncDelegate extends Communications.SyncDelegate {
         // Cancel any queued job for a book being deleted BEFORE counting or
         // downloading anything - otherwise the very sync that deletes the book
         // resumes its job and resurrects it missing its head chunks.
-        if (toDelete.size() > 0) {
-            var j = jobs();
-            var changed = false;
-            for (var i = 0; i < toDelete.size(); ++i) {
-                if (j[toDelete[i]] != null) {
-                    j.remove(toDelete[i]);
-                    changed = true;
-                }
-            }
-            if (changed) {
-                Application.Storage.setValue(Store.SYNC_JOBS, j);
-            }
+        for (var i = 0; i < toDelete.size(); ++i) {
+            JobStore.remove(toDelete[i]);
         }
 
-        var remaining = jobs();
         mTotal = toDelete.size();
-        var itemIds = remaining.keys();
-        for (var i = 0; i < itemIds.size(); ++i) {
-            var job = remaining[itemIds[i]];
+        var jobIds = JobStore.list();
+        for (var i = 0; i < jobIds.size(); ++i) {
+            var job = JobStore.get(jobIds[i]);
+            if (job == null) {
+                // Stray index entry (crash window) - heal HERE too, not just
+                // in downloadNext: a queue of only strays makes mTotal 0 and
+                // returns before downloadNext ever runs, leaving
+                // isSyncNeeded() true forever (endless no-op syncs).
+                JobStore.remove(jobIds[i]);
+                continue;
+            }
             var left = Chunks.total(job["durs"]) - job["done"];
             if (left > 0) { mTotal += left; }
         }
@@ -97,15 +89,12 @@ class SyncDelegate extends Communications.SyncDelegate {
     }
 
     // Delete every queued BOOK: BookStore evicts its cached chunks and drops
-    // its records; then remove it from the menu index. If nothing downloaded
-    // remains at all afterwards, sweep the whole media cache too - that
-    // reclaims any orphaned cache items a crash window may have left behind
-    // (cached but never recorded), which no per-book path can reach.
+    // its records; then remove it from the menu index.
     function deleteQueued(toDelete) {
         if (toDelete.size() == 0) { return; }
         for (var i = 0; i < toDelete.size(); ++i) {
             BookStore.deleteBook(toDelete[i]);
-            removeFromIndex(toDelete[i]);
+            BookStore.removeFromIndex(toDelete[i]);
             onOpDone();
         }
 
@@ -122,11 +111,6 @@ class SyncDelegate extends Communications.SyncDelegate {
         } else {
             Application.Storage.deleteValue(Store.DELETE_LIST);
         }
-
-        var index = Application.Storage.getValue(Store.BOOK_INDEX);
-        if (((index == null) || (index.size() == 0)) && (jobs().size() == 0)) {
-            Media.resetContentCache();
-        }
     }
 
     function containsId(arr, itemId) {
@@ -139,31 +123,36 @@ class SyncDelegate extends Communications.SyncDelegate {
     // Download the next chunk of the first queued book. Reads the queue fresh
     // so mid-sync queue changes (new book, clear queue, delete) take effect.
     function downloadNext() {
-        var j = jobs();
-        var itemIds = j.keys();
-        if (itemIds.size() == 0) {
+        var jobIds = JobStore.list();
+        if (jobIds.size() == 0) {
+            sweepOrphans();
             Communications.notifySyncComplete(null);
             return;
         }
 
-        var itemId = itemIds[0];
+        var itemId = jobIds[0];
 
         // Honor a delete queued mid-sync: stop downloading the doomed book
         // now (its actual deletion runs at the next sync start) instead of
         // pouring hundreds more chunks into a book the user already deleted.
         if (containsId(deletes(), itemId)) {
-            j.remove(itemId);
-            Application.Storage.setValue(Store.SYNC_JOBS, j);
+            JobStore.remove(itemId);
             downloadNext();
             return;
         }
 
-        var job = j[itemId];
+        var job = JobStore.get(itemId);
+        if (job == null) {
+            // Stray index entry (crash window) - self-heal and move on.
+            JobStore.remove(itemId);
+            downloadNext();
+            return;
+        }
+
         var c = Chunks.at(job["durs"], job["done"]);
         if (c == null) {
             // Book finished (or cursor out of range) - drop the job, move on.
-            j.remove(itemId);
-            Application.Storage.setValue(Store.SYNC_JOBS, j);
+            JobStore.remove(itemId);
             downloadNext();
             return;
         }
@@ -176,7 +165,13 @@ class SyncDelegate extends Communications.SyncDelegate {
             :mediaEncoding => Media.ENCODING_ADTS
         };
 
-        var context = { "item" => itemId };
+        // "k" pins WHICH chunk this request is for and "gen" pins WHICH job
+        // generation dispatched it: if the cursor moved, or the job was
+        // replaced wholesale by a re-queue (gen bumps on every re-queue, so
+        // even a same-cursor-value collision like 0==0 is caught), recording
+        // the stale bytes would put the wrong audio at the wrong position -
+        // the callback validates and discards instead.
+        var context = { "item" => itemId, "k" => job["done"], "gen" => job["gen"] };
         var delegate = new RequestDelegate(method(:onTrackDownloaded), context);
         var url = AbsApi.sidecarChunkUrl(itemId, job["inos"][c["file"]],
                                         c["cstart"], c["cend"]);
@@ -195,12 +190,13 @@ class SyncDelegate extends Communications.SyncDelegate {
         var itemId = context["item"];
         var refId = data.getId();
 
-        var j = jobs();
-        var job = j[itemId];
-        if (job == null) {
-            // The job was cancelled (cleared/deleted) while this chunk was in
-            // flight - evict the now-ownerless cached item and carry on with
-            // whatever the queue holds now.
+        var job = JobStore.get(itemId);
+        if ((job == null) || (context["gen"] != job["gen"]) || (context["k"] != job["done"])) {
+            // The job was cancelled (cleared/deleted), replaced by a re-queue
+            // (generation mismatch), or its cursor moved while this chunk was
+            // in flight - these bytes no longer have a valid slot. Evict the
+            // now-ownerless cached item and carry on with whatever the queue
+            // holds now.
             Media.deleteCachedItem(new Media.ContentRef(refId, Media.CONTENT_TYPE_AUDIO));
             downloadNext();
             return;
@@ -209,39 +205,57 @@ class SyncDelegate extends Communications.SyncDelegate {
         var k = job["done"];
         BookStore.ensureMeta(itemId, job["title"], job["durs"]);
         BookStore.saveChunk(itemId, k, refId);
-        addToIndex(itemId);
+        BookStore.addToIndex(itemId);
 
         // Advance + persist the cursor so a crash won't re-fetch. saveChunk is
         // overwrite-by-position, so even a crash between these writes can only
         // cause a harmless re-download, never a duplicate or a skipped chunk.
         job["done"] = k + 1;
         if (job["done"] >= Chunks.total(job["durs"])) {
-            j.remove(itemId);
+            JobStore.remove(itemId);
+        } else {
+            JobStore.put(itemId, job);
         }
-        Application.Storage.setValue(Store.SYNC_JOBS, j);
 
         onOpDone();
         downloadNext();
     }
 
-    function addToIndex(itemId) {
+    // Evict cached audio the OS holds that no book's records claim. Orphans
+    // come from crash windows (item cached, callback never recorded it) and
+    // would otherwise eat media-cache space forever - the cache outlives the
+    // app's own bookkeeping. Runs at the end of every sync; bounded by
+    // Chunks.MAX_TOTAL known refIds. Orphans are collected first, then
+    // evicted - never delete while walking the OS iterator.
+    function sweepOrphans() {
+        var known = {};
         var index = Application.Storage.getValue(Store.BOOK_INDEX);
         if (index == null) { index = []; }
-        for (var i = 0; i < index.size(); ++i) {
-            if (index[i].equals(itemId)) { return; }
+        for (var b = 0; b < index.size(); ++b) {
+            BookStore.addRefIds(index[b], known);
         }
-        index.add(itemId);
-        Application.Storage.setValue(Store.BOOK_INDEX, index);
-    }
+        // Queued books may have recorded chunks that aren't indexed yet
+        // (crash between saveChunk and addToIndex) - their pages are still
+        // authoritative, so count them as known too.
+        var jobIds = JobStore.list();
+        for (var i = 0; i < jobIds.size(); ++i) {
+            if (!containsId(index, jobIds[i])) {
+                BookStore.addRefIds(jobIds[i], known);
+            }
+        }
 
-    function removeFromIndex(itemId) {
-        var index = Application.Storage.getValue(Store.BOOK_INDEX);
-        if (index == null) { return; }
-        var out = [];
-        for (var i = 0; i < index.size(); ++i) {
-            if (!index[i].equals(itemId)) { out.add(index[i]); }
+        var orphans = [];
+        var iter = Media.getContentRefIter({ :contentType => Media.CONTENT_TYPE_AUDIO });
+        if (iter != null) {
+            var ref = iter.next();
+            while (ref != null) {
+                if (known[ref.getId()] == null) { orphans.add(ref.getId()); }
+                ref = iter.next();
+            }
         }
-        Application.Storage.setValue(Store.BOOK_INDEX, out);
+        for (var i = 0; i < orphans.size(); ++i) {
+            Media.deleteCachedItem(new Media.ContentRef(orphans[i], Media.CONTENT_TYPE_AUDIO));
+        }
     }
 
     function onOpDone() {


### PR DESCRIPTION
## Summary
Closes the four deferred b26 review findings plus the stuck status screens:

- **JobStore** (new): one queued job per Storage key (`job:<itemId>`) + a small index, so a chapterized book's O(files) `inos`/`durs` arrays never share a value with other books. Simulator-verified with 3 jobs × 700 files each; books past 600 files rejected at queue time with a clear message.
- **Watch-wide chunk cap** (`Chunks.MAX_TOTAL` = 1500 ≈ 75h): rejected at queue time with "Downloads full. Delete a book first." — and `plannedChunks` skips books already pending deletion so that instruction works immediately.
- **Orphan sweep** at the end of every sync evicts cached audio no book's records claim (crash-window leftovers), counting queued-but-not-yet-indexed books as known.
- **Duration drift**: re-selecting a book whose server-side durations changed wipes it (job first, then pages — mid-wipe crash decays benign) and restarts clean. All destructive work runs only **after** every early-return gate passes, so a rejection can never strand a live job over wiped pages.
- **Generation fence**: jobs carry a `gen` counter bumped on every re-queue; in-flight chunks from a superseded job are discarded even at equal cursor values.
- **Self-heal hardening**: stray job-index entries heal in `onStartSync` too; `clearAll` keeps index-before-value discipline per entry; re-queueing a doomed book un-dooms it.
- **Toasts**: Queued / Removing / Queue cleared are self-dismissing toasts (has-guarded, ErrorView fallback) — no more status screens stuck waiting on Back.
- Versions V2→V3 (storage reset on first launch; login preserved). Build tag b27; debug symbols preserved in `debug-symbols/`.

## Verification
- `make build` clean for `fenix8solar51mm`
- Simulator shape tests: 3 × 700-file jobs per-key write/readback ✔ (prior: 1200-chunk paged BookStore ✔)
- Adversarial multi-agent review: 7 confirmed findings, all fixed; both major fixes then re-verified end-to-end by a second pass ✔

🧙 Built with [WOZCODE](https://wozcode.com)