### PR TITLE
feat(login): preflight URL against /health before sending credentials (b28)

### DIFF
--- a/debug-symbols/b28.debug.xml
+++ b/debug-symbols/b28.debug.xml
@@ -1,0 +1,2233 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<debugInfo>
+    <manifest filename="/Users/cbrooker/Code/ABS-Garmin/manifest.xml"/>
+    <pcToLineNum>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="1" lineNum="33" parent="globals/BrowseDelegate" pc="268435460" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="2" lineNum="29" parent="globals/SyncDelegate" pc="268435472" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/bin/gen/006-B4533-00/source/Rez.mcgen" id="3" lineNum="7" parent="globals/Rez" pc="268435484" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="4" lineNum="65" parent="globals/GroupDelegate" pc="268435504" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="5" lineNum="4" parent="globals/LibraryMenuDelegate" pc="268435516" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="6" lineNum="7" parent="globals/WatchShelfApp" pc="268435528" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="7" lineNum="7" parent="globals/ContentDelegate" pc="268435540" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="8" lineNum="18" parent="globals/ContentIterator" pc="268435552" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="9" lineNum="129" parent="globals/FieldDelegate" pc="268435564" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="10" lineNum="8" parent="globals/LibraryView" pc="268435576" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="11" lineNum="6" parent="globals/LibraryViewDelegate" pc="268435588" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="12" lineNum="12" parent="globals/BookMenuDelegate" pc="268435600" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="13" lineNum="27" parent="globals/LoginView" pc="268435612" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="14" lineNum="10" parent="globals/DownloadedMenuDelegate" pc="268435624" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="15" lineNum="8" parent="globals/ErrorViewDelegate" pc="268435636" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="16" lineNum="5" parent="globals/ErrorView" pc="268435648" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="17" lineNum="11" parent="globals/DownloadedMenu" pc="268435660" symbol="&lt;init&gt;"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="38" parent="globals/Chunks" pc="268435672" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="39" parent="globals/Chunks" pc="268435683" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="40" parent="globals/Chunks" pc="268435686" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="41" parent="globals/Chunks" pc="268435702" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="42" parent="globals/Chunks" pc="268435709" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="42" parent="globals/Chunks" pc="268435716" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="43" parent="globals/Chunks" pc="268435722" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="44" parent="globals/Chunks" pc="268435725" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="45" parent="globals/Chunks" pc="268435733" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="46" parent="globals/Chunks" pc="268435750" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="47" parent="globals/Chunks" pc="268435757" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="47" parent="globals/Chunks" pc="268435765" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="48" parent="globals/Chunks" pc="268435772" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="49" parent="globals/Chunks" pc="268435779" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="18" lineNum="52" parent="globals/Chunks" pc="268435796" symbol="total"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="28" parent="globals/Chunks" pc="268435799" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="29" parent="globals/Chunks" pc="268435810" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="29" parent="globals/Chunks" pc="268435822" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="30" parent="globals/Chunks" pc="268435831" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="30" parent="globals/Chunks" pc="268435849" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="31" parent="globals/Chunks" pc="268435854" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="32" parent="globals/Chunks" pc="268435870" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="32" parent="globals/Chunks" pc="268435884" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="19" lineNum="34" parent="globals/Chunks" pc="268435899" symbol="same"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="80" parent="globals/Chunks" pc="268435901" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="81" parent="globals/Chunks" pc="268435912" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="82" parent="globals/Chunks" pc="268435915" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="83" parent="globals/Chunks" pc="268435918" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="84" parent="globals/Chunks" pc="268435934" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="85" parent="globals/Chunks" pc="268435941" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="85" parent="globals/Chunks" pc="268435948" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="86" parent="globals/Chunks" pc="268435954" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="87" parent="globals/Chunks" pc="268435957" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="88" parent="globals/Chunks" pc="268435965" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="89" parent="globals/Chunks" pc="268435982" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="90" parent="globals/Chunks" pc="268435989" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="90" parent="globals/Chunks" pc="268435997" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="91" parent="globals/Chunks" pc="268436004" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="92" parent="globals/Chunks" pc="268436012" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="99" parent="globals/Chunks" pc="268436056" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="100" parent="globals/Chunks" pc="268436063" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="102" parent="globals/Chunks" pc="268436070" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="20" lineNum="104" parent="globals/Chunks" pc="268436087" symbol="at"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="58" parent="globals/Chunks" pc="268436089" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="59" parent="globals/Chunks" pc="268436100" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="60" parent="globals/Chunks" pc="268436104" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="61" parent="globals/Chunks" pc="268436107" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="62" parent="globals/Chunks" pc="268436123" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="63" parent="globals/Chunks" pc="268436130" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="63" parent="globals/Chunks" pc="268436137" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="64" parent="globals/Chunks" pc="268436143" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="65" parent="globals/Chunks" pc="268436146" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="66" parent="globals/Chunks" pc="268436154" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="67" parent="globals/Chunks" pc="268436176" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="68" parent="globals/Chunks" pc="268436183" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="68" parent="globals/Chunks" pc="268436191" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="69" parent="globals/Chunks" pc="268436198" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="70" parent="globals/Chunks" pc="268436213" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="72" parent="globals/Chunks" pc="268436220" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Chunks.mc" id="21" lineNum="74" parent="globals/Chunks" pc="268436237" symbol="starts"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="22" lineNum="45" parent="globals/BrowseDelegate" pc="268436240" symbol="onSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="22" lineNum="45" parent="globals/BrowseDelegate" pc="268436242" symbol="onSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="23" lineNum="62" parent="globals/BrowseDelegate" pc="268436266" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="23" lineNum="62" parent="globals/BrowseDelegate" pc="268436268" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="44" parent="globals/BrowseDelegate" pc="268436284" symbol="onAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="24" lineNum="44" parent="globals/BrowseDelegate" pc="268436286" symbol="onAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="48" parent="globals/BrowseDelegate" pc="268436310" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="49" parent="globals/BrowseDelegate" pc="268436313" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="50" parent="globals/BrowseDelegate" pc="268436353" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="51" parent="globals/BrowseDelegate" pc="268436435" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="53" parent="globals/BrowseDelegate" pc="268436439" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="54" parent="globals/BrowseDelegate" pc="268436446" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="55" parent="globals/BrowseDelegate" pc="268436512" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="56" parent="globals/BrowseDelegate" pc="268436528" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="57" parent="globals/BrowseDelegate" pc="268436535" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="58" parent="globals/BrowseDelegate" pc="268436573" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="25" lineNum="60" parent="globals/BrowseDelegate" pc="268436634" symbol="pushGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="26" lineNum="43" parent="globals/BrowseDelegate" pc="268436677" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="26" lineNum="43" parent="globals/BrowseDelegate" pc="268436679" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="27" lineNum="46" parent="globals/BrowseDelegate" pc="268436697" symbol="onCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="27" lineNum="46" parent="globals/BrowseDelegate" pc="268436699" symbol="onCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="35" parent="globals/BrowseDelegate" pc="268436723" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="35" parent="globals/BrowseDelegate" pc="268436725" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="28" lineNum="35" parent="globals/BrowseDelegate" pc="268436737" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="36" parent="globals/BrowseDelegate" pc="268436747" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="37" parent="globals/BrowseDelegate" pc="268436750" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="38" parent="globals/BrowseDelegate" pc="268436759" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="38" parent="globals/BrowseDelegate" pc="268436776" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="39" parent="globals/BrowseDelegate" pc="268436812" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="39" parent="globals/BrowseDelegate" pc="268436829" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="40" parent="globals/BrowseDelegate" pc="268436863" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="40" parent="globals/BrowseDelegate" pc="268436880" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="29" lineNum="41" parent="globals/BrowseDelegate" pc="268436914" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Notify.mc" id="30" lineNum="9" parent="globals/Notify" pc="268436946" symbol="flash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Notify.mc" id="30" lineNum="10" parent="globals/Notify" pc="268436956" symbol="flash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Notify.mc" id="30" lineNum="11" parent="globals/Notify" pc="268436971" symbol="flash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Notify.mc" id="30" lineNum="13" parent="globals/Notify" pc="268436990" symbol="flash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="50" parent="globals/SyncDelegate" pc="268437064" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="51" parent="globals/SyncDelegate" pc="268437067" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="56" parent="globals/SyncDelegate" pc="268437075" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="57" parent="globals/SyncDelegate" pc="268437091" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="60" parent="globals/SyncDelegate" pc="268437119" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="61" parent="globals/SyncDelegate" pc="268437133" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="62" parent="globals/SyncDelegate" pc="268437145" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="63" parent="globals/SyncDelegate" pc="268437161" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="64" parent="globals/SyncDelegate" pc="268437180" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="69" parent="globals/SyncDelegate" pc="268437186" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="70" parent="globals/SyncDelegate" pc="268437204" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="72" parent="globals/SyncDelegate" pc="268437210" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="73" parent="globals/SyncDelegate" pc="268437241" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="73" parent="globals/SyncDelegate" pc="268437248" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="75" parent="globals/SyncDelegate" pc="268437276" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="76" parent="globals/SyncDelegate" pc="268437286" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="77" parent="globals/SyncDelegate" pc="268437300" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="80" parent="globals/SyncDelegate" pc="268437304" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="31" lineNum="81" parent="globals/SyncDelegate" pc="268437315" symbol="onStartSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="40" parent="globals/SyncDelegate" pc="268437323" symbol="deletes"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="41" parent="globals/SyncDelegate" pc="268437326" symbol="deletes"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="32" lineNum="42" parent="globals/SyncDelegate" pc="268437345" symbol="deletes"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="125" parent="globals/SyncDelegate" pc="268437359" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="126" parent="globals/SyncDelegate" pc="268437362" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="127" parent="globals/SyncDelegate" pc="268437374" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="128" parent="globals/SyncDelegate" pc="268437386" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="129" parent="globals/SyncDelegate" pc="268437393" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="130" parent="globals/SyncDelegate" pc="268437407" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="133" parent="globals/SyncDelegate" pc="268437411" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="138" parent="globals/SyncDelegate" pc="268437417" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="139" parent="globals/SyncDelegate" pc="268437436" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="140" parent="globals/SyncDelegate" pc="268437451" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="141" parent="globals/SyncDelegate" pc="268437458" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="144" parent="globals/SyncDelegate" pc="268437462" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="145" parent="globals/SyncDelegate" pc="268437478" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="147" parent="globals/SyncDelegate" pc="268437484" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="148" parent="globals/SyncDelegate" pc="268437499" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="149" parent="globals/SyncDelegate" pc="268437506" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="152" parent="globals/SyncDelegate" pc="268437510" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="153" parent="globals/SyncDelegate" pc="268437540" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="155" parent="globals/SyncDelegate" pc="268437546" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="156" parent="globals/SyncDelegate" pc="268437561" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="157" parent="globals/SyncDelegate" pc="268437568" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="160" parent="globals/SyncDelegate" pc="268437572" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="174" parent="globals/SyncDelegate" pc="268437603" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="175" parent="globals/SyncDelegate" pc="268437646" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="176" parent="globals/SyncDelegate" pc="268437681" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="33" lineNum="178" parent="globals/SyncDelegate" pc="268437730" symbol="downloadNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="261" parent="globals/SyncDelegate" pc="268437746" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="262" parent="globals/SyncDelegate" pc="268437749" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="265" parent="globals/SyncDelegate" pc="268437764" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="266" parent="globals/SyncDelegate" pc="268437792" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="266" parent="globals/SyncDelegate" pc="268437800" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="34" lineNum="267" parent="globals/SyncDelegate" pc="268437807" symbol="onOpDone"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="93" parent="globals/SyncDelegate" pc="268437823" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="94" parent="globals/SyncDelegate" pc="268437826" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="94" parent="globals/SyncDelegate" pc="268437838" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="95" parent="globals/SyncDelegate" pc="268437842" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="96" parent="globals/SyncDelegate" pc="268437858" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="97" parent="globals/SyncDelegate" pc="268437876" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="98" parent="globals/SyncDelegate" pc="268437894" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="104" parent="globals/SyncDelegate" pc="268437911" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="105" parent="globals/SyncDelegate" pc="268437919" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="106" parent="globals/SyncDelegate" pc="268437923" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="107" parent="globals/SyncDelegate" pc="268437939" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="107" parent="globals/SyncDelegate" pc="268437958" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="109" parent="globals/SyncDelegate" pc="268437986" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="110" parent="globals/SyncDelegate" pc="268437998" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="35" lineNum="112" parent="globals/SyncDelegate" pc="268438021" symbol="deleteQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="184" parent="globals/SyncDelegate" pc="268438040" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="185" parent="globals/SyncDelegate" pc="268438043" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="186" parent="globals/SyncDelegate" pc="268438058" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="187" parent="globals/SyncDelegate" pc="268438085" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="190" parent="globals/SyncDelegate" pc="268438089" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="191" parent="globals/SyncDelegate" pc="268438099" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="193" parent="globals/SyncDelegate" pc="268438108" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="194" parent="globals/SyncDelegate" pc="268438124" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="200" parent="globals/SyncDelegate" pc="268438170" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="201" parent="globals/SyncDelegate" pc="268438209" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="202" parent="globals/SyncDelegate" pc="268438216" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="205" parent="globals/SyncDelegate" pc="268438220" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="206" parent="globals/SyncDelegate" pc="268438230" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="207" parent="globals/SyncDelegate" pc="268438261" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="208" parent="globals/SyncDelegate" pc="268438280" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="213" parent="globals/SyncDelegate" pc="268438295" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="214" parent="globals/SyncDelegate" pc="268438308" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="215" parent="globals/SyncDelegate" pc="268438340" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="217" parent="globals/SyncDelegate" pc="268438358" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="220" parent="globals/SyncDelegate" pc="268438375" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="36" lineNum="221" parent="globals/SyncDelegate" pc="268438382" symbol="onTrackDownloaded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="116" parent="globals/SyncDelegate" pc="268438390" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="117" parent="globals/SyncDelegate" pc="268438393" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="118" parent="globals/SyncDelegate" pc="268438409" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="118" parent="globals/SyncDelegate" pc="268438427" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="37" lineNum="120" parent="globals/SyncDelegate" pc="268438442" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="38" lineNum="86" parent="globals/SyncDelegate" pc="268438444" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="38" lineNum="87" parent="globals/SyncDelegate" pc="268438446" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="38" lineNum="88" parent="globals/SyncDelegate" pc="268438457" symbol="onStopSync"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="230" parent="globals/SyncDelegate" pc="268438472" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="231" parent="globals/SyncDelegate" pc="268438475" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="232" parent="globals/SyncDelegate" pc="268438479" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="233" parent="globals/SyncDelegate" pc="268438498" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="233" parent="globals/SyncDelegate" pc="268438504" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="234" parent="globals/SyncDelegate" pc="268438511" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="235" parent="globals/SyncDelegate" pc="268438527" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="240" parent="globals/SyncDelegate" pc="268438557" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="241" parent="globals/SyncDelegate" pc="268438569" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="242" parent="globals/SyncDelegate" pc="268438585" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="243" parent="globals/SyncDelegate" pc="268438604" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="247" parent="globals/SyncDelegate" pc="268438637" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="248" parent="globals/SyncDelegate" pc="268438641" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="249" parent="globals/SyncDelegate" pc="268438668" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="250" parent="globals/SyncDelegate" pc="268438674" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="251" parent="globals/SyncDelegate" pc="268438684" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="252" parent="globals/SyncDelegate" pc="268438690" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="252" parent="globals/SyncDelegate" pc="268438705" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="253" parent="globals/SyncDelegate" pc="268438726" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="256" parent="globals/SyncDelegate" pc="268438742" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="39" lineNum="257" parent="globals/SyncDelegate" pc="268438758" symbol="sweepOrphans"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="40" lineNum="34" parent="globals/SyncDelegate" pc="268438811" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="40" lineNum="35" parent="globals/SyncDelegate" pc="268438813" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="40" lineNum="36" parent="globals/SyncDelegate" pc="268438825" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="40" lineNum="37" parent="globals/SyncDelegate" pc="268438833" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="41" lineNum="46" parent="globals/SyncDelegate" pc="268438842" symbol="isSyncNeeded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/SyncDelegate.mc" id="41" lineNum="47" parent="globals/SyncDelegate" pc="268438844" symbol="isSyncNeeded"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="42" lineNum="18" parent="globals/LoginCreds" pc="268438883" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="42" lineNum="18" parent="globals/LoginCreds" pc="268438885" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="42" lineNum="18" parent="globals/LoginCreds" pc="268438897" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="42" lineNum="18" parent="globals/LoginCreds" pc="268438909" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="43" lineNum="71" parent="globals/GroupDelegate" pc="268438922" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="43" lineNum="71" parent="globals/GroupDelegate" pc="268438924" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="44" lineNum="70" parent="globals/GroupDelegate" pc="268438940" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="44" lineNum="70" parent="globals/GroupDelegate" pc="268438942" symbol="onBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="45" lineNum="68" parent="globals/GroupDelegate" pc="268438960" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="45" lineNum="68" parent="globals/GroupDelegate" pc="268438962" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="45" lineNum="68" parent="globals/GroupDelegate" pc="268438974" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="45" lineNum="68" parent="globals/GroupDelegate" pc="268438983" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="46" lineNum="69" parent="globals/GroupDelegate" pc="268438993" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="46" lineNum="69" parent="globals/GroupDelegate" pc="268438995" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="47" lineNum="184" parent="globals/AbsProgressListener" pc="268439039" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="47" lineNum="185" parent="globals/AbsProgressListener" pc="268439041" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="47" lineNum="186" parent="globals/AbsProgressListener" pc="268439050" symbol="onResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="49" lineNum="7" parent="globals/LibraryMenuDelegate" pc="268439075" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="49" lineNum="7" parent="globals/LibraryMenuDelegate" pc="268439077" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="50" lineNum="5" parent="globals/LibraryMenuDelegate" pc="268439093" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="50" lineNum="5" parent="globals/LibraryMenuDelegate" pc="268439095" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="51" lineNum="6" parent="globals/LibraryMenuDelegate" pc="268439108" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryMenuDelegate.mc" id="51" lineNum="6" parent="globals/LibraryMenuDelegate" pc="268439110" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="52" lineNum="57" parent="globals/WatchShelfApp" pc="268439131" symbol="getProviderIconInfo"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="52" lineNum="58" parent="globals/WatchShelfApp" pc="268439133" symbol="getProviderIconInfo"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="53" lineNum="45" parent="globals/WatchShelfApp" pc="268439180" symbol="getPlaybackConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="53" lineNum="46" parent="globals/WatchShelfApp" pc="268439182" symbol="getPlaybackConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="54" lineNum="30" parent="globals/WatchShelfApp" pc="268439229" symbol="getContentDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="54" lineNum="31" parent="globals/WatchShelfApp" pc="268439231" symbol="getContentDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="55" lineNum="38" parent="globals/WatchShelfApp" pc="268439250" symbol="getSyncDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="55" lineNum="39" parent="globals/WatchShelfApp" pc="268439252" symbol="getSyncDelegate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="9" parent="globals/WatchShelfApp" pc="268439271" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="14" parent="globals/WatchShelfApp" pc="268439274" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="15" parent="globals/WatchShelfApp" pc="268439293" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="16" parent="globals/WatchShelfApp" pc="268439301" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="17" parent="globals/WatchShelfApp" pc="268439320" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="18" parent="globals/WatchShelfApp" pc="268439339" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="19" parent="globals/WatchShelfApp" pc="268439350" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="20" parent="globals/WatchShelfApp" pc="268439361" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="20" parent="globals/WatchShelfApp" pc="268439367" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="21" parent="globals/WatchShelfApp" pc="268439390" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="21" parent="globals/WatchShelfApp" pc="268439396" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="22" parent="globals/WatchShelfApp" pc="268439419" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="56" lineNum="26" parent="globals/WatchShelfApp" pc="268439442" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="57" lineNum="52" parent="globals/WatchShelfApp" pc="268439455" symbol="getSyncConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/WatchShelfApp.mc" id="57" lineNum="53" parent="globals/WatchShelfApp" pc="268439457" symbol="getSyncConfigurationView"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="58" lineNum="70" parent="globals/ContentDelegate" pc="268439504" symbol="onShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="58" lineNum="71" parent="globals/ContentDelegate" pc="268439506" symbol="onShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="59" lineNum="18" parent="globals/ContentDelegate" pc="268439519" symbol="getContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="59" lineNum="19" parent="globals/ContentDelegate" pc="268439521" symbol="getContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="42" parent="globals/ContentDelegate" pc="268439527" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="43" parent="globals/ContentDelegate" pc="268439530" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="43" parent="globals/ContentDelegate" pc="268439544" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="48" parent="globals/ContentDelegate" pc="268439548" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="49" parent="globals/ContentDelegate" pc="268439557" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="50" parent="globals/ContentDelegate" pc="268439566" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="51" parent="globals/ContentDelegate" pc="268439585" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="51" parent="globals/ContentDelegate" pc="268439591" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="52" parent="globals/ContentDelegate" pc="268439598" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="53" parent="globals/ContentDelegate" pc="268439614" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="54" parent="globals/ContentDelegate" pc="268439618" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="55" parent="globals/ContentDelegate" pc="268439640" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="56" parent="globals/ContentDelegate" pc="268439649" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="57" parent="globals/ContentDelegate" pc="268439665" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="62" parent="globals/ContentDelegate" pc="268439725" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="63" parent="globals/ContentDelegate" pc="268439735" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="63" parent="globals/ContentDelegate" pc="268439741" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="64" parent="globals/ContentDelegate" pc="268439745" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="60" lineNum="67" parent="globals/ContentDelegate" pc="268439755" symbol="syncProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="61" lineNum="75" parent="globals/ContentDelegate" pc="268439776" symbol="onThumbsUp"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="62" lineNum="12" parent="globals/ContentDelegate" pc="268439779" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="62" lineNum="13" parent="globals/ContentDelegate" pc="268439781" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="62" lineNum="14" parent="globals/ContentDelegate" pc="268439793" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="62" lineNum="15" parent="globals/ContentDelegate" pc="268439801" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="63" lineNum="33" parent="globals/ContentDelegate" pc="268439809" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="63" lineNum="34" parent="globals/ContentDelegate" pc="268439811" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="63" lineNum="38" parent="globals/ContentDelegate" pc="268439843" symbol="onSong"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="65" lineNum="22" parent="globals/ContentDelegate" pc="268439860" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="65" lineNum="23" parent="globals/ContentDelegate" pc="268439862" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="65" lineNum="24" parent="globals/ContentDelegate" pc="268439887" symbol="resetContentIterator"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentDelegate.mc" id="66" lineNum="76" parent="globals/ContentDelegate" pc="268439893" symbol="onThumbsDown"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="85" parent="globals/BookStore" pc="268439896" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="86" parent="globals/BookStore" pc="268439907" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="87" parent="globals/BookStore" pc="268439911" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="88" parent="globals/BookStore" pc="268439942" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="90" parent="globals/BookStore" pc="268439952" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="91" parent="globals/BookStore" pc="268439963" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="92" parent="globals/BookStore" pc="268439989" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="93" parent="globals/BookStore" pc="268439995" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="94" parent="globals/BookStore" pc="268440012" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="95" parent="globals/BookStore" pc="268440021" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="99" parent="globals/BookStore" pc="268440079" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="67" lineNum="101" parent="globals/BookStore" pc="268440114" symbol="deleteBook"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="106" parent="globals/BookStore" pc="268440138" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="107" parent="globals/BookStore" pc="268440149" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="108" parent="globals/BookStore" pc="268440168" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="108" parent="globals/BookStore" pc="268440174" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="109" parent="globals/BookStore" pc="268440181" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="110" parent="globals/BookStore" pc="268440197" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="110" parent="globals/BookStore" pc="268440215" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="112" parent="globals/BookStore" pc="268440229" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="68" lineNum="113" parent="globals/BookStore" pc="268440241" symbol="addToIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="116" parent="globals/BookStore" pc="268440262" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="117" parent="globals/BookStore" pc="268440273" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="118" parent="globals/BookStore" pc="268440292" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="118" parent="globals/BookStore" pc="268440298" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="119" parent="globals/BookStore" pc="268440302" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="120" parent="globals/BookStore" pc="268440306" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="121" parent="globals/BookStore" pc="268440322" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="121" parent="globals/BookStore" pc="268440341" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="69" lineNum="123" parent="globals/BookStore" pc="268440369" symbol="removeFromIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="30" parent="globals/BookStore" pc="268440390" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="70" lineNum="31" parent="globals/BookStore" pc="268440400" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="42" parent="globals/BookStore" pc="268440423" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="43" parent="globals/BookStore" pc="268440434" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="44" parent="globals/BookStore" pc="268440437" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="45" parent="globals/BookStore" pc="268440440" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="46" parent="globals/BookStore" pc="268440444" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="47" parent="globals/BookStore" pc="268440470" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="47" parent="globals/BookStore" pc="268440476" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="48" parent="globals/BookStore" pc="268440482" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="49" parent="globals/BookStore" pc="268440494" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="71" lineNum="51" parent="globals/BookStore" pc="268440504" symbol="count"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="128" parent="globals/BookStore" pc="268440507" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="129" parent="globals/BookStore" pc="268440518" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="130" parent="globals/BookStore" pc="268440521" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="131" parent="globals/BookStore" pc="268440525" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="132" parent="globals/BookStore" pc="268440551" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="132" parent="globals/BookStore" pc="268440557" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="133" parent="globals/BookStore" pc="268440561" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="134" parent="globals/BookStore" pc="268440577" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="134" parent="globals/BookStore" pc="268440586" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="72" lineNum="136" parent="globals/BookStore" pc="268440608" symbol="addRefIds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="147" parent="globals/BookStore" pc="268440619" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="148" parent="globals/BookStore" pc="268440630" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="149" parent="globals/BookStore" pc="268440642" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="149" parent="globals/BookStore" pc="268440648" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="150" parent="globals/BookStore" pc="268440652" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="151" parent="globals/BookStore" pc="268440674" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="152" parent="globals/BookStore" pc="268440677" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="153" parent="globals/BookStore" pc="268440680" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="154" parent="globals/BookStore" pc="268440684" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="155" parent="globals/BookStore" pc="268440710" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="155" parent="globals/BookStore" pc="268440716" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="156" parent="globals/BookStore" pc="268440722" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="157" parent="globals/BookStore" pc="268440738" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="158" parent="globals/BookStore" pc="268440760" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="160" parent="globals/BookStore" pc="268440788" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="73" lineNum="162" parent="globals/BookStore" pc="268440805" symbol="addLookup"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="58" parent="globals/BookStore" pc="268440816" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="59" parent="globals/BookStore" pc="268440827" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="60" parent="globals/BookStore" pc="268440841" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="61" parent="globals/BookStore" pc="268440852" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="62" parent="globals/BookStore" pc="268440878" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="62" parent="globals/BookStore" pc="268440884" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="63" parent="globals/BookStore" pc="268440891" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="64" parent="globals/BookStore" pc="268440904" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="65" parent="globals/BookStore" pc="268440911" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="66" parent="globals/BookStore" pc="268440933" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="68" parent="globals/BookStore" pc="268440975" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="72" parent="globals/BookStore" pc="268440985" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="72" parent="globals/BookStore" pc="268440998" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="73" parent="globals/BookStore" pc="268441012" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="74" lineNum="75" parent="globals/BookStore" pc="268441024" symbol="saveChunk"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="75" lineNum="25" parent="globals/BookStore" pc="268441052" symbol="pageKey"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="75" lineNum="26" parent="globals/BookStore" pc="268441062" symbol="pageKey"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="76" lineNum="22" parent="globals/BookStore" pc="268441080" symbol="key"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="76" lineNum="23" parent="globals/BookStore" pc="268441090" symbol="key"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="77" lineNum="34" parent="globals/BookStore" pc="268441099" symbol="ensureMeta"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="77" lineNum="35" parent="globals/BookStore" pc="268441109" symbol="ensureMeta"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookStore.mc" id="77" lineNum="36" parent="globals/BookStore" pc="268441123" symbol="ensureMeta"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="60" parent="globals/ContentIterator" pc="268441171" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="61" parent="globals/ContentIterator" pc="268441173" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="62" parent="globals/ContentIterator" pc="268441196" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="63" parent="globals/ContentIterator" pc="268441211" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="78" lineNum="65" parent="globals/ContentIterator" pc="268441228" symbol="next"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="104" parent="globals/ContentIterator" pc="268441230" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="105" parent="globals/ContentIterator" pc="268441233" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="107" parent="globals/ContentIterator" pc="268441257" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="108" parent="globals/ContentIterator" pc="268441311" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="113" parent="globals/ContentIterator" pc="268441315" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="114" parent="globals/ContentIterator" pc="268441356" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="79" lineNum="117" parent="globals/ContentIterator" pc="268441377" symbol="objAt"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="80" lineNum="68" parent="globals/ContentIterator" pc="268441379" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="80" lineNum="69" parent="globals/ContentIterator" pc="268441381" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="80" lineNum="70" parent="globals/ContentIterator" pc="268441391" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="80" lineNum="71" parent="globals/ContentIterator" pc="268441406" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="80" lineNum="73" parent="globals/ContentIterator" pc="268441423" symbol="previous"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="182" parent="globals/ContentIterator" pc="268441425" symbol="swap"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="183" parent="globals/ContentIterator" pc="268441428" symbol="swap"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="184" parent="globals/ContentIterator" pc="268441435" symbol="swap"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="81" lineNum="185" parent="globals/ContentIterator" pc="268441448" symbol="swap"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="80" parent="globals/ContentIterator" pc="268441459" symbol="peekPrevious"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="82" lineNum="81" parent="globals/ContentIterator" pc="268441461" symbol="peekPrevious"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="83" lineNum="84" parent="globals/ContentIterator" pc="268441478" symbol="canSkip"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="83" lineNum="85" parent="globals/ContentIterator" pc="268441480" symbol="canSkip"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="92" parent="globals/ContentIterator" pc="268441482" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="93" parent="globals/ContentIterator" pc="268441484" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="94" parent="globals/ContentIterator" pc="268441492" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="95" parent="globals/ContentIterator" pc="268441500" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="97" parent="globals/ContentIterator" pc="268441510" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="84" lineNum="98" parent="globals/ContentIterator" pc="268441517" symbol="toggleShuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="32" parent="globals/ContentIterator" pc="268441526" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="33" parent="globals/ContentIterator" pc="268441529" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="34" parent="globals/ContentIterator" pc="268441553" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="41" parent="globals/ContentIterator" pc="268441566" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="42" parent="globals/ContentIterator" pc="268441575" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="43" parent="globals/ContentIterator" pc="268441584" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="44" parent="globals/ContentIterator" pc="268441594" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="47" parent="globals/ContentIterator" pc="268441604" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="48" parent="globals/ContentIterator" pc="268441615" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="50" parent="globals/ContentIterator" pc="268441628" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="51" parent="globals/ContentIterator" pc="268441639" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="85" lineNum="53" parent="globals/ContentIterator" pc="268441652" symbol="getPlaybackProfile"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="86" lineNum="76" parent="globals/ContentIterator" pc="268441655" symbol="peekNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="86" lineNum="77" parent="globals/ContentIterator" pc="268441657" symbol="peekNext"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="87" lineNum="56" parent="globals/ContentIterator" pc="268441674" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="87" lineNum="57" parent="globals/ContentIterator" pc="268441676" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="88" lineNum="88" parent="globals/ContentIterator" pc="268441690" symbol="shuffling"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="88" lineNum="89" parent="globals/ContentIterator" pc="268441692" symbol="shuffling"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="24" parent="globals/ContentIterator" pc="268441698" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="25" parent="globals/ContentIterator" pc="268441700" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="26" parent="globals/ContentIterator" pc="268441712" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="27" parent="globals/ContentIterator" pc="268441720" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="89" lineNum="28" parent="globals/ContentIterator" pc="268441728" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="90" lineNum="175" parent="globals/ContentIterator" pc="268441736" symbol="after"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="90" lineNum="176" parent="globals/ContentIterator" pc="268441738" symbol="after"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="90" lineNum="177" parent="globals/ContentIterator" pc="268441746" symbol="after"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="90" lineNum="179" parent="globals/ContentIterator" pc="268441755" symbol="after"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="188" parent="globals/ContentIterator" pc="268441761" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="189" parent="globals/ContentIterator" pc="268441764" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="190" parent="globals/ContentIterator" pc="268441787" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="191" parent="globals/ContentIterator" pc="268441805" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="192" parent="globals/ContentIterator" pc="268441815" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="193" parent="globals/ContentIterator" pc="268441831" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="91" lineNum="195" parent="globals/ContentIterator" pc="268441851" symbol="shuffle"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="131" parent="globals/ContentIterator" pc="268441860" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="132" parent="globals/ContentIterator" pc="268441863" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="133" parent="globals/ContentIterator" pc="268441872" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="134" parent="globals/ContentIterator" pc="268441876" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="138" parent="globals/ContentIterator" pc="268441880" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="139" parent="globals/ContentIterator" pc="268441884" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="140" parent="globals/ContentIterator" pc="268441903" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="140" parent="globals/ContentIterator" pc="268441909" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="141" parent="globals/ContentIterator" pc="268441916" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="142" parent="globals/ContentIterator" pc="268441932" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="145" parent="globals/ContentIterator" pc="268441964" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="146" parent="globals/ContentIterator" pc="268441991" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="147" parent="globals/ContentIterator" pc="268441997" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="148" parent="globals/ContentIterator" pc="268442007" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="149" parent="globals/ContentIterator" pc="268442013" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="150" parent="globals/ContentIterator" pc="268442023" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="151" parent="globals/ContentIterator" pc="268442030" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="152" parent="globals/ContentIterator" pc="268442036" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="153" parent="globals/ContentIterator" pc="268442052" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="154" parent="globals/ContentIterator" pc="268442066" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="156" parent="globals/ContentIterator" pc="268442084" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="163" parent="globals/ContentIterator" pc="268442100" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="164" parent="globals/ContentIterator" pc="268442121" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="165" parent="globals/ContentIterator" pc="268442125" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="166" parent="globals/ContentIterator" pc="268442172" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="166" parent="globals/ContentIterator" pc="268442188" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="166" parent="globals/ContentIterator" pc="268442201" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="167" parent="globals/ContentIterator" pc="268442214" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ContentIterator.mc" id="92" lineNum="170" parent="globals/ContentIterator" pc="268442234" symbol="buildPlaylist"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="93" lineNum="44" parent="globals/JobStore" pc="268442243" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="93" lineNum="45" parent="globals/JobStore" pc="268442253" symbol="get"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="94" lineNum="39" parent="globals/JobStore" pc="268442276" symbol="list"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="94" lineNum="40" parent="globals/JobStore" pc="268442287" symbol="list"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="94" lineNum="41" parent="globals/JobStore" pc="268442306" symbol="list"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="95" lineNum="32" parent="globals/JobStore" pc="268442320" symbol="key"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="95" lineNum="33" parent="globals/JobStore" pc="268442330" symbol="key"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="48" parent="globals/JobStore" pc="268442339" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="49" parent="globals/JobStore" pc="268442350" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="50" parent="globals/JobStore" pc="268442375" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="51" parent="globals/JobStore" pc="268442383" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="52" parent="globals/JobStore" pc="268442399" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="52" parent="globals/JobStore" pc="268442417" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="54" parent="globals/JobStore" pc="268442431" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="96" lineNum="55" parent="globals/JobStore" pc="268442443" symbol="put"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="58" parent="globals/JobStore" pc="268442464" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="59" parent="globals/JobStore" pc="268442475" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="60" parent="globals/JobStore" pc="268442483" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="61" parent="globals/JobStore" pc="268442487" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="62" parent="globals/JobStore" pc="268442503" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="62" parent="globals/JobStore" pc="268442522" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="64" parent="globals/JobStore" pc="268442550" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="65" parent="globals/JobStore" pc="268442562" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="67" parent="globals/JobStore" pc="268442585" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="97" lineNum="69" parent="globals/JobStore" pc="268442603" symbol="remove"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="98" lineNum="76" parent="globals/JobStore" pc="268442627" symbol="clearAll"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="98" lineNum="77" parent="globals/JobStore" pc="268442638" symbol="clearAll"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="98" lineNum="78" parent="globals/JobStore" pc="268442646" symbol="clearAll"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/JobStore.mc" id="98" lineNum="79" parent="globals/JobStore" pc="268442662" symbol="clearAll"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="99" lineNum="22" parent="globals/Login" pc="268442687" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="99" lineNum="23" parent="globals/Login" pc="268442697" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="100" lineNum="94" parent="globals/AbsApi" pc="268442757" symbol="isConfigured"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="100" lineNum="95" parent="globals/AbsApi" pc="268442767" symbol="isConfigured"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="29" parent="globals/AbsApi" pc="268442788" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="30" parent="globals/AbsApi" pc="268442799" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="31" parent="globals/AbsApi" pc="268442818" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="31" parent="globals/AbsApi" pc="268442824" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="101" lineNum="32" parent="globals/AbsApi" pc="268442842" symbol="authToken"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="102" lineNum="162" parent="globals/AbsApi" pc="268442845" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="102" lineNum="163" parent="globals/AbsApi" pc="268442855" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="102" lineNum="164" parent="globals/AbsApi" pc="268442883" symbol="saveLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="103" lineNum="65" parent="globals/AbsApi" pc="268442904" symbol="getCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="103" lineNum="65" parent="globals/AbsApi" pc="268442914" symbol="getCollections"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="104" lineNum="145" parent="globals/AbsApi" pc="268442933" symbol="checkHealth"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="104" lineNum="146" parent="globals/AbsApi" pc="268442943" symbol="checkHealth"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="105" lineNum="40" parent="globals/AbsApi" pc="268442997" symbol="sidecarBase"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="105" lineNum="40" parent="globals/AbsApi" pc="268443007" symbol="sidecarBase"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="106" lineNum="153" parent="globals/AbsApi" pc="268443014" symbol="login"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="106" lineNum="154" parent="globals/AbsApi" pc="268443024" symbol="login"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="68" parent="globals/AbsApi" pc="268443108" symbol="getFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="107" lineNum="69" parent="globals/AbsApi" pc="268443118" symbol="getFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="108" lineNum="86" parent="globals/AbsApi" pc="268443191" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="108" lineNum="89" parent="globals/AbsApi" pc="268443202" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="108" lineNum="90" parent="globals/AbsApi" pc="268443218" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="108" lineNum="90" parent="globals/AbsApi" pc="268443252" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="108" lineNum="91" parent="globals/AbsApi" pc="268443257" symbol="_prop"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="109" lineNum="44" parent="globals/AbsApi" pc="268443260" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="109" lineNum="45" parent="globals/AbsApi" pc="268443271" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="109" lineNum="46" parent="globals/AbsApi" pc="268443298" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="109" lineNum="46" parent="globals/AbsApi" pc="268443310" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="109" lineNum="47" parent="globals/AbsApi" pc="268443320" symbol="getBookList"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="110" lineNum="166" parent="globals/AbsApi" pc="268443370" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="110" lineNum="167" parent="globals/AbsApi" pc="268443380" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="110" lineNum="168" parent="globals/AbsApi" pc="268443398" symbol="logout"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="111" lineNum="124" parent="globals/AbsApi" pc="268443417" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="111" lineNum="125" parent="globals/AbsApi" pc="268443428" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="111" lineNum="126" parent="globals/AbsApi" pc="268443451" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="111" lineNum="126" parent="globals/AbsApi" pc="268443457" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="111" lineNum="127" parent="globals/AbsApi" pc="268443470" symbol="patchProgress"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="112" lineNum="64" parent="globals/AbsApi" pc="268443571" symbol="getSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="112" lineNum="64" parent="globals/AbsApi" pc="268443581" symbol="getSeries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="113" lineNum="113" parent="globals/AbsApi" pc="268443600" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="113" lineNum="114" parent="globals/AbsApi" pc="268443611" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="113" lineNum="115" parent="globals/AbsApi" pc="268443621" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="113" lineNum="116" parent="globals/AbsApi" pc="268443639" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="113" lineNum="118" parent="globals/AbsApi" pc="268443651" symbol="progressSeconds"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="114" lineNum="63" parent="globals/AbsApi" pc="268443653" symbol="getAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="114" lineNum="63" parent="globals/AbsApi" pc="268443663" symbol="getAuthors"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="115" lineNum="80" parent="globals/AbsApi" pc="268443682" symbol="sidecarChunkUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="115" lineNum="81" parent="globals/AbsApi" pc="268443692" symbol="sidecarChunkUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="116" lineNum="170" parent="globals/AbsApi" pc="268443758" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="116" lineNum="171" parent="globals/AbsApi" pc="268443768" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="116" lineNum="172" parent="globals/AbsApi" pc="268443832" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="116" lineNum="174" parent="globals/AbsApi" pc="268443858" symbol="_noSlash"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="117" lineNum="19" parent="globals/AbsApi" pc="268443861" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="117" lineNum="20" parent="globals/AbsApi" pc="268443872" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="117" lineNum="21" parent="globals/AbsApi" pc="268443891" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="117" lineNum="21" parent="globals/AbsApi" pc="268443897" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="117" lineNum="22" parent="globals/AbsApi" pc="268443915" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="117" lineNum="22" parent="globals/AbsApi" pc="268443921" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="117" lineNum="23" parent="globals/AbsApi" pc="268443926" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="117" lineNum="24" parent="globals/AbsApi" pc="268443980" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="117" lineNum="26" parent="globals/AbsApi" pc="268444005" symbol="serverUrl"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="118" lineNum="101" parent="globals/AbsApi" pc="268444008" symbol="getLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="118" lineNum="102" parent="globals/AbsApi" pc="268444018" symbol="getLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="119" lineNum="55" parent="globals/AbsApi" pc="268444083" symbol="getGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/AbsApi.mc" id="119" lineNum="56" parent="globals/AbsApi" pc="268444093" symbol="getGroups"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="139" parent="globals/FieldDelegate" pc="268444163" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="140" parent="globals/FieldDelegate" pc="268444165" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="120" lineNum="141" parent="globals/FieldDelegate" pc="268444186" symbol="onTextEntered"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="143" parent="globals/FieldDelegate" pc="268444188" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="144" parent="globals/FieldDelegate" pc="268444190" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="121" lineNum="145" parent="globals/FieldDelegate" pc="268444202" symbol="onCancel"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="132" parent="globals/FieldDelegate" pc="268444204" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="133" parent="globals/FieldDelegate" pc="268444206" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="134" parent="globals/FieldDelegate" pc="268444218" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="122" lineNum="135" parent="globals/FieldDelegate" pc="268444227" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="123" lineNum="14" parent="globals/RequestDelegate" pc="268444237" symbol="makeWebRequest"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="123" lineNum="15" parent="globals/RequestDelegate" pc="268444239" symbol="makeWebRequest"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="124" lineNum="9" parent="globals/RequestDelegate" pc="268444272" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="124" lineNum="10" parent="globals/RequestDelegate" pc="268444274" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="124" lineNum="11" parent="globals/RequestDelegate" pc="268444283" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="125" lineNum="18" parent="globals/RequestDelegate" pc="268444293" symbol="onWebResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/RequestDelegate.mc" id="125" lineNum="19" parent="globals/RequestDelegate" pc="268444295" symbol="onWebResponse"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="7" parent="globals/Browse" pc="268444319" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="8" parent="globals/Browse" pc="268444330" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="9" parent="globals/Browse" pc="268444396" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="10" parent="globals/Browse" pc="268444466" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="11" parent="globals/Browse" pc="268444536" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="12" parent="globals/Browse" pc="268444606" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="126" lineNum="13" parent="globals/Browse" pc="268444676" symbol="start"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="127" lineNum="17" parent="globals/Browse" pc="268444718" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="127" lineNum="18" parent="globals/Browse" pc="268444729" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="127" lineNum="19" parent="globals/Browse" pc="268444775" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="127" lineNum="21" parent="globals/Browse" pc="268444880" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="127" lineNum="23" parent="globals/Browse" pc="268444884" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="127" lineNum="24" parent="globals/Browse" pc="268444894" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="127" lineNum="25" parent="globals/Browse" pc="268444960" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="127" lineNum="26" parent="globals/Browse" pc="268444976" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="127" lineNum="27" parent="globals/Browse" pc="268444983" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Browse.mc" id="127" lineNum="29" parent="globals/Browse" pc="268445050" symbol="showBooks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="43" parent="globals/LibraryView" pc="268445090" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="44" parent="globals/LibraryView" pc="268445093" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="45" parent="globals/LibraryView" pc="268445120" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="46" parent="globals/LibraryView" pc="268445130" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="47" parent="globals/LibraryView" pc="268445196" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="48" parent="globals/LibraryView" pc="268445212" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="50" parent="globals/LibraryView" pc="268445219" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="51" parent="globals/LibraryView" pc="268445255" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="54" parent="globals/LibraryView" pc="268445318" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="56" parent="globals/LibraryView" pc="268445356" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="128" lineNum="57" parent="globals/LibraryView" pc="268445409" symbol="onLibraries"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="129" lineNum="19" parent="globals/LibraryView" pc="268445421" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="129" lineNum="23" parent="globals/LibraryView" pc="268445423" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="129" lineNum="23" parent="globals/LibraryView" pc="268445431" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="129" lineNum="24" parent="globals/LibraryView" pc="268445435" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="129" lineNum="26" parent="globals/LibraryView" pc="268445443" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="129" lineNum="28" parent="globals/LibraryView" pc="268445457" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="129" lineNum="29" parent="globals/LibraryView" pc="268445468" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="129" lineNum="31" parent="globals/LibraryView" pc="268445472" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="130" lineNum="13" parent="globals/LibraryView" pc="268445499" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="130" lineNum="14" parent="globals/LibraryView" pc="268445501" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="130" lineNum="15" parent="globals/LibraryView" pc="268445513" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="130" lineNum="16" parent="globals/LibraryView" pc="268445551" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="131" lineNum="34" parent="globals/LibraryView" pc="268445560" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="131" lineNum="35" parent="globals/LibraryView" pc="268445562" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="131" lineNum="36" parent="globals/LibraryView" pc="268445574" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="131" lineNum="37" parent="globals/LibraryView" pc="268445582" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryView.mc" id="131" lineNum="38" parent="globals/LibraryView" pc="268445598" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="132" lineNum="13" parent="globals/LibraryViewDelegate" pc="268445638" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="132" lineNum="14" parent="globals/LibraryViewDelegate" pc="268445640" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="132" lineNum="15" parent="globals/LibraryViewDelegate" pc="268445655" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="133" lineNum="8" parent="globals/LibraryViewDelegate" pc="268445657" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/LibraryViewDelegate.mc" id="133" lineNum="9" parent="globals/LibraryViewDelegate" pc="268445659" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="134" lineNum="187" parent="globals/BookMenuDelegate" pc="268445672" symbol="inBookIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="134" lineNum="188" parent="globals/BookMenuDelegate" pc="268445675" symbol="inBookIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="134" lineNum="189" parent="globals/BookMenuDelegate" pc="268445694" symbol="inBookIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="134" lineNum="189" parent="globals/BookMenuDelegate" pc="268445700" symbol="inBookIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="134" lineNum="190" parent="globals/BookMenuDelegate" pc="268445705" symbol="inBookIndex"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="135" lineNum="198" parent="globals/BookMenuDelegate" pc="268445718" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="135" lineNum="199" parent="globals/BookMenuDelegate" pc="268445720" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="180" parent="globals/BookMenuDelegate" pc="268445736" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="181" parent="globals/BookMenuDelegate" pc="268445739" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="182" parent="globals/BookMenuDelegate" pc="268445755" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="182" parent="globals/BookMenuDelegate" pc="268445773" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="136" lineNum="184" parent="globals/BookMenuDelegate" pc="268445788" symbol="containsId"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="157" parent="globals/BookMenuDelegate" pc="268445790" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="158" parent="globals/BookMenuDelegate" pc="268445793" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="160" parent="globals/BookMenuDelegate" pc="268445796" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="161" parent="globals/BookMenuDelegate" pc="268445815" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="161" parent="globals/BookMenuDelegate" pc="268445821" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="163" parent="globals/BookMenuDelegate" pc="268445828" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="164" parent="globals/BookMenuDelegate" pc="268445840" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="165" parent="globals/BookMenuDelegate" pc="268445856" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="165" parent="globals/BookMenuDelegate" pc="268445892" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="166" parent="globals/BookMenuDelegate" pc="268445898" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="167" parent="globals/BookMenuDelegate" pc="268445917" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="167" parent="globals/BookMenuDelegate" pc="268445923" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="170" parent="globals/BookMenuDelegate" pc="268445961" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="171" parent="globals/BookMenuDelegate" pc="268445980" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="171" parent="globals/BookMenuDelegate" pc="268445986" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="172" parent="globals/BookMenuDelegate" pc="268445993" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="173" parent="globals/BookMenuDelegate" pc="268446009" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="174" parent="globals/BookMenuDelegate" pc="268446063" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="175" parent="globals/BookMenuDelegate" pc="268446069" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="137" lineNum="177" parent="globals/BookMenuDelegate" pc="268446101" symbol="plannedChunks"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="16" parent="globals/BookMenuDelegate" pc="268446104" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="17" parent="globals/BookMenuDelegate" pc="268446106" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="138" lineNum="18" parent="globals/BookMenuDelegate" pc="268446118" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="26" parent="globals/BookMenuDelegate" pc="268446127" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="27" parent="globals/BookMenuDelegate" pc="268446130" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="28" parent="globals/BookMenuDelegate" pc="268446176" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="30" parent="globals/BookMenuDelegate" pc="268446273" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="33" parent="globals/BookMenuDelegate" pc="268446277" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="34" parent="globals/BookMenuDelegate" pc="268446287" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="35" parent="globals/BookMenuDelegate" pc="268446297" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="35" parent="globals/BookMenuDelegate" pc="268446303" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="37" parent="globals/BookMenuDelegate" pc="268446313" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="38" parent="globals/BookMenuDelegate" pc="268446317" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="39" parent="globals/BookMenuDelegate" pc="268446321" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="40" parent="globals/BookMenuDelegate" pc="268446337" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="41" parent="globals/BookMenuDelegate" pc="268446365" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="41" parent="globals/BookMenuDelegate" pc="268446372" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="42" parent="globals/BookMenuDelegate" pc="268446378" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="43" parent="globals/BookMenuDelegate" pc="268446399" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="46" parent="globals/BookMenuDelegate" pc="268446421" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="47" parent="globals/BookMenuDelegate" pc="268446437" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="48" parent="globals/BookMenuDelegate" pc="268446444" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="49" parent="globals/BookMenuDelegate" pc="268446526" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="62" parent="globals/BookMenuDelegate" pc="268446530" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="63" parent="globals/BookMenuDelegate" pc="268446544" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="65" parent="globals/BookMenuDelegate" pc="268446626" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="75" parent="globals/BookMenuDelegate" pc="268446630" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="76" parent="globals/BookMenuDelegate" pc="268446649" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="77" parent="globals/BookMenuDelegate" pc="268446652" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="78" parent="globals/BookMenuDelegate" pc="268446658" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="85" parent="globals/BookMenuDelegate" pc="268446736" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="86" parent="globals/BookMenuDelegate" pc="268446765" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="88" parent="globals/BookMenuDelegate" pc="268446847" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="94" parent="globals/BookMenuDelegate" pc="268446851" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="95" parent="globals/BookMenuDelegate" pc="268446874" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="97" parent="globals/BookMenuDelegate" pc="268446956" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="103" parent="globals/BookMenuDelegate" pc="268446960" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="104" parent="globals/BookMenuDelegate" pc="268446979" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="112" parent="globals/BookMenuDelegate" pc="268447015" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="113" parent="globals/BookMenuDelegate" pc="268447020" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="114" parent="globals/BookMenuDelegate" pc="268447038" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="115" parent="globals/BookMenuDelegate" pc="268447056" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="122" parent="globals/BookMenuDelegate" pc="268447077" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="123" parent="globals/BookMenuDelegate" pc="268447096" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="124" parent="globals/BookMenuDelegate" pc="268447120" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="125" parent="globals/BookMenuDelegate" pc="268447124" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="126" parent="globals/BookMenuDelegate" pc="268447141" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="126" parent="globals/BookMenuDelegate" pc="268447163" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="128" parent="globals/BookMenuDelegate" pc="268447191" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="136" parent="globals/BookMenuDelegate" pc="268447214" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="137" parent="globals/BookMenuDelegate" pc="268447242" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="145" parent="globals/BookMenuDelegate" pc="268447305" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="139" lineNum="146" parent="globals/BookMenuDelegate" pc="268447337" symbol="onFiles"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="140" lineNum="193" parent="globals/BookMenuDelegate" pc="268447349" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="140" lineNum="194" parent="globals/BookMenuDelegate" pc="268447351" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="140" lineNum="194" parent="globals/BookMenuDelegate" pc="268447357" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="140" lineNum="195" parent="globals/BookMenuDelegate" pc="268447363" symbol="numOr"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="141" lineNum="21" parent="globals/BookMenuDelegate" pc="268447366" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="141" lineNum="22" parent="globals/BookMenuDelegate" pc="268447368" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/BookMenuDelegate.mc" id="141" lineNum="23" parent="globals/BookMenuDelegate" pc="268447382" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="142" lineNum="117" parent="globals/LoginView" pc="268447414" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="142" lineNum="118" parent="globals/LoginView" pc="268447416" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="142" lineNum="119" parent="globals/LoginView" pc="268447461" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="142" lineNum="120" parent="globals/LoginView" pc="268447498" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="142" lineNum="122" parent="globals/LoginView" pc="268447552" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="142" lineNum="123" parent="globals/LoginView" pc="268447561" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="142" lineNum="124" parent="globals/LoginView" pc="268447614" symbol="onLogin"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="77" parent="globals/LoginView" pc="268447626" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="78" parent="globals/LoginView" pc="268447628" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="78" parent="globals/LoginView" pc="268447635" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="79" parent="globals/LoginView" pc="268447670" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="79" parent="globals/LoginView" pc="268447678" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="143" lineNum="80" parent="globals/LoginView" pc="268447713" symbol="labelFor"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="104" parent="globals/LoginView" pc="268447745" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="105" parent="globals/LoginView" pc="268447747" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="105" parent="globals/LoginView" pc="268447754" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="106" parent="globals/LoginView" pc="268447770" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="106" parent="globals/LoginView" pc="268447778" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="107" parent="globals/LoginView" pc="268447794" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="107" parent="globals/LoginView" pc="268447802" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="144" lineNum="108" parent="globals/LoginView" pc="268447818" symbol="setField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="44" parent="globals/LoginView" pc="268447831" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="45" parent="globals/LoginView" pc="268447833" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="46" parent="globals/LoginView" pc="268447844" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="47" parent="globals/LoginView" pc="268447864" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="48" parent="globals/LoginView" pc="268447875" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="49" parent="globals/LoginView" pc="268447904" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="50" parent="globals/LoginView" pc="268447938" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="51" parent="globals/LoginView" pc="268447949" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="52" parent="globals/LoginView" pc="268447958" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="53" parent="globals/LoginView" pc="268447996" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="145" lineNum="58" parent="globals/LoginView" pc="268448007" symbol="onShow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="146" lineNum="111" parent="globals/LoginView" pc="268448047" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="146" lineNum="112" parent="globals/LoginView" pc="268448049" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="146" lineNum="113" parent="globals/LoginView" pc="268448058" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="146" lineNum="114" parent="globals/LoginView" pc="268448096" symbol="cancelFlow"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="63" parent="globals/LoginView" pc="268448108" symbol="onHealth"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="64" parent="globals/LoginView" pc="268448110" symbol="onHealth"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="65" parent="globals/LoginView" pc="268448152" symbol="onHealth"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="67" parent="globals/LoginView" pc="268448211" symbol="onHealth"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="68" parent="globals/LoginView" pc="268448220" symbol="onHealth"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="147" lineNum="69" parent="globals/LoginView" pc="268448273" symbol="onHealth"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="148" lineNum="84" parent="globals/LoginView" pc="268448285" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="148" lineNum="85" parent="globals/LoginView" pc="268448287" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="148" lineNum="86" parent="globals/LoginView" pc="268448295" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="148" lineNum="87" parent="globals/LoginView" pc="268448305" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="148" lineNum="88" parent="globals/LoginView" pc="268448375" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="148" lineNum="89" parent="globals/LoginView" pc="268448386" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="148" lineNum="90" parent="globals/LoginView" pc="268448457" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="148" lineNum="91" parent="globals/LoginView" pc="268448468" symbol="openField"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="149" lineNum="33" parent="globals/LoginView" pc="268448535" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="149" lineNum="34" parent="globals/LoginView" pc="268448538" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="149" lineNum="35" parent="globals/LoginView" pc="268448550" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="149" lineNum="36" parent="globals/LoginView" pc="268448558" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="149" lineNum="37" parent="globals/LoginView" pc="268448583" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="149" lineNum="38" parent="globals/LoginView" pc="268448595" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="149" lineNum="39" parent="globals/LoginView" pc="268448622" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="149" lineNum="40" parent="globals/LoginView" pc="268448634" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="150" lineNum="73" parent="globals/LoginView" pc="268448643" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="150" lineNum="74" parent="globals/LoginView" pc="268448645" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="150" lineNum="74" parent="globals/LoginView" pc="268448654" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="150" lineNum="74" parent="globals/LoginView" pc="268448666" symbol="onHide"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="151" lineNum="95" parent="globals/LoginView" pc="268448678" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="151" lineNum="96" parent="globals/LoginView" pc="268448680" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="151" lineNum="97" parent="globals/LoginView" pc="268448692" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="151" lineNum="98" parent="globals/LoginView" pc="268448700" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/Login.mc" id="151" lineNum="99" parent="globals/LoginView" pc="268448716" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="152" lineNum="74" parent="globals/DownloadedMenuDelegate" pc="268448756" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="152" lineNum="75" parent="globals/DownloadedMenuDelegate" pc="268448759" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="152" lineNum="75" parent="globals/DownloadedMenuDelegate" pc="268448771" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="152" lineNum="77" parent="globals/DownloadedMenuDelegate" pc="268448775" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="152" lineNum="78" parent="globals/DownloadedMenuDelegate" pc="268448794" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="152" lineNum="78" parent="globals/DownloadedMenuDelegate" pc="268448800" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="152" lineNum="79" parent="globals/DownloadedMenuDelegate" pc="268448807" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="152" lineNum="80" parent="globals/DownloadedMenuDelegate" pc="268448823" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="152" lineNum="82" parent="globals/DownloadedMenuDelegate" pc="268448848" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="152" lineNum="84" parent="globals/DownloadedMenuDelegate" pc="268448868" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="152" lineNum="85" parent="globals/DownloadedMenuDelegate" pc="268448879" symbol="queueDelete"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="88" parent="globals/DownloadedMenuDelegate" pc="268448912" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="153" lineNum="89" parent="globals/DownloadedMenuDelegate" pc="268448914" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="154" lineNum="12" parent="globals/DownloadedMenuDelegate" pc="268448930" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="154" lineNum="13" parent="globals/DownloadedMenuDelegate" pc="268448932" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="16" parent="globals/DownloadedMenuDelegate" pc="268448945" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="17" parent="globals/DownloadedMenuDelegate" pc="268448948" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="21" parent="globals/DownloadedMenuDelegate" pc="268448957" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="22" parent="globals/DownloadedMenuDelegate" pc="268448990" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="23" parent="globals/DownloadedMenuDelegate" pc="268449041" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="31" parent="globals/DownloadedMenuDelegate" pc="268449045" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="32" parent="globals/DownloadedMenuDelegate" pc="268449078" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="33" parent="globals/DownloadedMenuDelegate" pc="268449092" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="39" parent="globals/DownloadedMenuDelegate" pc="268449096" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="40" parent="globals/DownloadedMenuDelegate" pc="268449129" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="41" parent="globals/DownloadedMenuDelegate" pc="268449140" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="42" parent="globals/DownloadedMenuDelegate" pc="268449191" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="49" parent="globals/DownloadedMenuDelegate" pc="268449195" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="50" parent="globals/DownloadedMenuDelegate" pc="268449228" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="51" parent="globals/DownloadedMenuDelegate" pc="268449239" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="52" parent="globals/DownloadedMenuDelegate" pc="268449259" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="53" parent="globals/DownloadedMenuDelegate" pc="268449291" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="57" parent="globals/DownloadedMenuDelegate" pc="268449295" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="58" parent="globals/DownloadedMenuDelegate" pc="268449328" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="59" parent="globals/DownloadedMenuDelegate" pc="268449347" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="59" parent="globals/DownloadedMenuDelegate" pc="268449353" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="60" parent="globals/DownloadedMenuDelegate" pc="268449360" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="61" parent="globals/DownloadedMenuDelegate" pc="268449371" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenuDelegate.mc" id="155" lineNum="68" parent="globals/DownloadedMenuDelegate" pc="268449375" symbol="onSelect"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="156" lineNum="14" parent="globals/ErrorViewDelegate" pc="268449394" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="156" lineNum="15" parent="globals/ErrorViewDelegate" pc="268449396" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="156" lineNum="16" parent="globals/ErrorViewDelegate" pc="268449411" symbol="onBack"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="157" lineNum="10" parent="globals/ErrorViewDelegate" pc="268449413" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorViewDelegate.mc" id="157" lineNum="11" parent="globals/ErrorViewDelegate" pc="268449415" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="158" lineNum="9" parent="globals/ErrorView" pc="268449428" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="158" lineNum="10" parent="globals/ErrorView" pc="268449430" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="158" lineNum="11" parent="globals/ErrorView" pc="268449442" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="159" lineNum="14" parent="globals/ErrorView" pc="268449452" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="159" lineNum="15" parent="globals/ErrorView" pc="268449454" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="159" lineNum="16" parent="globals/ErrorView" pc="268449466" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="159" lineNum="17" parent="globals/ErrorView" pc="268449474" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/ErrorView.mc" id="159" lineNum="18" parent="globals/ErrorView" pc="268449490" symbol="onUpdate"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="71" parent="globals/DownloadedMenu" pc="268449530" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="72" parent="globals/DownloadedMenu" pc="268449533" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="73" parent="globals/DownloadedMenu" pc="268449545" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="74" parent="globals/DownloadedMenu" pc="268449548" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="74" parent="globals/DownloadedMenu" pc="268449565" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="75" parent="globals/DownloadedMenu" pc="268449577" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="160" lineNum="76" parent="globals/DownloadedMenu" pc="268449592" symbol="titleWithSize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="161" lineNum="62" parent="globals/DownloadedMenu" pc="268449651" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="161" lineNum="63" parent="globals/DownloadedMenu" pc="268449654" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="161" lineNum="64" parent="globals/DownloadedMenu" pc="268449673" symbol="hasQueued"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="13" parent="globals/DownloadedMenu" pc="268449717" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="14" parent="globals/DownloadedMenu" pc="268449720" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="19" parent="globals/DownloadedMenu" pc="268449751" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="21" parent="globals/DownloadedMenu" pc="268449820" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="22" parent="globals/DownloadedMenu" pc="268449839" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="22" parent="globals/DownloadedMenu" pc="268449845" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="30" parent="globals/DownloadedMenu" pc="268449852" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="31" parent="globals/DownloadedMenu" pc="268449864" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="36" parent="globals/DownloadedMenu" pc="268449936" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="37" parent="globals/DownloadedMenu" pc="268449949" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="44" parent="globals/DownloadedMenu" pc="268450021" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="45" parent="globals/DownloadedMenu" pc="268450030" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="48" parent="globals/DownloadedMenu" pc="268450102" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="49" parent="globals/DownloadedMenu" pc="268450114" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="52" parent="globals/DownloadedMenu" pc="268450186" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="53" parent="globals/DownloadedMenu" pc="268450202" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="54" parent="globals/DownloadedMenu" pc="268450209" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="55" parent="globals/DownloadedMenu" pc="268450225" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="56" parent="globals/DownloadedMenu" pc="268450261" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="57" parent="globals/DownloadedMenu" pc="268450277" symbol="initialize"/>
+        <entry filename="/Users/cbrooker/Code/ABS-Garmin/source/DownloadedMenu.mc" id="162" lineNum="58" parent="globals/DownloadedMenu" pc="268450314" symbol="initialize"/>
+    </pcToLineNum>
+    <symbolTable>
+        <entry id="50" method="true" symbol="containsId"/>
+        <entry id="8388639" module="true" symbol="Graphics"/>
+        <entry id="8390434" method="true" symbol="getSyncConfigurationView"/>
+        <entry id="22" object="true" symbol="DownloadedMenu"/>
+        <entry field="true" id="63" symbol="&lt;globals/GroupDelegate/&lt;&gt;mType&gt;"/>
+        <entry id="8390557" method="true" symbol="resetContentIterator"/>
+        <entry id="96" method="true" symbol="isConfigured"/>
+        <entry id="71" method="true" symbol="ensureMeta"/>
+        <entry id="131" method="true" symbol="titleWithSize"/>
+        <entry id="8390211" module="true" symbol="Media"/>
+        <entry id="115" method="true" symbol="numOr"/>
+        <entry field="true" id="147" symbol="errItems"/>
+        <entry id="48" method="true" symbol="pushGroups"/>
+        <entry id="16" object="true" symbol="AbsProgressListener"/>
+        <entry id="34" object="true" symbol="LoginView"/>
+        <entry id="8388632" method="true" symbol="&lt;init&gt;"/>
+        <entry id="8390379" method="true" symbol="onThumbsUp"/>
+        <entry id="8390380" method="true" symbol="onThumbsDown"/>
+        <entry id="76" method="true" symbol="buildPlaylist"/>
+        <entry id="3" module="true" symbol="globals/BookStore"/>
+        <entry id="49" method="true" symbol="flash"/>
+        <entry field="true" id="138" symbol="byAuthor"/>
+        <entry id="101" method="true" symbol="saveLogin"/>
+        <entry field="true" id="148" symbol="errLibraries"/>
+        <entry id="56" method="true" symbol="onOpDone"/>
+        <entry id="8390335" object="true" symbol="ContentIterator"/>
+        <entry id="35" module="true" symbol="Notify"/>
+        <entry field="true" id="166" symbol="settingApiKey"/>
+        <entry id="8388826" method="true" symbol="next"/>
+        <entry field="true" id="163" symbol="playDownloaded"/>
+        <entry field="true" id="107" symbol="mCallback"/>
+        <entry id="29" object="true" symbol="LibraryMenuDelegate"/>
+        <entry field="true" id="62" symbol="&lt;globals/GroupDelegate/&lt;&gt;mLib&gt;"/>
+        <entry id="18" module="true" symbol="BookStore"/>
+        <entry field="true" id="154" symbol="fieldServer"/>
+        <entry id="17" object="true" symbol="BookMenuDelegate"/>
+        <entry id="46" method="true" symbol="onCollections"/>
+        <entry id="5" module="true" symbol="globals/Chunks"/>
+        <entry field="true" id="78" symbol="&lt;globals/ContentIterator/&lt;&gt;mPlaylist&gt;"/>
+        <entry field="true" id="135" symbol="allBooks"/>
+        <entry id="28" module="true" symbol="JobStore"/>
+        <entry id="72" method="true" symbol="pageKey"/>
+        <entry id="81" method="true" symbol="swap"/>
+        <entry id="8388791" method="true" symbol="remove"/>
+        <entry field="true" id="165" symbol="queued"/>
+        <entry id="8390336" object="true" symbol="ContentDelegate"/>
+        <entry id="15" module="true" symbol="AbsApi"/>
+        <entry field="true" id="164" symbol="queueCleared"/>
+        <entry id="38" module="true" symbol="Versions"/>
+        <entry field="true" id="8388611" module="true" symbol="Toybox"/>
+        <entry id="128" method="true" symbol="queueDelete"/>
+        <entry id="8390377" method="true" symbol="getContentIterator"/>
+        <entry id="84" method="true" symbol="list"/>
+        <entry id="8389108" method="true" symbol="onResponse"/>
+        <entry id="100" method="true" symbol="progressSeconds"/>
+        <entry id="94" method="true" symbol="getLibraries"/>
+        <entry field="true" id="159" symbol="loggingIn"/>
+        <entry id="8390373" method="true" symbol="shuffling"/>
+        <entry id="85" method="true" symbol="_noSlash"/>
+        <entry id="39" object="true" symbol="WatchShelfApp"/>
+        <entry field="true" id="134" symbol="AppName"/>
+        <entry id="8390440" symbol="contentType"/>
+        <entry id="8390459" method="true" symbol="onStopSync"/>
+        <entry id="11" module="true" symbol="globals/Rez/Strings"/>
+        <entry id="19" module="true" symbol="Browse"/>
+        <entry id="8389594" symbol="headers"/>
+        <entry field="true" id="129" symbol="&lt;globals/ErrorView/&lt;&gt;mMessage&gt;"/>
+        <entry id="6" module="true" symbol="globals/JobStore"/>
+        <entry field="true" id="160" symbol="loginFailed"/>
+        <entry field="true" id="120" symbol="&lt;globals/LoginView/&lt;&gt;mCreds&gt;"/>
+        <entry id="70" method="true" symbol="deleteBook"/>
+        <entry id="8390430" method="true" symbol="getContentDelegate"/>
+        <entry id="58" method="true" symbol="sweepOrphans"/>
+        <entry field="true" id="54" symbol="&lt;globals/SyncDelegate/&lt;&gt;mDone&gt;"/>
+        <entry id="112" method="true" symbol="onLibraries"/>
+        <entry field="true" id="153" symbol="fieldPass"/>
+        <entry id="8388648" module="true" symbol="WatchUi"/>
+        <entry id="8389081" method="true" symbol="onBack"/>
+        <entry field="true" id="155" symbol="fieldUser"/>
+        <entry field="true" id="64" symbol="&lt;globals/ContentDelegate/&lt;&gt;mIterator&gt;"/>
+        <entry id="14" module="true" symbol="globals/Versions"/>
+        <entry id="93" method="true" symbol="getGroups"/>
+        <entry id="9" module="true" symbol="globals/Rez"/>
+        <entry id="44" method="true" symbol="onAuthors"/>
+        <entry id="87" method="true" symbol="authToken"/>
+        <entry id="8388789" method="true" symbol="get"/>
+        <entry id="8390342" method="true" symbol="isSyncNeeded"/>
+        <entry field="true" id="146" symbol="errDetail"/>
+        <entry field="true" id="137" symbol="browseLibrary"/>
+        <entry id="8389124" method="true" symbol="onUpdate"/>
+        <entry field="true" id="122" symbol="&lt;globals/LoginView/&lt;&gt;mState&gt;"/>
+        <entry id="8390431" method="true" symbol="getSyncDelegate"/>
+        <entry id="30" object="true" symbol="LibraryView"/>
+        <entry id="82" method="true" symbol="toggleShuffle"/>
+        <entry field="true" id="8390516" symbol="mContext"/>
+        <entry id="80" method="true" symbol="objAt"/>
+        <entry id="8388771" module="true" object="true" symbol="Drawables"/>
+        <entry id="42" method="true" symbol="starts"/>
+        <entry field="true" id="169" symbol="settingServerUrlPrompt"/>
+        <entry id="86" method="true" symbol="_prop"/>
+        <entry id="32" module="true" symbol="Login"/>
+        <entry id="8390433" method="true" symbol="getProviderIconInfo"/>
+        <entry id="57" method="true" symbol="onTrackDownloaded"/>
+        <entry id="7" module="true" symbol="globals/Login"/>
+        <entry field="true" id="161" symbol="pickBook"/>
+        <entry field="true" id="136" symbol="alreadyDownloaded"/>
+        <entry field="true" id="61" symbol="username"/>
+        <entry id="8389850" method="true" symbol="count"/>
+        <entry field="true" id="167" symbol="settingApiKeyPrompt"/>
+        <entry field="true" id="60" symbol="server"/>
+        <entry id="8390442" method="true" symbol="shuffle"/>
+        <entry field="true" id="79" symbol="&lt;globals/ContentIterator/&lt;&gt;mShuffling&gt;"/>
+        <entry id="8390337" object="true" symbol="SyncDelegate"/>
+        <entry id="40" method="true" symbol="at"/>
+        <entry id="8" module="true" symbol="globals/Notify"/>
+        <entry id="125" method="true" symbol="onLogin"/>
+        <entry id="68" method="true" symbol="addRefIds"/>
+        <entry field="true" id="144" symbol="downloaded"/>
+        <entry id="37" module="true" symbol="Store"/>
+        <entry id="13" module="true" symbol="globals/Store"/>
+        <entry id="8388637" module="true" symbol="Communications"/>
+        <entry id="102" method="true" symbol="serverUrl"/>
+        <entry id="24" object="true" symbol="ErrorView"/>
+        <entry id="33" object="true" symbol="LoginCreds"/>
+        <entry id="10" module="true" symbol="globals/Rez/Drawables"/>
+        <entry id="21" module="true" symbol="Chunks"/>
+        <entry id="8390371" method="true" symbol="peekNext"/>
+        <entry field="true" id="150" symbol="errNone"/>
+        <entry id="41" method="true" symbol="same"/>
+        <entry id="83" method="true" symbol="clearAll"/>
+        <entry field="true" id="139" symbol="byCollection"/>
+        <entry id="8390372" method="true" symbol="peekPrevious"/>
+        <entry id="8389844" symbol="responseType"/>
+        <entry field="true" id="110" symbol="&lt;globals/LibraryView/&lt;&gt;mMessage&gt;"/>
+        <entry field="true" id="8392276" symbol="skipForwardTimeDelta"/>
+        <entry id="8392335" module="true" object="true" symbol="Settings"/>
+        <entry field="true" id="162" symbol="pickLibrary"/>
+        <entry id="45" method="true" symbol="onBooks"/>
+        <entry id="69" method="true" symbol="addToIndex"/>
+        <entry id="98" method="true" symbol="logout"/>
+        <entry id="8388786" method="true" symbol="method"/>
+        <entry id="126" method="true" symbol="openField"/>
+        <entry field="true" id="158" symbol="logOut"/>
+        <entry id="8388644" module="true" symbol="System"/>
+        <entry id="8390382" method="true" symbol="onSong"/>
+        <entry id="97" method="true" symbol="login"/>
+        <entry field="true" id="121" symbol="&lt;globals/LoginView/&lt;&gt;mMessage&gt;"/>
+        <entry id="8389619" method="true" symbol="onSelect"/>
+        <entry id="8388769" module="true" object="true" symbol="Rez"/>
+        <entry field="true" id="43" symbol="&lt;globals/BrowseDelegate/&lt;&gt;mLib&gt;"/>
+        <entry field="true" id="59" symbol="password"/>
+        <entry id="25" object="true" symbol="ErrorViewDelegate"/>
+        <entry id="99" method="true" symbol="patchProgress"/>
+        <entry id="8389540" method="true" symbol="onTextEntered"/>
+        <entry id="8390432" method="true" symbol="getPlaybackConfigurationView"/>
+        <entry id="95" method="true" symbol="getSeries"/>
+        <entry id="109" method="true" symbol="showBooks"/>
+        <entry field="true" id="8392277" symbol="skipBackwardTimeDelta"/>
+        <entry field="true" id="106" symbol="&lt;globals/FieldDelegate/&lt;&gt;mView&gt;"/>
+        <entry id="8388640" module="true" symbol="Lang"/>
+        <entry field="true" id="168" symbol="settingServerUrl"/>
+        <entry id="118" method="true" symbol="cancelFlow"/>
+        <entry field="true" id="156" symbol="loading"/>
+        <entry id="23" object="true" symbol="DownloadedMenuDelegate"/>
+        <entry id="8390784" method="true" symbol="onRepeat"/>
+        <entry id="8390374" method="true" symbol="canSkip"/>
+        <entry field="true" id="123" symbol="&lt;globals/LoginView/&lt;&gt;mTimer&gt;"/>
+        <entry id="127" method="true" symbol="setField"/>
+        <entry id="8388610" symbol="statics"/>
+        <entry id="90" method="true" symbol="getBookList"/>
+        <entry id="8389123" method="true" symbol="onShow"/>
+        <entry id="12" module="true" symbol="globals/Settings"/>
+        <entry id="113" method="true" symbol="inBookIndex"/>
+        <entry id="31" object="true" symbol="LibraryViewDelegate"/>
+        <entry id="26" object="true" symbol="FieldDelegate"/>
+        <entry id="8390369" method="true" symbol="getPlaybackProfile"/>
+        <entry id="8389835" method="true" symbol="makeWebRequest"/>
+        <entry id="73" method="true" symbol="removeFromIndex"/>
+        <entry id="8390370" method="true" symbol="previous"/>
+        <entry id="8390522" method="true" symbol="key"/>
+        <entry field="true" id="132" symbol="launcher"/>
+        <entry field="true" id="111" symbol="&lt;globals/LibraryView/&lt;&gt;mStarted&gt;"/>
+        <entry id="8389350" module="true" symbol="globals"/>
+        <entry field="true" id="141" symbol="clearQueue"/>
+        <entry field="true" id="152" symbol="errTooManyFiles"/>
+        <entry id="117" method="true" symbol="plannedChunks"/>
+        <entry id="8388770" module="true" object="true" symbol="Strings"/>
+        <entry id="8391940" method="true" symbol="showToast"/>
+        <entry id="124" method="true" symbol="onHealth"/>
+        <entry id="20" object="true" symbol="BrowseDelegate"/>
+        <entry id="8388702" method="true" symbol="initialize"/>
+        <entry field="true" id="114" symbol="&lt;globals/BookMenuDelegate/&lt;&gt;mItemId&gt;"/>
+        <entry id="51" method="true" symbol="deleteQueued"/>
+        <entry id="67" method="true" symbol="addLookup"/>
+        <entry field="true" id="157" symbol="logIn"/>
+        <entry field="true" id="65" symbol="&lt;globals/ContentDelegate/&lt;&gt;mProgressLookup&gt;"/>
+        <entry field="true" id="143" symbol="deleting"/>
+        <entry id="88" method="true" symbol="checkHealth"/>
+        <entry id="36" object="true" symbol="RequestDelegate"/>
+        <entry id="53" method="true" symbol="downloadNext"/>
+        <entry id="2" module="true" symbol="globals/AbsApi"/>
+        <entry id="8388641" module="true" symbol="Math"/>
+        <entry id="8389541" method="true" symbol="onCancel"/>
+        <entry id="66" method="true" symbol="syncProgress"/>
+        <entry id="8390341" method="true" symbol="onStartSync"/>
+        <entry id="108" method="true" symbol="onWebResponse"/>
+        <entry id="89" method="true" symbol="getAuthors"/>
+        <entry field="true" id="55" symbol="&lt;globals/SyncDelegate/&lt;&gt;mTotal&gt;"/>
+        <entry id="116" method="true" symbol="onFiles"/>
+        <entry id="74" method="true" symbol="saveChunk"/>
+        <entry id="8388788" method="true" symbol="put"/>
+        <entry id="92" method="true" symbol="getFiles"/>
+        <entry id="104" method="true" symbol="sidecarChunkUrl"/>
+        <entry id="8388646" module="true" object="true" symbol="Timer"/>
+        <entry id="4" module="true" symbol="globals/Browse"/>
+        <entry id="103" method="true" symbol="sidecarBase"/>
+        <entry id="47" method="true" symbol="onSeries"/>
+        <entry field="true" id="149" symbol="errNoAudio"/>
+        <entry id="8388698" method="true" symbol="start"/>
+        <entry id="52" method="true" symbol="deletes"/>
+        <entry id="8390381" method="true" symbol="onShuffle"/>
+        <entry id="27" object="true" symbol="GroupDelegate"/>
+        <entry field="true" id="8389866" method="true" symbol="total"/>
+        <entry field="true" id="77" symbol="&lt;globals/ContentIterator/&lt;&gt;mIndex&gt;"/>
+        <entry field="true" id="145" symbol="downloadsFull"/>
+        <entry id="8390441" object="true" symbol="mediaEncoding"/>
+        <entry id="130" method="true" symbol="hasQueued"/>
+        <entry field="true" id="140" symbol="bySeries"/>
+        <entry field="true" id="142" symbol="deleteAllDownloads"/>
+        <entry id="8389125" method="true" symbol="onHide"/>
+        <entry field="true" id="133" symbol="providerIcon"/>
+        <entry id="119" method="true" symbol="labelFor"/>
+        <entry id="75" method="true" symbol="after"/>
+        <entry field="true" id="151" symbol="errNotWatchShelf"/>
+        <entry id="8388635" module="true" symbol="Application"/>
+        <entry field="true" id="8389642" symbol="title"/>
+        <entry field="true" id="105" symbol="&lt;globals/FieldDelegate/&lt;&gt;mField&gt;"/>
+        <entry id="91" method="true" symbol="getCollections"/>
+    </symbolTable>
+    <localVars>
+        <entry arg="true" endPc="268435798" name="durs" stackId="1" startPc="268435672"/>
+        <entry endPc="268435798" name="n" stackId="2" startPc="268435683"/>
+        <entry endPc="268435795" name="f" stackId="3" startPc="268435702"/>
+        <entry endPc="268435785" name="d" stackId="4" startPc="268435702"/>
+        <entry endPc="268435785" name="pos" stackId="5" startPc="268435702"/>
+        <entry endPc="268435782" name="size" stackId="6" startPc="268435733"/>
+        <entry endPc="268435782" name="end" stackId="7" startPc="268435733"/>
+        <entry arg="true" endPc="268435900" name="dursA" stackId="1" startPc="268435799"/>
+        <entry arg="true" endPc="268435900" name="dursB" stackId="2" startPc="268435799"/>
+        <entry endPc="268435898" name="i" stackId="3" startPc="268435870"/>
+        <entry arg="true" endPc="268436088" name="durs" stackId="1" startPc="268435901"/>
+        <entry arg="true" endPc="268436088" name="k" stackId="2" startPc="268435901"/>
+        <entry endPc="268436088" name="n" stackId="3" startPc="268435912"/>
+        <entry endPc="268436088" name="bookOffset" stackId="4" startPc="268435912"/>
+        <entry endPc="268436086" name="f" stackId="5" startPc="268435934"/>
+        <entry endPc="268436076" name="d" stackId="6" startPc="268435934"/>
+        <entry endPc="268436076" name="pos" stackId="7" startPc="268435934"/>
+        <entry endPc="268436066" name="size" stackId="8" startPc="268435965"/>
+        <entry endPc="268436066" name="end" stackId="9" startPc="268435965"/>
+        <entry arg="true" endPc="268436239" name="durs" stackId="1" startPc="268436089"/>
+        <entry endPc="268436239" name="out" stackId="2" startPc="268436100"/>
+        <entry endPc="268436239" name="bookOffset" stackId="3" startPc="268436100"/>
+        <entry endPc="268436236" name="f" stackId="4" startPc="268436123"/>
+        <entry endPc="268436226" name="d" stackId="5" startPc="268436123"/>
+        <entry endPc="268436226" name="pos" stackId="6" startPc="268436123"/>
+        <entry endPc="268436216" name="size" stackId="7" startPc="268436154"/>
+        <entry endPc="268436216" name="end" stackId="8" startPc="268436154"/>
+        <entry arg="true" endPc="268436265" name="code" stackId="1" startPc="268436240"/>
+        <entry arg="true" endPc="268436265" name="data" stackId="2" startPc="268436240"/>
+        <entry arg="true" endPc="268436309" name="code" stackId="1" startPc="268436284"/>
+        <entry arg="true" endPc="268436309" name="data" stackId="2" startPc="268436284"/>
+        <entry arg="true" endPc="268436676" name="code" stackId="1" startPc="268436310"/>
+        <entry arg="true" endPc="268436676" name="data" stackId="2" startPc="268436310"/>
+        <entry arg="true" endPc="268436676" name="key" stackId="3" startPc="268436310"/>
+        <entry arg="true" endPc="268436676" name="filterType" stackId="4" startPc="268436310"/>
+        <entry endPc="268436675" name="groups" stackId="5" startPc="268436313"/>
+        <entry endPc="268436675" name="m" stackId="6" startPc="268436313"/>
+        <entry endPc="268436633" name="i" stackId="7" startPc="268436528"/>
+        <entry endPc="268436623" name="g" stackId="8" startPc="268436528"/>
+        <entry endPc="268436623" name="sub" stackId="9" startPc="268436528"/>
+        <entry arg="true" endPc="268436696" name="code" stackId="1" startPc="268436677"/>
+        <entry arg="true" endPc="268436696" name="data" stackId="2" startPc="268436677"/>
+        <entry arg="true" endPc="268436722" name="code" stackId="1" startPc="268436697"/>
+        <entry arg="true" endPc="268436722" name="data" stackId="2" startPc="268436697"/>
+        <entry arg="true" endPc="268436746" name="libId" stackId="1" startPc="268436723"/>
+        <entry arg="true" endPc="268436945" name="item" stackId="1" startPc="268436747"/>
+        <entry endPc="268436944" name="mode" stackId="2" startPc="268436750"/>
+        <entry arg="true" endPc="268437063" name="stringRezId" stackId="1" startPc="268436946"/>
+        <entry endPc="268437321" name="toDelete" stackId="1" startPc="268437067"/>
+        <entry endPc="268437118" name="i" stackId="2" startPc="268437091"/>
+        <entry endPc="268437321" name="jobIds" stackId="3" startPc="268437067"/>
+        <entry endPc="268437275" name="i" stackId="4" startPc="268437161"/>
+        <entry endPc="268437265" name="job" stackId="5" startPc="268437161"/>
+        <entry endPc="268437265" name="left" stackId="6" startPc="268437161"/>
+        <entry endPc="268437358" name="d" stackId="1" startPc="268437326"/>
+        <entry endPc="268437744" name="jobIds" stackId="1" startPc="268437362"/>
+        <entry endPc="268437744" name="itemId" stackId="2" startPc="268437362"/>
+        <entry endPc="268437744" name="job" stackId="3" startPc="268437362"/>
+        <entry endPc="268437744" name="c" stackId="4" startPc="268437362"/>
+        <entry endPc="268437744" name="options" stackId="5" startPc="268437362"/>
+        <entry endPc="268437744" name="context" stackId="6" startPc="268437362"/>
+        <entry endPc="268437744" name="delegate" stackId="7" startPc="268437362"/>
+        <entry endPc="268437744" name="url" stackId="8" startPc="268437362"/>
+        <entry endPc="268437821" name="pct" stackId="1" startPc="268437749"/>
+        <entry arg="true" endPc="268438039" name="toDelete" stackId="1" startPc="268437823"/>
+        <entry endPc="268437910" name="i" stackId="2" startPc="268437858"/>
+        <entry endPc="268438038" name="fresh" stackId="3" startPc="268437826"/>
+        <entry endPc="268438038" name="remaining" stackId="4" startPc="268437826"/>
+        <entry endPc="268437985" name="i" stackId="5" startPc="268437939"/>
+        <entry arg="true" endPc="268438389" name="code" stackId="1" startPc="268438040"/>
+        <entry arg="true" endPc="268438389" name="data" stackId="2" startPc="268438040"/>
+        <entry arg="true" endPc="268438389" name="context" stackId="3" startPc="268438040"/>
+        <entry endPc="268438388" name="itemId" stackId="4" startPc="268438043"/>
+        <entry endPc="268438388" name="refId" stackId="5" startPc="268438043"/>
+        <entry endPc="268438388" name="job" stackId="6" startPc="268438043"/>
+        <entry endPc="268438388" name="k" stackId="7" startPc="268438043"/>
+        <entry arg="true" endPc="268438443" name="arr" stackId="1" startPc="268438390"/>
+        <entry arg="true" endPc="268438443" name="itemId" stackId="2" startPc="268438390"/>
+        <entry endPc="268438441" name="i" stackId="3" startPc="268438409"/>
+        <entry endPc="268438809" name="known" stackId="1" startPc="268438475"/>
+        <entry endPc="268438809" name="index" stackId="2" startPc="268438475"/>
+        <entry endPc="268438556" name="b" stackId="3" startPc="268438527"/>
+        <entry endPc="268438809" name="jobIds" stackId="4" startPc="268438475"/>
+        <entry endPc="268438636" name="i" stackId="5" startPc="268438585"/>
+        <entry endPc="268438809" name="orphans" stackId="6" startPc="268438475"/>
+        <entry endPc="268438809" name="iter" stackId="7" startPc="268438475"/>
+        <entry endPc="268438738" name="ref" stackId="8" startPc="268438674"/>
+        <entry endPc="268438809" name="i" stackId="9" startPc="268438758"/>
+        <entry arg="true" endPc="268438959" name="code" stackId="1" startPc="268438940"/>
+        <entry arg="true" endPc="268438959" name="data" stackId="2" startPc="268438940"/>
+        <entry arg="true" endPc="268438992" name="libId" stackId="1" startPc="268438960"/>
+        <entry arg="true" endPc="268438992" name="filterType" stackId="2" startPc="268438960"/>
+        <entry arg="true" endPc="268439038" name="item" stackId="1" startPc="268438993"/>
+        <entry arg="true" endPc="268439074" name="code" stackId="1" startPc="268439039"/>
+        <entry arg="true" endPc="268439074" name="data" stackId="2" startPc="268439039"/>
+        <entry arg="true" endPc="268439130" name="item" stackId="1" startPc="268439108"/>
+        <entry arg="true" endPc="268439249" name="args" stackId="1" startPc="268439229"/>
+        <entry endPc="268439453" name="version" stackId="1" startPc="268439274"/>
+        <entry endPc="268439438" name="server" stackId="2" startPc="268439301"/>
+        <entry endPc="268439438" name="token" stackId="3" startPc="268439301"/>
+        <entry arg="true" endPc="268439775" name="refId" stackId="1" startPc="268439527"/>
+        <entry arg="true" endPc="268439775" name="positionInChapter" stackId="2" startPc="268439527"/>
+        <entry endPc="268439721" name="index" stackId="3" startPc="268439557"/>
+        <entry endPc="268439721" name="b" stackId="4" startPc="268439614"/>
+        <entry endPc="268439711" name="perBook" stackId="5" startPc="268439614"/>
+        <entry endPc="268439711" name="refIds" stackId="6" startPc="268439614"/>
+        <entry endPc="268439711" name="i" stackId="7" startPc="268439665"/>
+        <entry endPc="268439774" name="hit" stackId="8" startPc="268439530"/>
+        <entry endPc="268439774" name="absolute" stackId="9" startPc="268439530"/>
+        <entry arg="true" endPc="268439859" name="refId" stackId="1" startPc="268439809"/>
+        <entry arg="true" endPc="268439859" name="songEvent" stackId="2" startPc="268439809"/>
+        <entry arg="true" endPc="268439859" name="playbackPosition" stackId="3" startPc="268439809"/>
+        <entry arg="true" endPc="268440137" name="itemId" stackId="1" startPc="268439896"/>
+        <entry endPc="268440136" name="last" stackId="2" startPc="268439907"/>
+        <entry endPc="268440113" name="p" stackId="3" startPc="268439963"/>
+        <entry endPc="268440103" name="arr" stackId="4" startPc="268439963"/>
+        <entry endPc="268440075" name="i" stackId="5" startPc="268440012"/>
+        <entry arg="true" endPc="268440261" name="itemId" stackId="1" startPc="268440138"/>
+        <entry endPc="268440260" name="index" stackId="2" startPc="268440149"/>
+        <entry endPc="268440228" name="i" stackId="3" startPc="268440197"/>
+        <entry arg="true" endPc="268440389" name="itemId" stackId="1" startPc="268440262"/>
+        <entry endPc="268440388" name="index" stackId="2" startPc="268440273"/>
+        <entry endPc="268440388" name="out" stackId="3" startPc="268440273"/>
+        <entry endPc="268440368" name="i" stackId="4" startPc="268440322"/>
+        <entry arg="true" endPc="268440422" name="itemId" stackId="1" startPc="268440390"/>
+        <entry arg="true" endPc="268440506" name="itemId" stackId="1" startPc="268440423"/>
+        <entry endPc="268440506" name="total" stackId="2" startPc="268440434"/>
+        <entry endPc="268440506" name="p" stackId="3" startPc="268440434"/>
+        <entry endPc="268440500" name="arr" stackId="4" startPc="268440444"/>
+        <entry arg="true" endPc="268440618" name="itemId" stackId="1" startPc="268440507"/>
+        <entry arg="true" endPc="268440618" name="out" stackId="2" startPc="268440507"/>
+        <entry endPc="268440617" name="p" stackId="3" startPc="268440518"/>
+        <entry endPc="268440614" name="arr" stackId="4" startPc="268440525"/>
+        <entry endPc="268440607" name="i" stackId="5" startPc="268440577"/>
+        <entry arg="true" endPc="268440815" name="itemId" stackId="1" startPc="268440619"/>
+        <entry arg="true" endPc="268440815" name="order" stackId="2" startPc="268440619"/>
+        <entry arg="true" endPc="268440815" name="out" stackId="3" startPc="268440619"/>
+        <entry endPc="268440814" name="meta" stackId="4" startPc="268440630"/>
+        <entry endPc="268440814" name="starts" stackId="5" startPc="268440630"/>
+        <entry endPc="268440814" name="k" stackId="6" startPc="268440630"/>
+        <entry endPc="268440814" name="p" stackId="7" startPc="268440630"/>
+        <entry endPc="268440811" name="arr" stackId="8" startPc="268440684"/>
+        <entry endPc="268440804" name="i" stackId="9" startPc="268440738"/>
+        <entry arg="true" endPc="268441051" name="itemId" stackId="1" startPc="268440816"/>
+        <entry arg="true" endPc="268441051" name="k" stackId="2" startPc="268440816"/>
+        <entry arg="true" endPc="268441051" name="refId" stackId="3" startPc="268440816"/>
+        <entry endPc="268441050" name="p" stackId="4" startPc="268440827"/>
+        <entry endPc="268441050" name="idx" stackId="5" startPc="268440827"/>
+        <entry endPc="268441050" name="arr" stackId="6" startPc="268440827"/>
+        <entry endPc="268440981" name="old" stackId="7" startPc="268440904"/>
+        <entry arg="true" endPc="268441079" name="itemId" stackId="1" startPc="268441052"/>
+        <entry arg="true" endPc="268441079" name="p" stackId="2" startPc="268441052"/>
+        <entry arg="true" endPc="268441098" name="itemId" stackId="1" startPc="268441080"/>
+        <entry arg="true" endPc="268441170" name="itemId" stackId="1" startPc="268441099"/>
+        <entry arg="true" endPc="268441170" name="title" stackId="2" startPc="268441099"/>
+        <entry arg="true" endPc="268441170" name="durs" stackId="3" startPc="268441099"/>
+        <entry arg="true" endPc="268441378" name="idx" stackId="1" startPc="268441230"/>
+        <entry endPc="268441368" name="e" stackId="2" startPc="268441311"/>
+        <entry arg="true" endPc="268441458" name="arr" stackId="1" startPc="268441425"/>
+        <entry arg="true" endPc="268441458" name="j" stackId="2" startPc="268441425"/>
+        <entry endPc="268441457" name="tmp" stackId="3" startPc="268441428"/>
+        <entry endPc="268441654" name="profile" stackId="1" startPc="268441529"/>
+        <entry arg="true" endPc="268441760" name="orderA" stackId="1" startPc="268441736"/>
+        <entry arg="true" endPc="268441760" name="startA" stackId="2" startPc="268441736"/>
+        <entry arg="true" endPc="268441760" name="orderB" stackId="3" startPc="268441736"/>
+        <entry arg="true" endPc="268441760" name="startB" stackId="4" startPc="268441736"/>
+        <entry endPc="268441850" name="i" stackId="1" startPc="268441787"/>
+        <entry endPc="268441840" name="j" stackId="2" startPc="268441787"/>
+        <entry endPc="268441840" name="tmp" stackId="3" startPc="268441787"/>
+        <entry endPc="268442241" name="orders" stackId="1" startPc="268441863"/>
+        <entry endPc="268442241" name="starts" stackId="2" startPc="268441863"/>
+        <entry endPc="268442241" name="lookup" stackId="3" startPc="268441863"/>
+        <entry endPc="268442241" name="index" stackId="4" startPc="268441863"/>
+        <entry endPc="268441963" name="b" stackId="5" startPc="268441932"/>
+        <entry endPc="268442241" name="iter" stackId="6" startPc="268441863"/>
+        <entry endPc="268442096" name="ref" stackId="7" startPc="268441997"/>
+        <entry endPc="268442093" name="refId" stackId="8" startPc="268442013"/>
+        <entry endPc="268442093" name="info" stackId="9" startPc="268442013"/>
+        <entry endPc="268442233" name="i" stackId="10" startPc="268442121"/>
+        <entry endPc="268442223" name="j" stackId="11" startPc="268442121"/>
+        <entry arg="true" endPc="268442275" name="itemId" stackId="1" startPc="268442243"/>
+        <entry endPc="268442319" name="index" stackId="1" startPc="268442287"/>
+        <entry arg="true" endPc="268442338" name="itemId" stackId="1" startPc="268442320"/>
+        <entry arg="true" endPc="268442463" name="itemId" stackId="1" startPc="268442339"/>
+        <entry arg="true" endPc="268442463" name="job" stackId="2" startPc="268442339"/>
+        <entry endPc="268442462" name="index" stackId="3" startPc="268442350"/>
+        <entry endPc="268442430" name="i" stackId="4" startPc="268442399"/>
+        <entry arg="true" endPc="268442626" name="itemId" stackId="1" startPc="268442464"/>
+        <entry endPc="268442625" name="index" stackId="2" startPc="268442475"/>
+        <entry endPc="268442625" name="out" stackId="3" startPc="268442475"/>
+        <entry endPc="268442549" name="i" stackId="4" startPc="268442503"/>
+        <entry endPc="268442685" name="index" stackId="1" startPc="268442638"/>
+        <entry endPc="268442685" name="i" stackId="2" startPc="268442662"/>
+        <entry endPc="268442844" name="v" stackId="1" startPc="268442799"/>
+        <entry arg="true" endPc="268442903" name="server" stackId="1" startPc="268442845"/>
+        <entry arg="true" endPc="268442903" name="token" stackId="2" startPc="268442845"/>
+        <entry arg="true" endPc="268442932" name="libId" stackId="1" startPc="268442904"/>
+        <entry arg="true" endPc="268442932" name="cb" stackId="2" startPc="268442904"/>
+        <entry arg="true" endPc="268442996" name="server" stackId="1" startPc="268442933"/>
+        <entry arg="true" endPc="268442996" name="cb" stackId="2" startPc="268442933"/>
+        <entry arg="true" endPc="268443107" name="server" stackId="1" startPc="268443014"/>
+        <entry arg="true" endPc="268443107" name="username" stackId="2" startPc="268443014"/>
+        <entry arg="true" endPc="268443107" name="password" stackId="3" startPc="268443014"/>
+        <entry arg="true" endPc="268443107" name="cb" stackId="4" startPc="268443014"/>
+        <entry arg="true" endPc="268443190" name="itemId" stackId="1" startPc="268443108"/>
+        <entry arg="true" endPc="268443190" name="cb" stackId="2" startPc="268443108"/>
+        <entry arg="true" endPc="268443259" name="key" stackId="1" startPc="268443191"/>
+        <entry endPc="268443259" name="v" stackId="2" startPc="268443202"/>
+        <entry arg="true" endPc="268443369" name="libId" stackId="1" startPc="268443260"/>
+        <entry arg="true" endPc="268443369" name="filterType" stackId="2" startPc="268443260"/>
+        <entry arg="true" endPc="268443369" name="filterId" stackId="3" startPc="268443260"/>
+        <entry arg="true" endPc="268443369" name="cb" stackId="4" startPc="268443260"/>
+        <entry endPc="268443368" name="params" stackId="5" startPc="268443271"/>
+        <entry arg="true" endPc="268443570" name="itemId" stackId="1" startPc="268443417"/>
+        <entry arg="true" endPc="268443570" name="currentTimeSec" stackId="2" startPc="268443417"/>
+        <entry arg="true" endPc="268443570" name="durationSec" stackId="3" startPc="268443417"/>
+        <entry endPc="268443569" name="params" stackId="4" startPc="268443428"/>
+        <entry arg="true" endPc="268443599" name="libId" stackId="1" startPc="268443571"/>
+        <entry arg="true" endPc="268443599" name="cb" stackId="2" startPc="268443571"/>
+        <entry arg="true" endPc="268443652" name="detail" stackId="1" startPc="268443600"/>
+        <entry endPc="268443652" name="p" stackId="2" startPc="268443611"/>
+        <entry arg="true" endPc="268443681" name="libId" stackId="1" startPc="268443653"/>
+        <entry arg="true" endPc="268443681" name="cb" stackId="2" startPc="268443653"/>
+        <entry arg="true" endPc="268443757" name="itemId" stackId="1" startPc="268443682"/>
+        <entry arg="true" endPc="268443757" name="ino" stackId="2" startPc="268443682"/>
+        <entry arg="true" endPc="268443757" name="startSec" stackId="3" startPc="268443682"/>
+        <entry arg="true" endPc="268443757" name="endSec" stackId="4" startPc="268443682"/>
+        <entry arg="true" endPc="268443860" name="url" stackId="1" startPc="268443758"/>
+        <entry endPc="268444007" name="v" stackId="1" startPc="268443872"/>
+        <entry arg="true" endPc="268444082" name="callback" stackId="1" startPc="268444008"/>
+        <entry arg="true" endPc="268444162" name="path" stackId="1" startPc="268444083"/>
+        <entry arg="true" endPc="268444162" name="libId" stackId="2" startPc="268444083"/>
+        <entry arg="true" endPc="268444162" name="cb" stackId="3" startPc="268444083"/>
+        <entry arg="true" endPc="268444187" name="text" stackId="1" startPc="268444163"/>
+        <entry arg="true" endPc="268444187" name="changed" stackId="2" startPc="268444163"/>
+        <entry arg="true" endPc="268444236" name="view" stackId="1" startPc="268444204"/>
+        <entry arg="true" endPc="268444236" name="field" stackId="2" startPc="268444204"/>
+        <entry arg="true" endPc="268444271" name="url" stackId="1" startPc="268444237"/>
+        <entry arg="true" endPc="268444271" name="params" stackId="2" startPc="268444237"/>
+        <entry arg="true" endPc="268444271" name="options" stackId="3" startPc="268444237"/>
+        <entry arg="true" endPc="268444292" name="callback" stackId="1" startPc="268444272"/>
+        <entry arg="true" endPc="268444292" name="context" stackId="2" startPc="268444272"/>
+        <entry arg="true" endPc="268444318" name="code" stackId="1" startPc="268444293"/>
+        <entry arg="true" endPc="268444318" name="data" stackId="2" startPc="268444293"/>
+        <entry arg="true" endPc="268444717" name="libId" stackId="1" startPc="268444319"/>
+        <entry endPc="268444716" name="m" stackId="2" startPc="268444330"/>
+        <entry arg="true" endPc="268445089" name="code" stackId="1" startPc="268444718"/>
+        <entry arg="true" endPc="268445089" name="data" stackId="2" startPc="268444718"/>
+        <entry endPc="268445088" name="books" stackId="3" startPc="268444729"/>
+        <entry endPc="268445088" name="m" stackId="4" startPc="268444729"/>
+        <entry endPc="268445049" name="i" stackId="5" startPc="268444976"/>
+        <entry endPc="268445039" name="b" stackId="6" startPc="268444976"/>
+        <entry arg="true" endPc="268445420" name="code" stackId="1" startPc="268445090"/>
+        <entry arg="true" endPc="268445420" name="data" stackId="2" startPc="268445090"/>
+        <entry endPc="268445352" name="libs" stackId="3" startPc="268445120"/>
+        <entry endPc="268445352" name="menu" stackId="4" startPc="268445120"/>
+        <entry endPc="268445317" name="i" stackId="5" startPc="268445212"/>
+        <entry endPc="268445307" name="lib" stackId="6" startPc="268445212"/>
+        <entry arg="true" endPc="268445637" name="dc" stackId="1" startPc="268445560"/>
+        <entry arg="true" endPc="268445717" name="itemId" stackId="1" startPc="268445672"/>
+        <entry endPc="268445717" name="index" stackId="2" startPc="268445675"/>
+        <entry arg="true" endPc="268445789" name="arr" stackId="1" startPc="268445736"/>
+        <entry arg="true" endPc="268445789" name="itemId" stackId="2" startPc="268445736"/>
+        <entry endPc="268445787" name="i" stackId="3" startPc="268445755"/>
+        <entry arg="true" endPc="268446103" name="excludeId" stackId="1" startPc="268445790"/>
+        <entry endPc="268446103" name="total" stackId="2" startPc="268445793"/>
+        <entry endPc="268446103" name="doomed" stackId="3" startPc="268445793"/>
+        <entry endPc="268446103" name="jobIds" stackId="4" startPc="268445793"/>
+        <entry endPc="268445960" name="i" stackId="5" startPc="268445856"/>
+        <entry endPc="268445950" name="job" stackId="6" startPc="268445856"/>
+        <entry endPc="268446103" name="index" stackId="7" startPc="268445793"/>
+        <entry endPc="268446100" name="i" stackId="8" startPc="268446009"/>
+        <entry arg="true" endPc="268447348" name="code" stackId="1" startPc="268446127"/>
+        <entry arg="true" endPc="268447348" name="data" stackId="2" startPc="268446127"/>
+        <entry endPc="268447347" name="files" stackId="3" startPc="268446130"/>
+        <entry endPc="268447347" name="title" stackId="4" startPc="268446130"/>
+        <entry endPc="268447347" name="inos" stackId="5" startPc="268446130"/>
+        <entry endPc="268447347" name="durs" stackId="6" startPc="268446130"/>
+        <entry endPc="268446420" name="f" stackId="7" startPc="268446337"/>
+        <entry endPc="268446410" name="dur" stackId="8" startPc="268446337"/>
+        <entry endPc="268447347" name="expected" stackId="9" startPc="268446130"/>
+        <entry endPc="268447347" name="meta" stackId="10" startPc="268446130"/>
+        <entry endPc="268447347" name="drifted" stackId="11" startPc="268446130"/>
+        <entry endPc="268447347" name="oldJob" stackId="12" startPc="268446130"/>
+        <entry endPc="268447347" name="gen" stackId="13" startPc="268446130"/>
+        <entry endPc="268447347" name="doomed" stackId="14" startPc="268446130"/>
+        <entry endPc="268447210" name="kept" stackId="15" startPc="268447120"/>
+        <entry endPc="268447190" name="i" stackId="16" startPc="268447141"/>
+        <entry endPc="268447347" name="have" stackId="17" startPc="268446130"/>
+        <entry arg="true" endPc="268447365" name="v" stackId="1" startPc="268447349"/>
+        <entry arg="true" endPc="268447365" name="dflt" stackId="2" startPc="268447349"/>
+        <entry arg="true" endPc="268447413" name="item" stackId="1" startPc="268447366"/>
+        <entry arg="true" endPc="268447625" name="code" stackId="1" startPc="268447414"/>
+        <entry arg="true" endPc="268447625" name="data" stackId="2" startPc="268447414"/>
+        <entry arg="true" endPc="268447744" name="state" stackId="1" startPc="268447626"/>
+        <entry arg="true" endPc="268447830" name="field" stackId="1" startPc="268447745"/>
+        <entry arg="true" endPc="268447830" name="text" stackId="2" startPc="268447745"/>
+        <entry arg="true" endPc="268448284" name="code" stackId="1" startPc="268448108"/>
+        <entry arg="true" endPc="268448284" name="data" stackId="2" startPc="268448108"/>
+        <entry endPc="268448641" name="s" stackId="1" startPc="268448538"/>
+        <entry arg="true" endPc="268448755" name="dc" stackId="1" startPc="268448678"/>
+        <entry arg="true" endPc="268448911" name="itemIds" stackId="1" startPc="268448756"/>
+        <entry endPc="268448910" name="deleteList" stackId="2" startPc="268448759"/>
+        <entry endPc="268448847" name="i" stackId="3" startPc="268448823"/>
+        <entry arg="true" endPc="268449393" name="item" stackId="1" startPc="268448945"/>
+        <entry endPc="268449392" name="id" stackId="2" startPc="268448948"/>
+        <entry endPc="268449371" name="index" stackId="3" startPc="268449328"/>
+        <entry arg="true" endPc="268449451" name="message" stackId="1" startPc="268449428"/>
+        <entry arg="true" endPc="268449529" name="dc" stackId="1" startPc="268449452"/>
+        <entry endPc="268449650" name="stats" stackId="1" startPc="268449533"/>
+        <entry endPc="268449650" name="used" stackId="2" startPc="268449533"/>
+        <entry endPc="268449650" name="mb" stackId="3" startPc="268449533"/>
+        <entry endPc="268449716" name="deleteList" stackId="1" startPc="268449654"/>
+        <entry endPc="268450361" name="index" stackId="1" startPc="268449720"/>
+        <entry endPc="268450361" name="i" stackId="2" startPc="268450202"/>
+        <entry endPc="268450351" name="itemId" stackId="3" startPc="268450202"/>
+        <entry endPc="268450351" name="meta" stackId="4" startPc="268450202"/>
+        <entry endPc="268450351" name="title" stackId="5" startPc="268450202"/>
+        <entry endPc="268450351" name="count" stackId="6" startPc="268450202"/>
+        <entry endPc="268450351" name="sub" stackId="7" startPc="268450202"/>
+    </localVars>
+    <deviceInfo deviceVersion="e6263c2a80ff43933f83afa71f1f6645dc2cb4a3" partNumber="006-B4533-00"/>
+    <annotations>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="queued"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldServer"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errNotWatchShelf"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="downloadsFull"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="byAuthor"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errNone"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="AppName"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errNoAudio"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="deleteAllDownloads"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingApiKeyPrompt"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldUser"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingServerUrlPrompt"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errTooManyFiles"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loggingIn"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingServerUrl"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="deleting"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errItems"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="fieldPass"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="settingApiKey"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="clearQueue"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="logIn"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="browseLibrary"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="pickBook"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="alreadyDownloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="bySeries"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loginFailed"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="byCollection"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errLibraries"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="pickLibrary"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="playDownloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="loading"/>
+        <annotationEntry annotation="initialized" class="Drawables" module="globals/Rez" symbol="providerIcon"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="errDetail"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="allBooks"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="logOut"/>
+        <annotationEntry annotation="initialized" class="Drawables" module="globals/Rez" symbol="launcher"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="downloaded"/>
+        <annotationEntry annotation="initialized" class="Strings" module="globals/Rez" symbol="queueCleared"/>
+    </annotations>
+    <dataEntryOffsetMappings>
+        <dataEntry label="globals" offset="139" parentId="" symbolId="globals" type="module"/>
+        <dataEntry label="globals/Chunks" offset="440" parentId="globals" symbolId="Chunks" type="module"/>
+        <dataEntry label="globals/BrowseDelegate" offset="502" parentId="globals" symbolId="BrowseDelegate" type="class"/>
+        <dataEntry label="globals/Notify" offset="618" parentId="globals" symbolId="Notify" type="module"/>
+        <dataEntry label="globals/SyncDelegate" offset="653" parentId="globals" symbolId="SyncDelegate" type="class"/>
+        <dataEntry label="globals/Rez" offset="805" parentId="globals" symbolId="Rez" type="module"/>
+        <dataEntry label="globals/LoginCreds" offset="849" parentId="globals" symbolId="LoginCreds" type="class"/>
+        <dataEntry label="globals/GroupDelegate" offset="920" parentId="globals" symbolId="GroupDelegate" type="class"/>
+        <dataEntry label="globals/Store" offset="1009" parentId="globals" symbolId="Store" type="module"/>
+        <dataEntry label="globals/AbsProgressListener" offset="1035" parentId="globals" symbolId="AbsProgressListener" type="class"/>
+        <dataEntry label="globals/LibraryMenuDelegate" offset="1088" parentId="globals" symbolId="LibraryMenuDelegate" type="class"/>
+        <dataEntry label="globals/WatchShelfApp" offset="1150" parentId="globals" symbolId="WatchShelfApp" type="class"/>
+        <dataEntry label="globals/Settings" offset="1239" parentId="globals" symbolId="Settings" type="module"/>
+        <dataEntry label="globals/ContentDelegate" offset="1265" parentId="globals" symbolId="ContentDelegate" type="class"/>
+        <dataEntry label="globals/BookStore" offset="1399" parentId="globals" symbolId="BookStore" type="module"/>
+        <dataEntry label="globals/ContentIterator" offset="1524" parentId="globals" symbolId="ContentIterator" type="class"/>
+        <dataEntry label="globals/JobStore" offset="1721" parentId="globals" symbolId="JobStore" type="module"/>
+        <dataEntry label="globals/Login" offset="1801" parentId="globals" symbolId="Login" type="module"/>
+        <dataEntry label="globals/AbsApi" offset="1836" parentId="globals" symbolId="AbsApi" type="module"/>
+        <dataEntry label="globals/FieldDelegate" offset="2042" parentId="globals" symbolId="FieldDelegate" type="class"/>
+        <dataEntry label="globals/RequestDelegate" offset="2122" parentId="globals" symbolId="RequestDelegate" type="class"/>
+        <dataEntry label="globals/Browse" offset="2202" parentId="globals" symbolId="Browse" type="module"/>
+        <dataEntry label="globals/Versions" offset="2246" parentId="globals" symbolId="Versions" type="module"/>
+        <dataEntry label="globals/LibraryView" offset="2272" parentId="globals" symbolId="LibraryView" type="class"/>
+        <dataEntry label="globals/LibraryViewDelegate" offset="2361" parentId="globals" symbolId="LibraryViewDelegate" type="class"/>
+        <dataEntry label="globals/BookMenuDelegate" offset="2414" parentId="globals" symbolId="BookMenuDelegate" type="class"/>
+        <dataEntry label="globals/LoginView" offset="2530" parentId="globals" symbolId="LoginView" type="class"/>
+        <dataEntry label="globals/DownloadedMenuDelegate" offset="2691" parentId="globals" symbolId="DownloadedMenuDelegate" type="class"/>
+        <dataEntry label="globals/ErrorViewDelegate" offset="2762" parentId="globals" symbolId="ErrorViewDelegate" type="class"/>
+        <dataEntry label="globals/ErrorView" offset="2815" parentId="globals" symbolId="ErrorView" type="class"/>
+        <dataEntry label="globals/DownloadedMenu" offset="2877" parentId="globals" symbolId="DownloadedMenu" type="class"/>
+        <dataEntry label="globals/Rez/Drawables" offset="2939" parentId="Rez" symbolId="Drawables" type="module"/>
+        <dataEntry label="globals/Rez/Strings" offset="2983" parentId="Rez" symbolId="Strings" type="module"/>
+    </dataEntryOffsetMappings>
+    <functions>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Chunks">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435471" name="&lt;init&gt;" parent="BrowseDelegate" startPc="268435460">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Notify">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435483" name="&lt;init&gt;" parent="SyncDelegate" startPc="268435472">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435503" name="&lt;init&gt;" parent="Rez" startPc="268435484">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="LoginCreds">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435515" name="&lt;init&gt;" parent="GroupDelegate" startPc="268435504">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Store">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="AbsProgressListener">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435527" name="&lt;init&gt;" parent="LibraryMenuDelegate" startPc="268435516">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435539" name="&lt;init&gt;" parent="WatchShelfApp" startPc="268435528">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Settings">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435551" name="&lt;init&gt;" parent="ContentDelegate" startPc="268435540">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="BookStore">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435563" name="&lt;init&gt;" parent="ContentIterator" startPc="268435552">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="JobStore">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Login">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="AbsApi">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435575" name="&lt;init&gt;" parent="FieldDelegate" startPc="268435564">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="RequestDelegate">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Browse">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Versions">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435587" name="&lt;init&gt;" parent="LibraryView" startPc="268435576">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435599" name="&lt;init&gt;" parent="LibraryViewDelegate" startPc="268435588">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435611" name="&lt;init&gt;" parent="BookMenuDelegate" startPc="268435600">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435623" name="&lt;init&gt;" parent="LoginView" startPc="268435612">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435635" name="&lt;init&gt;" parent="DownloadedMenuDelegate" startPc="268435624">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435647" name="&lt;init&gt;" parent="ErrorViewDelegate" startPc="268435636">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435659" name="&lt;init&gt;" parent="ErrorView" startPc="268435648">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435671" name="&lt;init&gt;" parent="DownloadedMenu" startPc="268435660">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435798" name="total" parent="Chunks" startPc="268435672">
+            <param id="durs"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268435900" name="same" parent="Chunks" startPc="268435799">
+            <param id="dursA"/>
+            <param id="dursB"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436088" name="at" parent="Chunks" startPc="268435901">
+            <param id="durs"/>
+            <param id="k"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436239" name="starts" parent="Chunks" startPc="268436089">
+            <param id="durs"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436265" name="onSeries" parent="BrowseDelegate" startPc="268436240">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436283" name="onBack" parent="BrowseDelegate" startPc="268436266">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436309" name="onAuthors" parent="BrowseDelegate" startPc="268436284">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436676" name="pushGroups" parent="BrowseDelegate" startPc="268436310">
+            <param id="code"/>
+            <param id="data"/>
+            <param id="key"/>
+            <param id="filterType"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436696" name="onBooks" parent="BrowseDelegate" startPc="268436677">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436722" name="onCollections" parent="BrowseDelegate" startPc="268436697">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436746" name="initialize" parent="BrowseDelegate" startPc="268436723">
+            <param id="libId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268436945" name="onSelect" parent="BrowseDelegate" startPc="268436747">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437063" name="flash" parent="Notify" startPc="268436946">
+            <param id="stringRezId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437322" name="onStartSync" parent="SyncDelegate" startPc="268437064">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437358" name="deletes" parent="SyncDelegate" startPc="268437323">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437745" name="downloadNext" parent="SyncDelegate" startPc="268437359">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268437822" name="onOpDone" parent="SyncDelegate" startPc="268437746">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438039" name="deleteQueued" parent="SyncDelegate" startPc="268437823">
+            <param id="toDelete"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438389" name="onTrackDownloaded" parent="SyncDelegate" startPc="268438040">
+            <param id="code"/>
+            <param id="data"/>
+            <param id="context"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438443" name="containsId" parent="SyncDelegate" startPc="268438390">
+            <param id="arr"/>
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438471" name="onStopSync" parent="SyncDelegate" startPc="268438444">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438810" name="sweepOrphans" parent="SyncDelegate" startPc="268438472">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438841" name="initialize" parent="SyncDelegate" startPc="268438811">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438882" name="isSyncNeeded" parent="SyncDelegate" startPc="268438842">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Drawables">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="&lt;init&gt;" parent="Strings">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438921" name="initialize" parent="LoginCreds" startPc="268438883">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438939" name="onBack" parent="GroupDelegate" startPc="268438922">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438959" name="onBooks" parent="GroupDelegate" startPc="268438940">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268438992" name="initialize" parent="GroupDelegate" startPc="268438960">
+            <param id="libId"/>
+            <param id="filterType"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439038" name="onSelect" parent="GroupDelegate" startPc="268438993">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439074" name="onResponse" parent="AbsProgressListener" startPc="268439039">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="initialize" parent="AbsProgressListener">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439092" name="onBack" parent="LibraryMenuDelegate" startPc="268439075">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439107" name="initialize" parent="LibraryMenuDelegate" startPc="268439093">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439130" name="onSelect" parent="LibraryMenuDelegate" startPc="268439108">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439179" name="getProviderIconInfo" parent="WatchShelfApp" startPc="268439131">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439228" name="getPlaybackConfigurationView" parent="WatchShelfApp" startPc="268439180">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439249" name="getContentDelegate" parent="WatchShelfApp" startPc="268439229">
+            <param id="args"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439270" name="getSyncDelegate" parent="WatchShelfApp" startPc="268439250">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439454" name="initialize" parent="WatchShelfApp" startPc="268439271">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439503" name="getSyncConfigurationView" parent="WatchShelfApp" startPc="268439455">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439518" name="onShuffle" parent="ContentDelegate" startPc="268439504">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439526" name="getContentIterator" parent="ContentDelegate" startPc="268439519">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439775" name="syncProgress" parent="ContentDelegate" startPc="268439527">
+            <param id="refId"/>
+            <param id="positionInChapter"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439778" name="onThumbsUp" parent="ContentDelegate" startPc="268439776">
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439808" name="initialize" parent="ContentDelegate" startPc="268439779">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439859" name="onSong" parent="ContentDelegate" startPc="268439809">
+            <param id="refId"/>
+            <param id="songEvent"/>
+            <param id="playbackPosition"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" name="onRepeat" parent="ContentDelegate">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439892" name="resetContentIterator" parent="ContentDelegate" startPc="268439860">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268439895" name="onThumbsDown" parent="ContentDelegate" startPc="268439893">
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440137" name="deleteBook" parent="BookStore" startPc="268439896">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440261" name="addToIndex" parent="BookStore" startPc="268440138">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440389" name="removeFromIndex" parent="BookStore" startPc="268440262">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440422" name="get" parent="BookStore" startPc="268440390">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440506" name="count" parent="BookStore" startPc="268440423">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440618" name="addRefIds" parent="BookStore" startPc="268440507">
+            <param id="itemId"/>
+            <param id="out"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268440815" name="addLookup" parent="BookStore" startPc="268440619">
+            <param id="itemId"/>
+            <param id="order"/>
+            <param id="out"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441051" name="saveChunk" parent="BookStore" startPc="268440816">
+            <param id="itemId"/>
+            <param id="k"/>
+            <param id="refId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441079" name="pageKey" parent="BookStore" startPc="268441052">
+            <param id="itemId"/>
+            <param id="p"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441098" name="key" parent="BookStore" startPc="268441080">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441170" name="ensureMeta" parent="BookStore" startPc="268441099">
+            <param id="itemId"/>
+            <param id="title"/>
+            <param id="durs"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441229" name="next" parent="ContentIterator" startPc="268441171">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441378" name="objAt" parent="ContentIterator" startPc="268441230">
+            <param id="idx"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441424" name="previous" parent="ContentIterator" startPc="268441379">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441458" name="swap" parent="ContentIterator" startPc="268441425">
+            <param id="arr"/>
+            <param id="j"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441477" name="peekPrevious" parent="ContentIterator" startPc="268441459">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441481" name="canSkip" parent="ContentIterator" startPc="268441478">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441525" name="toggleShuffle" parent="ContentIterator" startPc="268441482">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441654" name="getPlaybackProfile" parent="ContentIterator" startPc="268441526">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441673" name="peekNext" parent="ContentIterator" startPc="268441655">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441689" name="get" parent="ContentIterator" startPc="268441674">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441697" name="shuffling" parent="ContentIterator" startPc="268441690">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441735" name="initialize" parent="ContentIterator" startPc="268441698">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441760" name="after" parent="ContentIterator" startPc="268441736">
+            <param id="orderA"/>
+            <param id="startA"/>
+            <param id="orderB"/>
+            <param id="startB"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268441859" name="shuffle" parent="ContentIterator" startPc="268441761">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442242" name="buildPlaylist" parent="ContentIterator" startPc="268441860">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442275" name="get" parent="JobStore" startPc="268442243">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442319" name="list" parent="JobStore" startPc="268442276">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442338" name="key" parent="JobStore" startPc="268442320">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442463" name="put" parent="JobStore" startPc="268442339">
+            <param id="itemId"/>
+            <param id="job"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442626" name="remove" parent="JobStore" startPc="268442464">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442686" name="clearAll" parent="JobStore" startPc="268442627">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442756" name="start" parent="Login" startPc="268442687">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442787" name="isConfigured" parent="AbsApi" startPc="268442757">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442844" name="authToken" parent="AbsApi" startPc="268442788">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442903" name="saveLogin" parent="AbsApi" startPc="268442845">
+            <param id="server"/>
+            <param id="token"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442932" name="getCollections" parent="AbsApi" startPc="268442904">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268442996" name="checkHealth" parent="AbsApi" startPc="268442933">
+            <param id="server"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443013" name="sidecarBase" parent="AbsApi" startPc="268442997">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443107" name="login" parent="AbsApi" startPc="268443014">
+            <param id="server"/>
+            <param id="username"/>
+            <param id="password"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443190" name="getFiles" parent="AbsApi" startPc="268443108">
+            <param id="itemId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443259" name="_prop" parent="AbsApi" startPc="268443191">
+            <param id="key"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443369" name="getBookList" parent="AbsApi" startPc="268443260">
+            <param id="libId"/>
+            <param id="filterType"/>
+            <param id="filterId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443416" name="logout" parent="AbsApi" startPc="268443370">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443570" name="patchProgress" parent="AbsApi" startPc="268443417">
+            <param id="itemId"/>
+            <param id="currentTimeSec"/>
+            <param id="durationSec"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443599" name="getSeries" parent="AbsApi" startPc="268443571">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443652" name="progressSeconds" parent="AbsApi" startPc="268443600">
+            <param id="detail"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443681" name="getAuthors" parent="AbsApi" startPc="268443653">
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443757" name="sidecarChunkUrl" parent="AbsApi" startPc="268443682">
+            <param id="itemId"/>
+            <param id="ino"/>
+            <param id="startSec"/>
+            <param id="endSec"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268443860" name="_noSlash" parent="AbsApi" startPc="268443758">
+            <param id="url"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444007" name="serverUrl" parent="AbsApi" startPc="268443861">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444082" name="getLibraries" parent="AbsApi" startPc="268444008">
+            <param id="callback"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444162" name="getGroups" parent="AbsApi" startPc="268444083">
+            <param id="path"/>
+            <param id="libId"/>
+            <param id="cb"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444187" name="onTextEntered" parent="FieldDelegate" startPc="268444163">
+            <param id="text"/>
+            <param id="changed"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444203" name="onCancel" parent="FieldDelegate" startPc="268444188">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444236" name="initialize" parent="FieldDelegate" startPc="268444204">
+            <param id="view"/>
+            <param id="field"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444271" name="makeWebRequest" parent="RequestDelegate" startPc="268444237">
+            <param id="url"/>
+            <param id="params"/>
+            <param id="options"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444292" name="initialize" parent="RequestDelegate" startPc="268444272">
+            <param id="callback"/>
+            <param id="context"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444318" name="onWebResponse" parent="RequestDelegate" startPc="268444293">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268444717" name="start" parent="Browse" startPc="268444319">
+            <param id="libId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445089" name="showBooks" parent="Browse" startPc="268444718">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445420" name="onLibraries" parent="LibraryView" startPc="268445090">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445498" name="onShow" parent="LibraryView" startPc="268445421">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445559" name="initialize" parent="LibraryView" startPc="268445499">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445637" name="onUpdate" parent="LibraryView" startPc="268445560">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445656" name="onBack" parent="LibraryViewDelegate" startPc="268445638">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445671" name="initialize" parent="LibraryViewDelegate" startPc="268445657">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445717" name="inBookIndex" parent="BookMenuDelegate" startPc="268445672">
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445735" name="onBack" parent="BookMenuDelegate" startPc="268445718">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268445789" name="containsId" parent="BookMenuDelegate" startPc="268445736">
+            <param id="arr"/>
+            <param id="itemId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446103" name="plannedChunks" parent="BookMenuDelegate" startPc="268445790">
+            <param id="excludeId"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268446126" name="initialize" parent="BookMenuDelegate" startPc="268446104">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447348" name="onFiles" parent="BookMenuDelegate" startPc="268446127">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447365" name="numOr" parent="BookMenuDelegate" startPc="268447349">
+            <param id="v"/>
+            <param id="dflt"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447413" name="onSelect" parent="BookMenuDelegate" startPc="268447366">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447625" name="onLogin" parent="LoginView" startPc="268447414">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447744" name="labelFor" parent="LoginView" startPc="268447626">
+            <param id="state"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268447830" name="setField" parent="LoginView" startPc="268447745">
+            <param id="field"/>
+            <param id="text"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448046" name="onShow" parent="LoginView" startPc="268447831">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448107" name="cancelFlow" parent="LoginView" startPc="268448047">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448284" name="onHealth" parent="LoginView" startPc="268448108">
+            <param id="code"/>
+            <param id="data"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448534" name="openField" parent="LoginView" startPc="268448285">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448642" name="initialize" parent="LoginView" startPc="268448535">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448677" name="onHide" parent="LoginView" startPc="268448643">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448755" name="onUpdate" parent="LoginView" startPc="268448678">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448911" name="queueDelete" parent="DownloadedMenuDelegate" startPc="268448756">
+            <param id="itemIds"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448929" name="onBack" parent="DownloadedMenuDelegate" startPc="268448912">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268448944" name="initialize" parent="DownloadedMenuDelegate" startPc="268448930">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449393" name="onSelect" parent="DownloadedMenuDelegate" startPc="268448945">
+            <param id="item"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449412" name="onBack" parent="ErrorViewDelegate" startPc="268449394">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449427" name="initialize" parent="ErrorViewDelegate" startPc="268449413">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449451" name="initialize" parent="ErrorView" startPc="268449428">
+            <param id="message"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449529" name="onUpdate" parent="ErrorView" startPc="268449452">
+            <param id="dc"/>
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449650" name="titleWithSize" parent="DownloadedMenu" startPc="268449530">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268449716" name="hasQueued" parent="DownloadedMenu" startPc="268449651">
+            <documentation/>
+        </functionEntry>
+        <functionEntry accessMode="public" endPc="268450362" name="initialize" parent="DownloadedMenu" startPc="268449717">
+            <documentation/>
+        </functionEntry>
+    </functions>
+</debugInfo>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -21,6 +21,7 @@
     <string id="errItems">Could not load books</string>
     <string id="errDetail">Could not load book</string>
     <string id="errNoAudio">No audio in this book</string>
+    <string id="errNotWatchShelf">Not a WatchShelf URL.\nUse your WatchShelf\naddress, not ABS.</string>
 
     <!-- settings labels (shown in Garmin Connect Mobile / Express) -->
     <string id="settingServerUrl">WatchShelf URL</string>

--- a/sidecar/server.js
+++ b/sidecar/server.js
@@ -229,7 +229,12 @@ const server = http.createServer((req, res) => {
   let p = u.pathname;
   if (BASE_PATH && p.startsWith(BASE_PATH)) { p = p.slice(BASE_PATH.length) || '/'; }
   const g = req.method === 'GET';
-  if (p === '/health') { res.writeHead(200).end('ok'); return; }
+  // CONTRACT: the watch's login preflight requires status 200, Content-Type
+  // text/plain, and a body of EXACTLY "ok" (no newline) - it is how the app
+  // distinguishes a WatchShelf sidecar from anything else (e.g. the ABS
+  // server itself) before sending credentials anywhere. Don't change any of
+  // the three without updating Login.mc.
+  if (p === '/health') { res.writeHead(200, { 'Content-Type': 'text/plain' }).end('ok'); return; }
   if (p === '/login'       && req.method === 'POST') { login(req, res); return; }
   if (p === '/libraries'   && g) { libraries(req, res, u); return; }
   if (p === '/list'        && g) { list(req, res, u); return; }

--- a/source/AbsApi.mc
+++ b/source/AbsApi.mc
@@ -134,6 +134,22 @@ module AbsApi {
     }
 
     // ---- on-watch login ----------------------------------------------------
+
+    // Preflight: is this URL actually a WatchShelf sidecar? Its /health
+    // returns exactly "ok" (text/plain). Logging into the ABS server's own
+    // URL by mistake is otherwise indistinguishable at login time - ABS has
+    // its OWN /login that succeeds and returns a token, and every call after
+    // that gets an HTML page the watch reports as an opaque -400. Verified
+    // end-to-end in the simulator: correct sidecar URL -> library loads;
+    // ABS URL -> caught here before credentials are sent.
+    function checkHealth(server, cb) {
+        Communications.makeWebRequest(
+            _noSlash(server) + "/health", null,
+            { :method => Communications.HTTP_REQUEST_METHOD_GET,
+              :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_TEXT_PLAIN },
+            cb);
+    }
+
     function login(server, username, password, cb) {
         Communications.makeWebRequest(
             _noSlash(server) + "/login",

--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -54,5 +54,5 @@ module Versions {
     const current = V3;
     // Visible build tag - bump every build so we can confirm on-watch which
     // build is actually running (the MTP transfer is unreliable).
-    const tag = "b27";
+    const tag = "b28";
 }

--- a/source/Login.mc
+++ b/source/Login.mc
@@ -51,9 +51,23 @@ class LoginView extends WatchUi.View {
             mState = 4;
             mMessage = WatchUi.loadResource(Rez.Strings.loggingIn);
             WatchUi.requestUpdate();
-            AbsApi.login(mCreds.server, mCreds.username, mCreds.password, method(:onLogin));
+            // Preflight the URL before sending credentials anywhere: ABS's own
+            // /login would happily accept them and return a token, and the
+            // mistake would only surface later as an opaque -400. /health
+            // answering exactly "ok" is the sidecar's fingerprint.
+            AbsApi.checkHealth(mCreds.server, method(:onHealth));
         }
         // state 4 (waiting) / 99 (error): message already set, do nothing.
+    }
+
+    function onHealth(code, data) {
+        if (code == 200 && (data instanceof Toybox.Lang.String) && data.equals("ok")) {
+            AbsApi.login(mCreds.server, mCreds.username, mCreds.password, method(:onLogin));
+        } else {
+            mState = 99;
+            mMessage = WatchUi.loadResource(Rez.Strings.errNotWatchShelf) + "\n(" + code + ")";
+            WatchUi.requestUpdate();
+        }
     }
 
     function onHide() {


### PR DESCRIPTION
## Root cause of "could not load libraries (-400)"
Logging in with the **ABS server URL** instead of the **WatchShelf sidecar URL**. ABS has its own `/login` that accepts credentials and returns a token, so login *looks* successful — then `/libraries` hits ABS's HTML 404, which the watch's JSON `responseType` reports as the opaque `-400`. Not an app bug; a wrong-URL trap with no feedback.

## Fix
- `AbsApi.checkHealth` GETs `{url}/health` (text/plain) **before** login; `LoginView` proceeds to `AbsApi.login` only if the body is exactly `"ok"` (the sidecar's fingerprint), else shows `errNotWatchShelf` ("Not a WatchShelf URL. Use your WatchShelf address, not ABS.").
- Sidecar `/health` now sends an explicit `Content-Type: text/plain` (raw Node `http` sent none) so the watch's `TEXT_PLAIN` responseType parses it — documented as a contract the preflight depends on. (This closes the review finding that the preflight could otherwise `-400` against the *correct* URL.)

## Verified end-to-end in the Connect IQ simulator (fenix8solar51mm, live sidecar)
Drove the real app via Media Mode → Sync Configuration / Playback:
- **Choose Library → All Books** loads (no `-400`) — confirms the wrong-URL diagnosis.
- **The Algebraist** (389-chunk m4b — the one that crashed the watch) **queued + synced 39 AAC/44.1kHz/mono chunks with no OOM**.
- **Native player opened over the content — no "Media Error Occurred"** (the exact prior failure screen); play/pause live.

This is the first fully-verified end-to-end run of the whole pipeline. Build tag b28; debug symbols in `debug-symbols/`.

🧙 Built with [WOZCODE](https://wozcode.com)