### PR TITLE
Two-way play-progress sync with Audiobookshelf (b34)

### DIFF
--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -14,6 +14,8 @@
     <string id="queueCleared">Queue cleared</string>
     <string id="deleteAllDownloads">Delete all downloads</string>
     <string id="playDownloaded">Play downloaded</string>
+    <string id="syncNow">Sync now</string>
+    <string id="syncing">Syncing...</string>
     <string id="alreadyDownloaded">Already downloaded.\nSee "Downloaded".</string>
 
     <!-- errors -->

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -14,6 +14,9 @@
     <string id="queueCleared">Queue cleared</string>
     <string id="deleteAllDownloads">Delete all downloads</string>
     <string id="playDownloaded">Play downloaded</string>
+    <string id="resume">Resume</string>
+    <string id="playFromStart">Play from start</string>
+    <string id="deleteBook">Delete from watch</string>
     <string id="syncNow">Sync now</string>
     <string id="syncing">Syncing...</string>
     <string id="alreadyDownloaded">Already downloaded.\nSee "Downloaded".</string>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -19,6 +19,8 @@
     <string id="alreadyDownloaded">Already downloaded.\nSee "Downloaded".</string>
 
     <!-- errors -->
+    <string id="errPhone">No phone connection.\nOpen Garmin Connect\non your phone.</string>
+    <string id="errServer">Server not responding.\nCheck it's running.</string>
     <string id="errLibraries">Could not load libraries</string>
     <string id="errItems">Could not load books</string>
     <string id="errDetail">Could not load book</string>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -13,6 +13,7 @@
     <string id="clearQueue">Clear queue</string>
     <string id="queueCleared">Queue cleared</string>
     <string id="deleteAllDownloads">Delete all downloads</string>
+    <string id="confirmDeleteAll">Delete ALL downloads?</string>
     <string id="playDownloaded">Play downloaded</string>
     <string id="resume">Resume</string>
     <string id="playFromStart">Play from start</string>

--- a/sidecar/server.js
+++ b/sidecar/server.js
@@ -21,7 +21,10 @@
 //   GET /transcode?item&file&fmt&start&end&token -> a small audio chunk
 //   GET /cover?item&token[&w]    -> the book's cover, hard-resized by us to a
 //                                   small JPEG (the watch decodes it in 512KB)
-//   POST /progress?token  {itemId,currentTime,duration} -> real PATCH to ABS
+//   GET  /progress?item&token -> {currentTime,duration,lastUpdate,isFinished}
+//                                (seconds) or {} - saved position for resume
+//   POST /progress?token  {itemId,currentTime,duration,lastUpdateSec}
+//                                -> real PATCH to ABS (lastUpdateSec -> ms)
 
 import http from 'node:http';
 import { spawn } from 'node:child_process';
@@ -343,6 +346,23 @@ function readJson(req, cb) {
   req.on('error', () => cb(null));
 }
 
+// Slim a full ABS userMediaProgress down to what the watch needs, converting
+// lastUpdate from epoch MILLISECONDS to epoch SECONDS - the watch stores time in
+// a 32-bit Number, which an ms value overflows (and JSON-decodes lossily).
+function slimProgress(p) {
+  return {
+    currentTime: p.currentTime || 0,
+    duration: p.duration || 0,
+    lastUpdate: Math.floor((p.lastUpdate || 0) / 1000),
+    isFinished: !!p.isFinished,
+  };
+}
+
+// POST /progress?token {itemId,currentTime,duration,lastUpdateSec} -> PATCH ABS.
+// lastUpdateSec (epoch seconds, the watch's listen time) becomes ABS's
+// lastUpdate (ms). ABS honors a client-supplied lastUpdate ("for local sync"),
+// so an offline listen flushed later still orders correctly against other
+// devices instead of looking like it happened at flush time.
 function progress(req, res, u) {
   const token = u.searchParams.get('token');
   if (!token) { fail(res, 400, 'bad params'); return; }
@@ -352,12 +372,27 @@ function progress(req, res, u) {
     if (!access) { fail(res, 401, 'unauthorized'); return; }
     const payload = { currentTime: body.currentTime };
     if (typeof body.duration === 'number' && body.duration > 0) { payload.duration = body.duration; payload.progress = Math.min(1, body.currentTime / body.duration); }
+    if (typeof body.lastUpdateSec === 'number' && body.lastUpdateSec > 0) { payload.lastUpdate = Math.round(body.lastUpdateSec * 1000); }
     try {
       const r = await fetch(`${ABS}/api/me/progress/${encodeURIComponent(body.itemId)}`,
         { method: 'PATCH', headers: { ...bearer(access), 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
       if (r.ok) { res.writeHead(200, jsonHead).end(JSON.stringify({ ok: true })); } else { fail(res, 502, 'ABS ' + r.status); }
     } catch (e) { res.writeHead(502).end('ABS unreachable'); }
   });
+}
+
+// GET /progress?item&token -> the item's saved position for cross-device resume,
+// as {currentTime,duration,lastUpdate,isFinished} (seconds), or {} if ABS has
+// none. ABS only attaches userMediaProgress to item detail when expanded=1 AND
+// include contains 'progress'.
+async function progressRead(req, res, u) {
+  const item = u.searchParams.get('item'), token = u.searchParams.get('token');
+  if (!item || !token || !IDRE.test(item)) { fail(res, 400, 'bad params'); return; }
+  try {
+    const d = await absJson(`/api/items/${encodeURIComponent(item)}?expanded=1&include=progress`, token);
+    const p = d.userMediaProgress;
+    res.writeHead(200, jsonHead).end(JSON.stringify(p ? slimProgress(p) : {}));
+  } catch (e) { fail(res, e.status === 401 ? 401 : 502, String(e.message || 'ABS')); }
 }
 
 // POST /login {username,password} -> proxy to ABS /login, return a slim {user:{token}}.
@@ -425,6 +460,7 @@ const server = http.createServer((req, res) => {
   if (p === '/files'       && g) { files(req, res, u); return; }
   if (p === '/transcode'   && g) { transcode(req, res, u); return; }
   if (p === '/cover'       && g) { cover(req, res, u); return; }
+  if (p === '/progress'    && g) { progressRead(req, res, u); return; }
   if (p === '/progress'    && req.method === 'POST') { progress(req, res, u); return; }
   res.writeHead(404).end();
 });

--- a/sidecar/server.js
+++ b/sidecar/server.js
@@ -41,6 +41,13 @@ const PORT = Number(process.env.PORT || 8081);
 // also works. Set BASE_PATH='' to disable if your proxy already strips.
 const BASE_PATH = (process.env.BASE_PATH ?? '/watchshelf-transcode').replace(/\/+$/, '');
 const UA   = 'WatchShelf-sidecar';
+// Hard ceiling on every ABS round-trip. A healthy ABS answers in well under a
+// second, so this never trips legitimately - it exists so a stale/slow token
+// refresh (or a wedged ABS) can't HANG a watch request. Without it, a bad
+// refresh left the watch's makeWebRequest to time out on its own (-300, "could
+// not load libraries") instead of getting a fast 401 it can act on. Every ABS
+// fetch below passes `signal: AbortSignal.timeout(ABS_TIMEOUT_MS)`.
+const ABS_TIMEOUT_MS = 8000;
 // STOP PERIODIC RE-LOGIN - per user, keeping each user's own identity.
 // ABS >= 2.26 hands out a SHORT-LIVED (~1h) accessToken + a LONG-LIVED (~30d,
 // rotating) refreshToken at login; once the accessToken expires every watch
@@ -80,7 +87,7 @@ async function refreshSession(sid) {
   const s = sessions[sid];
   if (!s || !s.refresh) { return false; }
   try {
-    const r = await fetch(`${ABS}/auth/refresh`, { method: 'POST', headers: { 'x-refresh-token': s.refresh, 'x-return-tokens': 'true', 'User-Agent': UA } });
+    const r = await fetch(`${ABS}/auth/refresh`, { method: 'POST', headers: { 'x-refresh-token': s.refresh, 'x-return-tokens': 'true', 'User-Agent': UA }, signal: AbortSignal.timeout(ABS_TIMEOUT_MS) });
     if (!r.ok) { return false; }
     const u = (((await r.json()) || {}).user || {});
     if (!u.accessToken) { return false; }
@@ -277,9 +284,9 @@ const bookOf = (it) => ({
 async function absJson(path, sid) {
   const access = await freshAccess(sid);
   if (!access) { const e = new Error('unauthorized'); e.status = 401; throw e; }
-  let r = await fetch(`${ABS}${path}`, { headers: bearer(access) });
+  let r = await fetch(`${ABS}${path}`, { headers: bearer(access), signal: AbortSignal.timeout(ABS_TIMEOUT_MS) });
   if (r.status === 401 && (await refreshSession(sid))) {
-    r = await fetch(`${ABS}${path}`, { headers: bearer(sessions[sid].access) });
+    r = await fetch(`${ABS}${path}`, { headers: bearer(sessions[sid].access), signal: AbortSignal.timeout(ABS_TIMEOUT_MS) });
   }
   if (!r.ok) { const e = new Error('ABS ' + r.status); e.status = r.status; throw e; }
   return r.json();
@@ -375,7 +382,7 @@ function progress(req, res, u) {
     if (typeof body.lastUpdateSec === 'number' && body.lastUpdateSec > 0) { payload.lastUpdate = Math.round(body.lastUpdateSec * 1000); }
     try {
       const r = await fetch(`${ABS}/api/me/progress/${encodeURIComponent(body.itemId)}`,
-        { method: 'PATCH', headers: { ...bearer(access), 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+        { method: 'PATCH', headers: { ...bearer(access), 'Content-Type': 'application/json' }, body: JSON.stringify(payload), signal: AbortSignal.timeout(ABS_TIMEOUT_MS) });
       if (r.ok) { res.writeHead(200, jsonHead).end(JSON.stringify({ ok: true })); } else { fail(res, 502, 'ABS ' + r.status); }
     } catch (e) { res.writeHead(502).end('ABS unreachable'); }
   });
@@ -408,6 +415,7 @@ function login(req, res) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'User-Agent': UA, 'x-return-tokens': 'true' },
         body: JSON.stringify({ username: body.username, password: body.password }),
+        signal: AbortSignal.timeout(ABS_TIMEOUT_MS),
       });
       if (!r.ok) { fail(res, r.status === 401 ? 401 : 502, 'login ' + r.status); return; }
       const u = (((await r.json()) || {}).user || {});

--- a/source/AbsApi.mc
+++ b/source/AbsApi.mc
@@ -120,30 +120,56 @@ module AbsApi {
             callback);
     }
 
-    // ---- progress sync -----------------------------------------------------
+    // ---- progress sync (two-way) -------------------------------------------
 
-    // Read saved position (seconds) from an item-detail response, or 0.
-    function progressSeconds(detail) {
-        var p = detail["userMediaProgress"];
-        if ((p != null) && (p["currentTime"] != null)) {
-            return p["currentTime"];
-        }
-        return 0;
-    }
-
-    // Progress sync via the sidecar (Monkey C has no PATCH; ABS ignores
-    // X-HTTP-Method-Override). The watch POSTs; the sidecar PATCHes ABS with the
-    // same token. Fire-and-forget.
-    function patchProgress(itemId, currentTimeSec, durationSec) {
+    // WRITE: push a position to ABS via the sidecar (Monkey C has no PATCH; ABS
+    // ignores X-HTTP-Method-Override, so the watch POSTs and the sidecar PATCHes
+    // with the same token). `lastUpdateSec` is the watch's listen time in epoch
+    // SECONDS; the sidecar converts it to ABS's millisecond lastUpdate so
+    // cross-device last-write-wins orders correctly - even for an offline listen
+    // flushed much later. `cb` receives (code, data): the live playback path
+    // passes a mark-clean listener; the sync flush passes its own step callback.
+    function postProgress(itemId, currentTimeSec, durationSec, lastUpdateSec, cb) {
         var params = { "itemId" => itemId, "currentTime" => currentTimeSec };
         if (durationSec != null) { params["duration"] = durationSec; }
+        if (lastUpdateSec != null) { params["lastUpdateSec"] = lastUpdateSec; }
         Communications.makeWebRequest(
             sidecarBase() + "/progress?token=" + authToken(),
             params,
             { :method => Communications.HTTP_REQUEST_METHOD_POST,
               :headers => { "Content-Type" => Communications.REQUEST_CONTENT_TYPE_JSON },
               :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON },
-            new AbsProgressListener().method(:onResponse));
+            cb);
+    }
+
+    // Live playback push: fire, and clear the book's dirty flag on a confirmed
+    // 200 (so an online listen never needs a later flush; an offline one stays
+    // dirty and gets flushed on the next sync).
+    function patchProgress(itemId, currentTimeSec, durationSec, lastUpdateSec) {
+        postProgress(itemId, currentTimeSec, durationSec, lastUpdateSec,
+            new AbsProgressListener(itemId, lastUpdateSec).method(:onResponse));
+    }
+
+    // READ: GET the saved position for one book from the sidecar (which reads
+    // ABS item detail with ?include=progress). Response is the slim shape
+    // { currentTime, duration, lastUpdate, isFinished } in SECONDS, or {} when
+    // ABS has no progress for this item. `cb` receives (code, data).
+    function getProgress(itemId, cb) {
+        Communications.makeWebRequest(
+            sidecarBase() + "/progress",
+            { "item" => itemId, "token" => authToken() },
+            { :method => Communications.HTTP_REQUEST_METHOD_GET,
+              :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON },
+            cb);
+    }
+
+    // Parse a getProgress() response into [positionSec, lastUpdateSec], or null
+    // when the book has no server progress (empty {} or missing fields).
+    function readProgress(data) {
+        if ((data == null) || (data["currentTime"] == null) || (data["lastUpdate"] == null)) {
+            return null;
+        }
+        return [data["currentTime"], data["lastUpdate"]];
     }
 
     // ---- on-watch login ----------------------------------------------------
@@ -188,14 +214,23 @@ module AbsApi {
     }
 }
 
-// Owns the fire-and-forget progress-update callback. AbsApi is a module (no
+// Owns the live-playback progress-update callback. AbsApi is a module (no
 // `self`), so `method(:...)` cannot resolve inside it; a class instance can. The
 // instance stays alive while the request is in flight because makeWebRequest
-// holds a reference to the Method it is given.
+// holds a reference to the Method it is given. On a confirmed 200 it clears the
+// book's dirty flag (markClean guards against clobbering a newer in-flight
+// write); a failure leaves it dirty for the next sync's flush.
 class AbsProgressListener {
-    function initialize() {}
+    private var mItemId;
+    private var mTsSec;
+    function initialize(itemId, tsSec) {
+        mItemId = itemId;
+        mTsSec = tsSec;
+    }
     function onResponse(code, data) {
-        if (code != 200) {
+        if (code == 200) {
+            Progress.markClean(mItemId, mTsSec);
+        } else {
             System.println("ABS progress update failed: " + code);
         }
     }

--- a/source/AbsApi.mc
+++ b/source/AbsApi.mc
@@ -206,6 +206,12 @@ module AbsApi {
         Application.Storage.deleteValue(Store.SERVER);
         Application.Storage.deleteValue(Store.TOKEN);
     }
+    // Drop ONLY the login token, keeping the server URL. Used when ABS reports
+    // the session is dead (401): isConfigured() flips false so the login flow
+    // restarts, but the user doesn't have to re-type their server URL.
+    function clearToken() {
+        Application.Storage.deleteValue(Store.TOKEN);
+    }
     function _noSlash(url) {
         if ((url != null) && url.length() > 0 && url.substring(url.length() - 1, url.length()).equals("/")) {
             return url.substring(0, url.length() - 1);

--- a/source/BookActionMenu.mc
+++ b/source/BookActionMenu.mc
@@ -42,16 +42,11 @@ class BookActionMenuDelegate extends WatchUi.Menu2InputDelegate {
             return;
         }
 
-        // Delete this one book: queue it and run a sync (SyncDelegate.deleteQueued
-        // evicts each cached chunk). Whole-book only - see Constants.mc for why
-        // per-chunk state is forbidden. Pop back to the book list afterwards.
+        // Delete this one book (shared path: queue + sync, evicts the chunks).
+        // A single book is far less destructive than "delete all", so no extra
+        // confirm here. Pop back to the book list afterwards.
         if ((id instanceof Toybox.Lang.String) && id.equals("delete")) {
-            var deleteList = Application.Storage.getValue(Store.DELETE_LIST);
-            if (deleteList == null) { deleteList = []; }
-            deleteList.add(mItemId);
-            Application.Storage.setValue(Store.DELETE_LIST, deleteList);
-            Communications.startSync();
-            Notify.flash(Rez.Strings.deleting);
+            Downloads.queueDelete([mItemId]);
             WatchUi.popView(WatchUi.SLIDE_RIGHT);
             return;
         }

--- a/source/BookActionMenu.mc
+++ b/source/BookActionMenu.mc
@@ -1,0 +1,63 @@
+using Toybox.Application;
+using Toybox.Communications;
+using Toybox.Media;
+using Toybox.WatchUi;
+
+// Per-book actions, reached from PlayMenu. Resume / Play from start hand the
+// chosen book + mode to the native player via Media.startPlayback(args); the
+// ContentIterator reads {item, mode} to position its cursor (see
+// ContentIterator.applyStart). Delete queues this one book for removal, exactly
+// like the old top-level book-row tap did.
+class BookActionMenu extends WatchUi.Menu2 {
+
+    function initialize(itemId, title) {
+        Menu2.initialize({ :title => title });
+        addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.resume), null, "resume", null));
+        addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.playFromStart), null, "start", null));
+        addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.deleteBook), null, "delete", null));
+    }
+}
+
+class BookActionMenuDelegate extends WatchUi.Menu2InputDelegate {
+
+    private var mItemId;
+
+    function initialize(itemId) {
+        Menu2InputDelegate.initialize();
+        mItemId = itemId;
+    }
+
+    function onSelect(item) {
+        var id = item.getId();
+
+        // Resume from the synced position; Play from start begins at 0. Both pass
+        // the book id + mode to the native player, which launches playback mode
+        // and hands the args to our ContentDelegate/ContentIterator.
+        if ((id instanceof Toybox.Lang.String) && id.equals("resume")) {
+            Media.startPlayback({ "item" => mItemId, "mode" => "resume" });
+            return;
+        }
+        if ((id instanceof Toybox.Lang.String) && id.equals("start")) {
+            Media.startPlayback({ "item" => mItemId, "mode" => "start" });
+            return;
+        }
+
+        // Delete this one book: queue it and run a sync (SyncDelegate.deleteQueued
+        // evicts each cached chunk). Whole-book only - see Constants.mc for why
+        // per-chunk state is forbidden. Pop back to the book list afterwards.
+        if ((id instanceof Toybox.Lang.String) && id.equals("delete")) {
+            var deleteList = Application.Storage.getValue(Store.DELETE_LIST);
+            if (deleteList == null) { deleteList = []; }
+            deleteList.add(mItemId);
+            Application.Storage.setValue(Store.DELETE_LIST, deleteList);
+            Communications.startSync();
+            Notify.flash(Rez.Strings.deleting);
+            WatchUi.popView(WatchUi.SLIDE_RIGHT);
+            return;
+        }
+    }
+
+    function onBack() {
+        WatchUi.popView(WatchUi.SLIDE_RIGHT);
+    }
+}

--- a/source/BookMenuDelegate.mc
+++ b/source/BookMenuDelegate.mc
@@ -24,6 +24,8 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
     }
 
     function onFiles(code, data) {
+        // Session expired -> re-login instead of a dead-end error.
+        if (code == 401) { Login.reauth(); return; }
         if (code != 200 || data == null) {
             WatchUi.pushView(new ErrorView(Errors.message(Rez.Strings.errDetail, code)),
                 new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);

--- a/source/BookMenuDelegate.mc
+++ b/source/BookMenuDelegate.mc
@@ -133,11 +133,15 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
         // hard kill mid-wipe with the job still queued would leave that job
         // resuming over truncated pages (null-padded silent holes). With the
         // job already gone, a mid-wipe crash decays to a benign partial that
-        // the stranded/orphan machinery cleans up.
+        // the stranded/orphan machinery cleans up. Then UN-INDEX before evict,
+        // so a kill between them leaves an unindexed book with orphan chunks
+        // (swept next sync) rather than an indexed book with zero chunks (which
+        // would make playback start a different book). Progress is NOT pruned:
+        // it's the SAME book re-downloading, so its resume point stays valid.
         if (drifted) {
             JobStore.remove(mItemId);
-            BookStore.deleteBook(mItemId);
             BookStore.removeFromIndex(mItemId);
+            BookStore.deleteBook(mItemId);
         }
 
         // Queueing a book un-dooms it: if it's still sitting in DELETE_LIST

--- a/source/BookMenuDelegate.mc
+++ b/source/BookMenuDelegate.mc
@@ -25,7 +25,7 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
 
     function onFiles(code, data) {
         if (code != 200 || data == null) {
-            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errDetail) + "\n(" + code + ")"),
+            WatchUi.pushView(new ErrorView(Errors.message(Rez.Strings.errDetail, code)),
                 new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }
@@ -41,7 +41,7 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
         }
 
         if (data["files"] == null || data["files"].size() == 0) {
-            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errDetail) + "\n(" + code + ")"),
+            WatchUi.pushView(new ErrorView(Errors.message(Rez.Strings.errDetail, code)),
                 new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }

--- a/source/Browse.mc
+++ b/source/Browse.mc
@@ -28,7 +28,7 @@ module Browse {
     // Build + push a book menu from { books:[{id,title,author}] }.
     function showBooks(code, data) {
         if (code != 200 || data == null || data["books"] == null || data["books"].size() == 0) {
-            WatchUi.pushView(new ErrorView(WatchUi.loadResource(Rez.Strings.errItems) + "\n(" + code + ")"),
+            WatchUi.pushView(new ErrorView(Errors.message(Rez.Strings.errItems, code)),
                 new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }

--- a/source/Browse.mc
+++ b/source/Browse.mc
@@ -27,6 +27,8 @@ module Browse {
 
     // Build + push a book menu from { books:[{id,title,author}] }.
     function showBooks(code, data) {
+        // Session expired -> re-login instead of a dead-end error.
+        if (code == 401) { Login.reauth(); return; }
         if (code != 200 || data == null || data["books"] == null || data["books"].size() == 0) {
             WatchUi.pushView(new ErrorView(Errors.message(Rez.Strings.errItems, code)),
                 new ErrorViewDelegate(), WatchUi.SLIDE_LEFT);

--- a/source/Constants.mc
+++ b/source/Constants.mc
@@ -32,6 +32,17 @@ module Store {
     const APP_VERSION = "appVersion";  // Number, see Versions
     const SERVER      = "absServer";   // server URL saved by on-watch login
     const TOKEN       = "absToken";    // bearer token saved by on-watch login
+
+    // Two-way play-progress state, O(books): one small dictionary keyed by
+    // itemId (never per-chunk - see the OOM post-mortem above). See Progress.mc
+    // for the value shape and the last-write-wins merge.
+    const PROGRESS    = "prog";
+    // One-shot flag: the user tapped "Sync now". Makes isSyncNeeded() true for
+    // exactly one sync (onStartSync deletes it immediately), so an on-demand
+    // progress exchange runs even when no download/delete is queued - WITHOUT
+    // leaving isSyncNeeded() permanently true (which the OS would turn into
+    // endless no-op syncs).
+    const FORCE_SYNC  = "forceSync";
 }
 
 // ---------------------------------------------------------------------------
@@ -58,6 +69,9 @@ module Versions {
     }
     const current = V4;
     // Visible build tag - bump every build so we can confirm on-watch which
-    // build is actually running (the MTP transfer is unreliable).
-    const tag = "b33";
+    // build is actually running (the MTP transfer is unreliable). `current` is
+    // NOT bumped for b34: two-way progress only ADDS new Storage keys (PROGRESS,
+    // FORCE_SYNC) and never changes an existing value's shape, so the version
+    // wipe (which would force every book to re-download) must not fire.
+    const tag = "b34";
 }

--- a/source/ContentDelegate.mc
+++ b/source/ContentDelegate.mc
@@ -77,9 +77,17 @@ class ContentDelegate extends Media.ContentDelegate {
         var hit = mProgressLookup[refId];
         if (hit == null) { return; }
         var absolute = hit[1] + positionInChapter;
-        // The book's total duration lets ABS compute a progress fraction;
-        // null (older record without durations) keeps ABS's stored duration.
-        AbsApi.patchProgress(hit[0], absolute, hit[2]);
+        // Persist the position LOCALLY first (survives being offline, and even
+        // an app kill mid-listen). The live push then clears the dirty flag if
+        // it reaches ABS; if it doesn't (phoneless run), it stays queued and the
+        // next sync flushes it. Same timestamp is used for both so the flush and
+        // the eventual cross-device merge agree on when this was played.
+        var ts = Progress.nowSec();
+        Progress.record(hit[0], absolute, ts);
+        // The book's total duration (hit[2]) lets ABS compute a progress
+        // fraction; null (older record without durations) keeps ABS's stored
+        // duration.
+        AbsApi.patchProgress(hit[0], absolute, hit[2], ts);
     }
 
     // A track started: put its book's cover on the native player screen

--- a/source/ContentDelegate.mc
+++ b/source/ContentDelegate.mc
@@ -76,7 +76,11 @@ class ContentDelegate extends Media.ContentDelegate {
         ensureLookup();
         var hit = mProgressLookup[refId];
         if (hit == null) { return; }
-        var absolute = hit[1] + positionInChapter;
+        // If this chunk was resumed partway in via ActiveContent, onSong reports
+        // playbackPosition RELATIVE to that start offset, so add it back to get
+        // the true book-absolute position (0 for every normally-started chunk).
+        var startOff = (mIterator != null) ? mIterator.resumeOffsetFor(refId) : 0;
+        var absolute = hit[1] + startOff + positionInChapter;
         // Persist the position LOCALLY first (survives being offline, and even
         // an app kill mid-listen). The live push then clears the dirty flag if
         // it reaches ABS; if it doesn't (phoneless run), it stays queued and the

--- a/source/ContentDelegate.mc
+++ b/source/ContentDelegate.mc
@@ -9,9 +9,14 @@ class ContentDelegate extends Media.ContentDelegate {
     private var mIterator;
     private var mProgressLookup; // { refId => [itemId, start, bookDuration] }, lazy
     private var mArtItemId;      // book whose cover is currently on the player
+    private var mArgs;           // { item, mode } from startPlayback, or null
 
-    function initialize() {
+    // args is the payload passed to Media.startPlayback (our BookActionMenu
+    // sends { item, mode }); null when playback is launched from the native
+    // Music widget. It flows on to the ContentIterator to position the cursor.
+    function initialize(args) {
         ContentDelegate.initialize();
+        mArgs = args;
         mProgressLookup = null;
         mArtItemId = null;
         resetContentIterator();
@@ -22,7 +27,7 @@ class ContentDelegate extends Media.ContentDelegate {
     }
 
     function resetContentIterator() {
-        mIterator = new ContentIterator();
+        mIterator = new ContentIterator(mArgs);
         return mIterator;
     }
 

--- a/source/ContentIterator.mc
+++ b/source/ContentIterator.mc
@@ -158,18 +158,17 @@ class ContentIterator extends Media.ContentIterator {
     // The sidecar strips ALL tags from transcoded chunks (deliberately - a
     // Garmin-confirmed bug makes certain ID3 text frames break native playback
     // on real hardware), so without this the player screen shows blank
-    // title/artist. Attach metadata at hand-off instead (the SubMusic
-    // pattern): title = "<book> - <h:mm:ss>" where the timestamp is the
-    // chunk's book-absolute start - with ~3-minute chunks that doubles as the
-    // "where am I in the whole book" indicator next to the native player's
-    // within-chunk position bar - artist = author, album = book title,
-    // trackNumber = the chunk's position within its book.
+    // title/artist. Attach metadata at hand-off instead (the SubMusic pattern):
+    // title = book name, artist = author, album = book name, trackNumber = the
+    // chunk's position within its book. (The title used to append the chunk's
+    // book-absolute timestamp as a coarse position readout; dropped for a clean
+    // "book - author" screen - the native player still shows within-chunk time.)
     function decorate(obj, idx) {
         try {
             var meta = obj.getMetadata();
             if (meta == null) { meta = new Media.ContentMetadata(); }
             var title = mBookTitles[mOrders[idx]];
-            meta.title = title + " - " + fmtTime(mStarts[idx]);
+            meta.title = title;
             meta.album = title;
             var author = mBookAuthors[mOrders[idx]];
             if (author != null) { meta.artist = author; }
@@ -192,7 +191,7 @@ class ContentIterator extends Media.ContentIterator {
     function resumeMetadata(idx) {
         var meta = new Media.ContentMetadata();
         var title = mBookTitles[mOrders[idx]];
-        meta.title = title + " - " + fmtTime(mStarts[idx]);
+        meta.title = title;
         meta.album = title;
         var author = mBookAuthors[mOrders[idx]];
         if (author != null) { meta.artist = author; }
@@ -208,18 +207,6 @@ class ContentIterator extends Media.ContentIterator {
         var j = idx;
         while ((j > 0) && (mOrders[j - 1] == b)) { --j; }
         return idx - j + 1;
-    }
-
-    // Seconds -> "h:mm:ss" (or "m:ss" under an hour).
-    function fmtTime(totalSec) {
-        var s = totalSec.toNumber();
-        var h = s / 3600;
-        var m = (s % 3600) / 60;
-        var sec = s % 60;
-        if (h > 0) {
-            return h.toString() + ":" + m.format("%02d") + ":" + sec.format("%02d");
-        }
-        return m.toString() + ":" + sec.format("%02d");
     }
 
     // Build the ordered playlist. Ids come from the OS's OWN content cache

--- a/source/ContentIterator.mc
+++ b/source/ContentIterator.mc
@@ -236,6 +236,42 @@ class ContentIterator extends Media.ContentIterator {
             }
         }
         mIndex = 0;
+        applyResume();
+    }
+
+    // Start the cursor at the resume point synced from ABS, instead of the very
+    // first chunk. We pick the CHUNK that contains the saved position (the
+    // native player has no seek-into-a-track hook from here, so resume lands at
+    // that chunk's start - at most one chunk / ~3 min early). Best-effort: any
+    // problem falls back to mIndex = 0 (play from the beginning), never a crash.
+    function applyResume() {
+        try {
+            var r = Progress.bestResume(); // [itemId, positionSec] or null
+            if (r == null) { return; }
+            var index = Application.Storage.getValue(Store.BOOK_INDEX);
+            if (index == null) { return; }
+            var slot = -1;
+            for (var i = 0; i < index.size(); ++i) {
+                if (index[i].equals(r[0])) { slot = i; break; }
+            }
+            if (slot < 0) { return; } // resumed book isn't downloaded - ignore
+            var target = r[1];
+            // A book's chunks are contiguous and ascending in the sorted
+            // playlist: walk this book's run, taking the last chunk that starts
+            // at or before the target, then stop.
+            var pick = -1;
+            for (var i = 0; i < mPlaylist.size(); ++i) {
+                if (mOrders[i] == slot) {
+                    if (mStarts[i] <= target) { pick = i; } else { break; }
+                } else if (pick >= 0) {
+                    break;
+                }
+            }
+            if (pick >= 0) { mIndex = pick; }
+        } catch (e) {
+            System.println("applyResume failed: " + e.getErrorMessage());
+            mIndex = 0;
+        }
     }
 
     // True if (orderA, startA) sorts AFTER (orderB, startB): by book first

--- a/source/ContentIterator.mc
+++ b/source/ContentIterator.mc
@@ -26,6 +26,8 @@ class ContentIterator extends Media.ContentIterator {
     private var mBookTitles;  // [ title, ... ]  indexed by BOOK_INDEX slot (O(books))
     private var mBookAuthors; // [ author or null, ... ] same indexing
     private var mShuffling;
+    private var mResumeRefId;  // the ONE chunk to start partway in (or null)
+    private var mResumeOffset; // seconds into that chunk (Number); 0 = none
 
     function initialize() {
         ContentIterator.initialize();
@@ -67,6 +69,7 @@ class ContentIterator extends Media.ContentIterator {
     function next() {
         if (mIndex < (mPlaylist.size() - 1)) {
             ++mIndex;
+            clearResume(); // the mid-chunk offset applies only to the first chunk
             return objAt(mIndex);
         }
         return null;
@@ -75,6 +78,7 @@ class ContentIterator extends Media.ContentIterator {
     function previous() {
         if (mIndex > 0) {
             --mIndex;
+            clearResume();
             return objAt(mIndex);
         }
         return null;
@@ -111,7 +115,21 @@ class ContentIterator extends Media.ContentIterator {
     function objAt(idx) {
         if ((idx >= 0) && (idx < mPlaylist.size())) {
             try {
-                var obj = Media.getCachedContentObj(new Media.ContentRef(mPlaylist[idx], Media.CONTENT_TYPE_AUDIO));
+                var refId = mPlaylist[idx];
+                var ref = new Media.ContentRef(refId, Media.CONTENT_TYPE_AUDIO);
+                // Precise resume: this ONE chunk starts partway in. ActiveContent
+                // (API 3.0.0+) carries a start position in seconds, so the native
+                // player begins there instead of at 0. If it's unsupported on this
+                // device or throws, fall through to the plain cached obj - playback
+                // then resumes at the chunk's start (~offset early), never crashes.
+                if ((mResumeRefId != null) && refId.equals(mResumeRefId) && (mResumeOffset > 0)) {
+                    try {
+                        return new Media.ActiveContent(ref, resumeMetadata(idx), mResumeOffset);
+                    } catch (e2) {
+                        System.println("ActiveContent resume failed: " + e2.getErrorMessage());
+                    }
+                }
+                var obj = Media.getCachedContentObj(ref);
                 if (obj != null) { decorate(obj, idx); }
                 return obj;
             } catch (e) {
@@ -156,6 +174,21 @@ class ContentIterator extends Media.ContentIterator {
         }
     }
 
+    // Fresh ContentMetadata for a chunk, used for the ActiveContent resume path
+    // (which takes metadata at construction, unlike the cached-obj path that
+    // decorates in place). Cached chunks carry no tags - the sidecar strips them
+    // - so building fresh loses nothing. Mirrors decorate()'s captioning.
+    function resumeMetadata(idx) {
+        var meta = new Media.ContentMetadata();
+        var title = mBookTitles[mOrders[idx]];
+        meta.title = title + " - " + fmtTime(mStarts[idx]);
+        meta.album = title;
+        var author = mBookAuthors[mOrders[idx]];
+        if (author != null) { meta.artist = author; }
+        if (!mShuffling) { meta.trackNumber = trackNo(idx); }
+        return meta;
+    }
+
     // 1-based position of chunk idx within its book (chunks of one book are
     // contiguous in the sorted playlist; the backward scan is a few hundred
     // integer compares at worst, once per track hand-off).
@@ -190,6 +223,7 @@ class ContentIterator extends Media.ContentIterator {
     // confirmed in the simulator), and identical titles would interleave two
     // books chunk-by-chunk.
     function buildPlaylist() {
+        clearResume();
         mPlaylist = [];
         mOrders = [];
         mStarts = [];
@@ -239,11 +273,11 @@ class ContentIterator extends Media.ContentIterator {
         applyResume();
     }
 
-    // Start the cursor at the resume point synced from ABS, instead of the very
-    // first chunk. We pick the CHUNK that contains the saved position (the
-    // native player has no seek-into-a-track hook from here, so resume lands at
-    // that chunk's start - at most one chunk / ~3 min early). Best-effort: any
-    // problem falls back to mIndex = 0 (play from the beginning), never a crash.
+    // Start the cursor at the resume point synced from ABS instead of the very
+    // first chunk. We pick the CHUNK that contains the saved position, then start
+    // that chunk PARTWAY IN via ActiveContent (see objAt) so resume is exact, not
+    // just chunk-aligned. Best-effort throughout: any problem leaves the cursor
+    // at 0 / the chunk start, never a crash.
     function applyResume() {
         try {
             var r = Progress.bestResume(); // [itemId, positionSec] or null
@@ -267,11 +301,31 @@ class ContentIterator extends Media.ContentIterator {
                     break;
                 }
             }
-            if (pick >= 0) { mIndex = pick; }
+            if (pick >= 0) {
+                mIndex = pick;
+                var off = (target - mStarts[pick]).toNumber(); // seconds into chunk
+                if (off > 0) {
+                    mResumeRefId = mPlaylist[pick];
+                    mResumeOffset = off;
+                }
+            }
         } catch (e) {
             System.println("applyResume failed: " + e.getErrorMessage());
             mIndex = 0;
         }
+    }
+
+    // Resume offset (seconds) to add for `refId`, else 0. ContentDelegate needs
+    // it because ActiveContent reports onSong playbackPosition RELATIVE to the
+    // configured start, so the true in-chunk offset is start + position.
+    function resumeOffsetFor(refId) {
+        if ((mResumeRefId != null) && refId.equals(mResumeRefId)) { return mResumeOffset; }
+        return 0;
+    }
+
+    function clearResume() {
+        mResumeRefId = null;
+        mResumeOffset = 0;
     }
 
     // True if (orderA, startA) sorts AFTER (orderB, startB): by book first
@@ -300,6 +354,7 @@ class ContentIterator extends Media.ContentIterator {
             swapAt(mStarts, i, j);
         }
         mIndex = 0;
+        clearResume(); // shuffled playback doesn't mid-chunk resume
     }
 
     function swapAt(arr, i, j) {

--- a/source/ContentIterator.mc
+++ b/source/ContentIterator.mc
@@ -137,7 +137,14 @@ class ContentIterator extends Media.ContentIterator {
                     try {
                         return new Media.ActiveContent(ref, resumeMetadata(idx), mResumeOffset);
                     } catch (e2) {
+                        // ActiveContent unsupported here: fall through to the plain
+                        // cached obj, which plays the chunk from 0. The offset was
+                        // NOT applied, so clear the resume state - otherwise
+                        // resumeOffsetFor() would keep reporting it and
+                        // ContentDelegate.syncProgress would add it back, pushing a
+                        // position ~offset seconds too far ahead to ABS.
                         System.println("ActiveContent resume failed: " + e2.getErrorMessage());
+                        clearResume();
                     }
                 }
                 var obj = Media.getCachedContentObj(ref);
@@ -335,11 +342,38 @@ class ContentIterator extends Media.ContentIterator {
         if (pick >= 0) {
             mIndex = pick;
             var off = (target - mStarts[pick]).toNumber(); // seconds into chunk
+            // Clamp to the picked chunk's REAL length. When the synced position
+            // lands in a chunk that isn't downloaded yet (a partially-downloaded
+            // book), the loop above picks the LAST cached chunk, whose start can
+            // be far below target - leaving off pointing past the chunk's end. An
+            // unclamped off makes ActiveContent overshoot AND makes syncProgress
+            // write that inflated position back to ABS (corrupting cross-device
+            // resume). If off reaches the chunk end, we can't resume precisely
+            // into audio we don't have: start cleanly at the chunk head (off = 0).
+            if (off > 0) {
+                var span = chunkLen(slot, pick - first);
+                if ((span <= 0) || (off >= span)) { off = 0; }
+            }
             if (off > 0) {
                 mResumeRefId = mPlaylist[pick];
                 mResumeOffset = off;
             }
         }
+    }
+
+    // Exact playable length (seconds) of book `slot`'s chunk at in-book index
+    // `k`, or -1 if unknown. Chunks download strictly in order, so a cached
+    // chunk's offset from the book's first playlist row IS its true chunk index.
+    // Boundaries are DERIVED (Chunks.at), never stored per-chunk (OOM discipline);
+    // a fixed LEN guess would misjudge the short last chunk of each file.
+    function chunkLen(slot, k) {
+        var index = Application.Storage.getValue(Store.BOOK_INDEX);
+        if ((index == null) || (slot < 0) || (slot >= index.size())) { return -1; }
+        var meta = BookStore.get(index[slot]);
+        if ((meta == null) || (meta["durs"] == null)) { return -1; }
+        var c = Chunks.at(meta["durs"], k);
+        if (c == null) { return -1; }
+        return c["cend"] - c["cstart"];
     }
 
     // Resume offset (seconds) to add for `refId`, else 0. ContentDelegate needs

--- a/source/ContentIterator.mc
+++ b/source/ContentIterator.mc
@@ -28,9 +28,20 @@ class ContentIterator extends Media.ContentIterator {
     private var mShuffling;
     private var mResumeRefId;  // the ONE chunk to start partway in (or null)
     private var mResumeOffset; // seconds into that chunk (Number); 0 = none
+    private var mStartItem;    // book itemId to start at (from startPlayback), or null
+    private var mStartMode;    // "resume" | "start" | null
 
-    function initialize() {
+    // args is the startPlayback payload: { item, mode } selects a specific book
+    // and whether to resume or start it; null (native Music widget) resumes the
+    // most-recently-progressed book.
+    function initialize(args) {
         ContentIterator.initialize();
+        mStartItem = null;
+        mStartMode = null;
+        if (args != null) {
+            mStartItem = args["item"];
+            mStartMode = args["mode"];
+        }
         mIndex = 0;
         mShuffling = false;
         buildPlaylist();
@@ -270,48 +281,77 @@ class ContentIterator extends Media.ContentIterator {
             }
         }
         mIndex = 0;
-        applyResume();
+        applyStart();
     }
 
-    // Start the cursor at the resume point synced from ABS instead of the very
-    // first chunk. We pick the CHUNK that contains the saved position, then start
-    // that chunk PARTWAY IN via ActiveContent (see objAt) so resume is exact, not
-    // just chunk-aligned. Best-effort throughout: any problem leaves the cursor
-    // at 0 / the chunk start, never a crash.
-    function applyResume() {
+    // Position the cursor for THIS playback session. If a specific book was
+    // chosen (BookActionMenu -> startPlayback { item, mode }), start it at its
+    // synced position ("resume") or at 0 ("start"). With no book (native Music
+    // widget / null args), resume the most-recently-progressed book. Best-effort
+    // throughout: any problem leaves the cursor at 0, never a crash.
+    function applyStart() {
         try {
-            var r = Progress.bestResume(); // [itemId, positionSec] or null
-            if (r == null) { return; }
-            var index = Application.Storage.getValue(Store.BOOK_INDEX);
-            if (index == null) { return; }
-            var slot = -1;
-            for (var i = 0; i < index.size(); ++i) {
-                if (index[i].equals(r[0])) { slot = i; break; }
+            var slot;
+            var target;
+            if (mStartItem != null) {
+                slot = slotOf(mStartItem);
+                if (slot < 0) { return; } // chosen book isn't downloaded
+                target = ((mStartMode != null) && mStartMode.equals("resume"))
+                    ? resumePosFor(mStartItem) : 0;
+            } else {
+                var r = Progress.bestResume(); // [itemId, positionSec] or null
+                if (r == null) { return; }
+                slot = slotOf(r[0]);
+                if (slot < 0) { return; }
+                target = r[1];
             }
-            if (slot < 0) { return; } // resumed book isn't downloaded - ignore
-            var target = r[1];
-            // A book's chunks are contiguous and ascending in the sorted
-            // playlist: walk this book's run, taking the last chunk that starts
-            // at or before the target, then stop.
-            var pick = -1;
-            for (var i = 0; i < mPlaylist.size(); ++i) {
-                if (mOrders[i] == slot) {
-                    if (mStarts[i] <= target) { pick = i; } else { break; }
-                } else if (pick >= 0) {
-                    break;
-                }
-            }
-            if (pick >= 0) {
-                mIndex = pick;
-                var off = (target - mStarts[pick]).toNumber(); // seconds into chunk
-                if (off > 0) {
-                    mResumeRefId = mPlaylist[pick];
-                    mResumeOffset = off;
-                }
-            }
+            positionAtBook(slot, target);
         } catch (e) {
-            System.println("applyResume failed: " + e.getErrorMessage());
+            System.println("applyStart failed: " + e.getErrorMessage());
             mIndex = 0;
+        }
+    }
+
+    // BOOK_INDEX slot (== sort order) for an itemId, or -1 if not downloaded.
+    function slotOf(itemId) {
+        var index = Application.Storage.getValue(Store.BOOK_INDEX);
+        if (index == null) { return -1; }
+        for (var i = 0; i < index.size(); ++i) {
+            if (index[i].equals(itemId)) { return i; }
+        }
+        return -1;
+    }
+
+    // Saved book-absolute resume position (seconds) for a book, or 0.
+    function resumePosFor(itemId) {
+        var e = Progress.get(itemId); // [positionSec, tsSec, dirty] or null
+        return (e != null) ? e[0] : 0;
+    }
+
+    // Put mIndex on the chunk of book `slot` that contains `target` seconds, and
+    // (via ActiveContent, see objAt) start it partway in for an exact resume. A
+    // book's chunks are contiguous and ascending in the sorted playlist. Falls
+    // back to the book's first cached chunk when target precedes it (e.g. "start"
+    // on a book whose head isn't at absolute 0).
+    function positionAtBook(slot, target) {
+        var first = -1;
+        var pick = -1;
+        for (var i = 0; i < mPlaylist.size(); ++i) {
+            if (mOrders[i] == slot) {
+                if (first < 0) { first = i; }
+                if (mStarts[i] <= target) { pick = i; } else { break; }
+            } else if (first >= 0) {
+                break;
+            }
+        }
+        if (pick < 0) { pick = first; }
+        if (pick >= 0) {
+            mIndex = pick;
+            var off = (target - mStarts[pick]).toNumber(); // seconds into chunk
+            if (off > 0) {
+                mResumeRefId = mPlaylist[pick];
+                mResumeOffset = off;
+            }
         }
     }
 

--- a/source/DownloadedMenu.mc
+++ b/source/DownloadedMenu.mc
@@ -31,6 +31,16 @@ class DownloadedMenu extends WatchUi.Menu2 {
             addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.playDownloaded), null, "play", null));
         }
 
+        // "Sync now" - force an on-demand two-way progress exchange with ABS
+        // (push our listens, pull other devices'). The value at a device handoff:
+        // the OS only auto-syncs on its own schedule (roughly, on the charger),
+        // which won't have fired in the minute between finishing on the watch and
+        // picking up in the car - and there is no wake-on-reconnect event to make
+        // it instant. This is the deterministic "sync before I switch" control.
+        if (AbsApi.isConfigured() && (index.size() > 0)) {
+            addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.syncNow), null, "syncnow", null));
+        }
+
         // Only offer to log out if actually logged in - avoids a pointless item
         // on a fresh, unconfigured install.
         if (AbsApi.isConfigured()) {

--- a/source/DownloadedMenu.mc
+++ b/source/DownloadedMenu.mc
@@ -2,12 +2,12 @@ using Toybox.Application;
 using Toybox.Media;
 using Toybox.WatchUi;
 
-// Lists downloaded books - one row per book from the BOOK_INDEX, with the
-// chunk count as the subtitle. Selecting a book removes ALL of its chunks;
-// "Play downloaded" starts playback (Media.startPlayback), which hands off to
-// the native player driving ContentIterator's set. The watch's own Music
-// widget (hold the music-controls button -> Music Providers -> WatchShelf)
-// reaches the SAME downloaded content and is the platform-standard way in too.
+// The top-level management screen: browse the library, open the downloaded
+// books ("Play downloaded" -> PlayMenu, where each book offers Resume / Play
+// from start / Delete), sync, log out, and bulk maintenance. The per-book list
+// lives in PlayMenu now, not here. The watch's own Music widget (hold the
+// music-controls button -> Music Providers -> WatchShelf) reaches the SAME
+// downloaded content and is the platform-standard way into playback too.
 class DownloadedMenu extends WatchUi.Menu2 {
 
     function initialize() {
@@ -21,12 +21,10 @@ class DownloadedMenu extends WatchUi.Menu2 {
         var index = Application.Storage.getValue(Store.BOOK_INDEX);
         if (index == null) { index = []; }
 
-        // Explicit, direct "Play" action - a plain MenuItem calling
-        // Media.startPlayback() straight from onSelect. NOT wired through
-        // Menu2's onDone(): per Garmin's own API docs, onDone() is only ever
-        // triggered by a WatchUi.CheckboxMenu, never a plain Menu2 like this
-        // one - so a Done-based "play" action here would be silently
-        // unreachable on real hardware no matter what the user pressed.
+        // "Play downloaded" -> the book list (PlayMenu), where each book offers
+        // Resume / Play from start / Delete. A normal tap handled in onSelect;
+        // NOT Menu2's onDone() (that only fires on a CheckboxMenu, never a plain
+        // Menu2, so it would be unreachable on real hardware).
         if (index.size() > 0) {
             addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.playDownloaded), null, "play", null));
         }
@@ -58,22 +56,8 @@ class DownloadedMenu extends WatchUi.Menu2 {
         if (index.size() > 0) {
             addItem(new WatchUi.MenuItem(WatchUi.loadResource(Rez.Strings.deleteAllDownloads), null, "deleteall", null));
         }
-
-        // Book rows carry the cover art synced by SyncDelegate (IconMenuItem,
-        // NOT MenuItem.setIcon - plain MenuItem icons only render in the
-        // subscreen area, never in the list on round watches). Books whose
-        // art fetch failed get the placeholder glyph.
-        var placeholder = WatchUi.loadResource(Rez.Drawables.bookIcon);
-        for (var i = 0; i < index.size(); ++i) {
-            var itemId = index[i];
-            var meta = BookStore.get(itemId);
-            var title = ((meta != null) && (meta["title"] != null)) ? meta["title"] : "Book";
-            var count = BookStore.count(itemId);
-            var sub = count.toString() + " part" + ((count == 1) ? "" : "s");
-            var art = BookStore.icon(itemId);
-            addItem(new WatchUi.IconMenuItem(title, sub, itemId,
-                (art != null) ? art : placeholder, null));
-        }
+        // Individual books now live under "Play downloaded" (PlayMenu), each with
+        // its own Resume / Play from start / Delete actions - not as rows here.
     }
 
     function hasQueued() {

--- a/source/DownloadedMenuDelegate.mc
+++ b/source/DownloadedMenuDelegate.mc
@@ -69,35 +69,39 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
             return;
         }
 
-        // "Delete all downloads" -> queue every downloaded book.
+        // "Delete all downloads" -> wipes EVERY book, so confirm first (a mis-tap
+        // here used to nuke the whole library instantly). The actual delete runs
+        // from the confirmation delegate on YES.
         if ((id instanceof Toybox.Lang.String) && id.equals("deleteall")) {
             var index = Application.Storage.getValue(Store.BOOK_INDEX);
             if (index == null) { index = []; }
-            queueDelete(index);
+            if (index.size() == 0) { return; }
+            WatchUi.pushView(
+                new WatchUi.Confirmation(WatchUi.loadResource(Rez.Strings.confirmDeleteAll)),
+                new DeleteAllConfirmDelegate(index), WatchUi.SLIDE_LEFT);
             return;
         }
         // No book rows live in this menu anymore - per-book delete moved to
         // PlayMenu -> BookActionMenu. Unknown ids fall through to nothing.
     }
 
-    // Add every given book itemId to the delete queue, then run a sync now to
-    // perform the deletions (Media.deleteCachedItem happens per cached chunk in
-    // SyncDelegate.deleteQueued).
-    function queueDelete(itemIds) {
-        if (itemIds.size() == 0) { return; }
-
-        var deleteList = Application.Storage.getValue(Store.DELETE_LIST);
-        if (deleteList == null) { deleteList = []; }
-        for (var i = 0; i < itemIds.size(); ++i) {
-            deleteList.add(itemIds[i]);
-        }
-        Application.Storage.setValue(Store.DELETE_LIST, deleteList);
-
-        Communications.startSync();
-        Notify.flash(Rez.Strings.deleting);
-    }
-
     function onBack() {
         WatchUi.popView(WatchUi.SLIDE_RIGHT);
+    }
+}
+
+// "Delete all downloads" confirmation. Only on YES do we queue every book for
+// deletion (Downloads.queueDelete kicks the sync that evicts the chunks).
+class DeleteAllConfirmDelegate extends WatchUi.ConfirmationDelegate {
+    private var mItemIds;
+    function initialize(itemIds) {
+        ConfirmationDelegate.initialize();
+        mItemIds = itemIds;
+    }
+    function onResponse(response) {
+        if (response == WatchUi.CONFIRM_YES) {
+            Downloads.queueDelete(mItemIds);
+        }
+        return true;
     }
 }

--- a/source/DownloadedMenuDelegate.mc
+++ b/source/DownloadedMenuDelegate.mc
@@ -23,13 +23,11 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
             return;
         }
 
-        // "Play downloaded" -> start playback directly. NOT wired through
-        // Menu2's onDone() (see class comment) - onDone() never fires on a
-        // plain Menu2 like this one, only on a WatchUi.CheckboxMenu, so a
-        // Done-triggered "play" was unreachable on real hardware no matter
-        // what the user pressed. This is a normal, always-reachable tap.
+        // "Play downloaded" -> the book list (PlayMenu). Picking a book there
+        // offers Resume / Play from start / Delete. A normal, always-reachable
+        // tap (NOT Menu2 onDone(), which never fires on a plain Menu2).
         if ((id instanceof Toybox.Lang.String) && id.equals("play")) {
-            Media.startPlayback(null);
+            WatchUi.pushView(new PlayMenu(), new PlayMenuDelegate(), WatchUi.SLIDE_LEFT);
             return;
         }
 
@@ -78,12 +76,8 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
             queueDelete(index);
             return;
         }
-
-        // Anything else is a BOOK's itemId - queue that one book for deletion.
-        // Deletions are always whole-book (a book can be 100+ ~3-min chunks;
-        // per-chunk anything isn't usable, and per-chunk STORAGE is what used
-        // to OOM-crash the app - see Constants.mc).
-        queueDelete([id]);
+        // No book rows live in this menu anymore - per-book delete moved to
+        // PlayMenu -> BookActionMenu. Unknown ids fall through to nothing.
     }
 
     // Add every given book itemId to the delete queue, then run a sync now to

--- a/source/DownloadedMenuDelegate.mc
+++ b/source/DownloadedMenuDelegate.mc
@@ -33,6 +33,19 @@ class DownloadedMenuDelegate extends WatchUi.Menu2InputDelegate {
             return;
         }
 
+        // "Sync now" -> force a one-shot sync so the two-way progress exchange
+        // runs even with no download/delete queued. The FORCE_SYNC flag makes
+        // isSyncNeeded() true (onStartSync clears it), and startSync() kicks the
+        // system sync that carries it out. Whether it can actually reach ABS
+        // depends on connectivity right now (phone in range / WiFi) - the same
+        // constraint every sidecar call has.
+        if ((id instanceof Toybox.Lang.String) && id.equals("syncnow")) {
+            Application.Storage.setValue(Store.FORCE_SYNC, true);
+            Communications.startSync();
+            Notify.flash(Rez.Strings.syncing);
+            return;
+        }
+
         // "Log out" -> clear the stored server/token and go straight to a fresh
         // on-watch login (switchToView, not push, so Back doesn't return to a
         // stale pre-logout menu - matches how LoginView.onLogin returns on success).

--- a/source/Downloads.mc
+++ b/source/Downloads.mc
@@ -1,0 +1,21 @@
+using Toybox.Application;
+using Toybox.Communications;
+
+// Shared deletion path for downloaded books - used by the per-book action menu
+// (one book) and the "Delete all downloads" confirmation (every book). Queue the
+// whole books and kick a sync; SyncDelegate.deleteQueued evicts each cached
+// chunk. Whole-book only: per-chunk state is what used to OOM-crash the app
+// (see Constants.mc).
+module Downloads {
+    function queueDelete(itemIds) {
+        if (itemIds.size() == 0) { return; }
+        var deleteList = Application.Storage.getValue(Store.DELETE_LIST);
+        if (deleteList == null) { deleteList = []; }
+        for (var i = 0; i < itemIds.size(); ++i) {
+            deleteList.add(itemIds[i]);
+        }
+        Application.Storage.setValue(Store.DELETE_LIST, deleteList);
+        Communications.startSync();
+        Notify.flash(Rez.Strings.deleting);
+    }
+}

--- a/source/Errors.mc
+++ b/source/Errors.mc
@@ -1,0 +1,40 @@
+using Toybox.WatchUi;
+
+// Turns a makeWebRequest response code into wording a user can act on. `code` is
+// the integer every CIQ web callback receives: 200 = OK, a POSITIVE value is an
+// HTTP status, a NEGATIVE value is a Communications transport error. The two the
+// user actually hits:
+//
+//   -104  BLE_CONNECTION_UNAVAILABLE - the watch can't reach the phone at all
+//         (Garmin Connect Mobile not running / Bluetooth bridge down). Nothing
+//         even left the watch. This is NOT a WatchShelf/ABS problem.
+//   -300  NETWORK_REQUEST_TIMED_OUT - the request DID leave the watch (phone
+//         bridge is fine) but nothing answered in time: the sidecar / tunnel is
+//         down, slow, or unreachable. A "server" problem, not a phone one.
+//   -400  INVALID_HTTP_BODY_IN_NETWORK_RESPONSE - reply wasn't the JSON we
+//         expected (wrong URL, or the sidecar/ABS is unhappy). Grouped with 5xx.
+//
+// Unknown codes fall through to the caller's own generic message, and the raw
+// number is ALWAYS appended so a genuine bug stays diagnosable on-device.
+module Errors {
+
+    // A short, actionable hint for a code we recognise, or null otherwise.
+    function hint(code) {
+        if (code == -104) {
+            return WatchUi.loadResource(Rez.Strings.errPhone);
+        }
+        if ((code == -300) || (code == -400) || ((code >= 500) && (code <= 599))) {
+            return WatchUi.loadResource(Rez.Strings.errServer);
+        }
+        return null;
+    }
+
+    // Full text for an error screen: the friendly hint when we recognise the
+    // code, else the caller's generic fallback - either way with the raw number
+    // appended (small, for support), so nothing becomes un-diagnosable.
+    function message(fallbackRezId, code) {
+        var h = hint(code);
+        var base = (h != null) ? h : WatchUi.loadResource(fallbackRezId);
+        return base + "\n(" + code + ")";
+    }
+}

--- a/source/LibraryView.mc
+++ b/source/LibraryView.mc
@@ -41,6 +41,8 @@ class LibraryView extends WatchUi.View {
 
     // Got the library list -> show a menu of book libraries.
     function onLibraries(code, data) {
+        // Session expired -> re-login instead of a dead-end error.
+        if (code == 401) { Login.reauth(); return; }
         if ((code == 200) && (data != null) && (data["libraries"] != null)) {
             var libs = data["libraries"];
             var menu = new WatchUi.Menu2({ :title => WatchUi.loadResource(Rez.Strings.pickLibrary) });

--- a/source/LibraryView.mc
+++ b/source/LibraryView.mc
@@ -53,7 +53,7 @@ class LibraryView extends WatchUi.View {
             }
             WatchUi.pushView(menu, new LibraryMenuDelegate(), WatchUi.SLIDE_LEFT);
         } else {
-            mMessage = WatchUi.loadResource(Rez.Strings.errLibraries) + "\n(" + code + ")";
+            mMessage = Errors.message(Rez.Strings.errLibraries, code);
             WatchUi.requestUpdate();
         }
     }

--- a/source/Login.mc
+++ b/source/Login.mc
@@ -65,7 +65,7 @@ class LoginView extends WatchUi.View {
             AbsApi.login(mCreds.server, mCreds.username, mCreds.password, method(:onLogin));
         } else {
             mState = 99;
-            mMessage = WatchUi.loadResource(Rez.Strings.errNotWatchShelf) + "\n(" + code + ")";
+            mMessage = Errors.message(Rez.Strings.errNotWatchShelf, code);
             WatchUi.requestUpdate();
         }
     }
@@ -120,7 +120,7 @@ class LoginView extends WatchUi.View {
             WatchUi.switchToView(new LibraryView(), new LibraryViewDelegate(), WatchUi.SLIDE_LEFT);
         } else {
             mState = 99;
-            mMessage = WatchUi.loadResource(Rez.Strings.loginFailed) + "\n(" + code + ")";
+            mMessage = Errors.message(Rez.Strings.loginFailed, code);
             WatchUi.requestUpdate();
         }
     }

--- a/source/Login.mc
+++ b/source/Login.mc
@@ -22,6 +22,14 @@ module Login {
     function start() {
         WatchUi.pushView(new LoginView(), new LibraryViewDelegate(), WatchUi.SLIDE_LEFT);
     }
+    // ABS reported our session dead (401). Drop the stale token (keep the server
+    // URL) and restart login, so a data screen recovers cleanly instead of
+    // dead-ending on "Could not load..." or a -300 hang. This is the one action
+    // that actually fixes an expired session, surfaced automatically.
+    function reauth() {
+        AbsApi.clearToken();
+        start();
+    }
 }
 
 class LoginView extends WatchUi.View {

--- a/source/PlayMenu.mc
+++ b/source/PlayMenu.mc
@@ -1,0 +1,47 @@
+using Toybox.Application;
+using Toybox.WatchUi;
+
+// "Play downloaded" -> a list of the downloaded books (one row per BOOK_INDEX
+// entry, cover art if present else the placeholder glyph). Selecting a book
+// opens its action menu (Resume / Play from start / Delete). This is the play
+// entry point; the old top-level menu no longer plays or lists books directly.
+class PlayMenu extends WatchUi.Menu2 {
+
+    function initialize() {
+        Menu2.initialize({ :title => WatchUi.loadResource(Rez.Strings.playDownloaded) });
+
+        var index = Application.Storage.getValue(Store.BOOK_INDEX);
+        if (index == null) { index = []; }
+
+        var placeholder = WatchUi.loadResource(Rez.Drawables.bookIcon);
+        for (var i = 0; i < index.size(); ++i) {
+            var itemId = index[i];
+            var meta = BookStore.get(itemId);
+            var title = ((meta != null) && (meta["title"] != null)) ? meta["title"] : "Book";
+            var count = BookStore.count(itemId);
+            var sub = count.toString() + " part" + ((count == 1) ? "" : "s");
+            var art = BookStore.icon(itemId);
+            addItem(new WatchUi.IconMenuItem(title, sub, itemId,
+                (art != null) ? art : placeholder, null));
+        }
+    }
+}
+
+class PlayMenuDelegate extends WatchUi.Menu2InputDelegate {
+    function initialize() {
+        Menu2InputDelegate.initialize();
+    }
+
+    // A book row -> its per-book action menu. The row id IS the itemId.
+    function onSelect(item) {
+        var itemId = item.getId();
+        var meta = BookStore.get(itemId);
+        var title = ((meta != null) && (meta["title"] != null)) ? meta["title"] : "Book";
+        WatchUi.pushView(new BookActionMenu(itemId, title),
+            new BookActionMenuDelegate(itemId), WatchUi.SLIDE_LEFT);
+    }
+
+    function onBack() {
+        WatchUi.popView(WatchUi.SLIDE_RIGHT);
+    }
+}

--- a/source/PlayMenu.mc
+++ b/source/PlayMenu.mc
@@ -2,9 +2,17 @@ using Toybox.Application;
 using Toybox.WatchUi;
 
 // "Play downloaded" -> a list of the downloaded books (one row per BOOK_INDEX
-// entry, cover art if present else the placeholder glyph). Selecting a book
-// opens its action menu (Resume / Play from start / Delete). This is the play
-// entry point; the old top-level menu no longer plays or lists books directly.
+// entry). Selecting a book opens its action menu (Resume / Play from start /
+// Delete). This is the play entry point; the old top-level menu no longer plays
+// or lists books directly.
+//
+// PLAIN MenuItem, NO per-row cover art - deliberately. An earlier b34 draft used
+// IconMenuItem with BookStore.icon(); that art is dead code today (cover fetch
+// was removed in b33, so icon() always returns null and only the placeholder
+// glyph rendered), so the IconMenuItem bought nothing while nudging toward the
+// per-row-icon pattern the Browse list had to abandon (b29->b30) to stop OOMing
+// its unbounded list. Keep this list plain; cover art belongs only on the player
+// screen (Media.setAlbumArt), never as menu-row icons.
 class PlayMenu extends WatchUi.Menu2 {
 
     function initialize() {
@@ -13,16 +21,17 @@ class PlayMenu extends WatchUi.Menu2 {
         var index = Application.Storage.getValue(Store.BOOK_INDEX);
         if (index == null) { index = []; }
 
-        var placeholder = WatchUi.loadResource(Rez.Drawables.bookIcon);
         for (var i = 0; i < index.size(); ++i) {
             var itemId = index[i];
+            var count = BookStore.count(itemId);
+            // Skip a book with no cached chunks - an unplayable transient (the
+            // crash window between a delete's un-index and evict). Selecting it
+            // would have nothing to play and could start a different book.
+            if (count == 0) { continue; }
             var meta = BookStore.get(itemId);
             var title = ((meta != null) && (meta["title"] != null)) ? meta["title"] : "Book";
-            var count = BookStore.count(itemId);
             var sub = count.toString() + " part" + ((count == 1) ? "" : "s");
-            var art = BookStore.icon(itemId);
-            addItem(new WatchUi.IconMenuItem(title, sub, itemId,
-                (art != null) ? art : placeholder, null));
+            addItem(new WatchUi.MenuItem(title, sub, itemId, null));
         }
     }
 }

--- a/source/Progress.mc
+++ b/source/Progress.mc
@@ -28,7 +28,8 @@ module Progress {
 
     function all() {
         var m = Application.Storage.getValue(Store.PROGRESS);
-        return (m == null) ? {} : m;
+        if (m == null) { return {}; }
+        return m;
     }
 
     function save(m) {

--- a/source/Progress.mc
+++ b/source/Progress.mc
@@ -48,6 +48,17 @@ module Progress {
         save(m);
     }
 
+    // Drop a book's saved progress. Called when the book is deleted from the
+    // watch so a stale entry can't linger and win bestResume() - which would
+    // misdirect a later native-widget resume to a book that's no longer here.
+    function remove(itemId) {
+        var m = all();
+        if (m.hasKey(itemId)) {
+            m.remove(itemId);
+            save(m);
+        }
+    }
+
     // Mark a book's write confirmed to ABS - but ONLY if no NEWER local write
     // landed while the request was in flight. A later record() bumps tsSec, so a
     // stale 200 for an older position must not clear the newer dirty one.
@@ -92,14 +103,21 @@ module Progress {
         return out;
     }
 
-    // The most-recently-updated book as [itemId, positionSec], or null - the
-    // book (and offset) to resume playback at across devices.
+    // The most-recently-updated DOWNLOADED book as [itemId, positionSec], or
+    // null - the book (and offset) to resume playback at across devices. Only
+    // books still in BOOK_INDEX are considered: a progress entry for a deleted
+    // book (or one downloaded on another device but not here) can't be resumed,
+    // and letting it win would strand the null-args resume on a book that isn't
+    // present (playback then silently starts a different book at 0).
     function bestResume() {
         var m = all();
         var ids = m.keys();
+        var index = Application.Storage.getValue(Store.BOOK_INDEX);
+        if (index == null) { index = []; }
         var bestId = null;
         var bestTs = null;
         for (var i = 0; i < ids.size(); ++i) {
+            if (!_indexed(index, ids[i])) { continue; }
             var e = m[ids[i]];
             if ((bestTs == null) || (e[1] > bestTs)) {
                 bestTs = e[1];
@@ -108,5 +126,12 @@ module Progress {
         }
         if (bestId == null) { return null; }
         return [bestId, m[bestId][0]];
+    }
+
+    function _indexed(index, itemId) {
+        for (var i = 0; i < index.size(); ++i) {
+            if (index[i].equals(itemId)) { return true; }
+        }
+        return false;
     }
 }

--- a/source/Progress.mc
+++ b/source/Progress.mc
@@ -1,0 +1,111 @@
+using Toybox.Application;
+using Toybox.Time;
+
+// Two-way play-progress state. O(books) - ONE small Storage dictionary keyed by
+// itemId, never per-chunk (see Constants.mc for the OOM post-mortem that forced
+// O(books) everywhere). One entry per book the user has played or resumed:
+//
+//   { itemId => [ positionSec, tsSec, dirty ] }
+//
+//   positionSec  book-absolute playback position in seconds - the resume point.
+//   tsSec        when that position was set, in EPOCH SECONDS. This is the same
+//                clock ABS records as MediaProgress.lastUpdate (the sidecar
+//                converts sec<->ms at the edge), so cross-device last-write-wins
+//                is a plain numeric compare. Watch writes stamp Time.now(); a
+//                server pull carries ABS's own lastUpdate.
+//   dirty        true  = written locally but not yet confirmed to ABS (must be
+//                        flushed on the next sync);
+//                false = in sync with ABS.
+//
+// Seconds (not ms) is deliberate: an epoch-ms value overflows the watch's 32-bit
+// Number and JSON-decodes to a lossy Float, which would corrupt LWW ordering.
+// Epoch seconds stays an exact Number, and the sidecar does the *1000 / /1000.
+module Progress {
+
+    function nowSec() {
+        return Time.now().value();
+    }
+
+    function all() {
+        var m = Application.Storage.getValue(Store.PROGRESS);
+        return (m == null) ? {} : m;
+    }
+
+    function save(m) {
+        Application.Storage.setValue(Store.PROGRESS, m);
+    }
+
+    function get(itemId) {
+        return all()[itemId];
+    }
+
+    // Record a locally-observed position. Always marked dirty: the next sync
+    // flushes it to ABS, and the live push (if online) clears it via markClean.
+    function record(itemId, positionSec, tsSec) {
+        var m = all();
+        m[itemId] = [positionSec, tsSec, true];
+        save(m);
+    }
+
+    // Mark a book's write confirmed to ABS - but ONLY if no NEWER local write
+    // landed while the request was in flight. A later record() bumps tsSec, so a
+    // stale 200 for an older position must not clear the newer dirty one.
+    function markClean(itemId, tsSec) {
+        var m = all();
+        var e = m[itemId];
+        if ((e != null) && e[2] && (e[1] <= tsSec)) {
+            m[itemId] = [e[0], e[1], false];
+            save(m);
+        }
+    }
+
+    // Merge a position pulled from ABS, last-write-wins by tsSec: a strictly
+    // newer server value replaces ours (and is clean - no need to push it back);
+    // an equal/older one is ignored so a fresh local listen is never regressed.
+    function mergeServer(itemId, positionSec, tsSec) {
+        var m = all();
+        var e = m[itemId];
+        if ((e == null) || (tsSec > e[1])) {
+            m[itemId] = [positionSec, tsSec, false];
+            save(m);
+        }
+    }
+
+    // Any local write still awaiting a flush? Drives isSyncNeeded().
+    function hasDirty() {
+        var m = all();
+        var ids = m.keys();
+        for (var i = 0; i < ids.size(); ++i) {
+            if (m[ids[i]][2]) { return true; }
+        }
+        return false;
+    }
+
+    function dirtyIds() {
+        var m = all();
+        var ids = m.keys();
+        var out = [];
+        for (var i = 0; i < ids.size(); ++i) {
+            if (m[ids[i]][2]) { out.add(ids[i]); }
+        }
+        return out;
+    }
+
+    // The most-recently-updated book as [itemId, positionSec], or null - the
+    // book (and offset) to resume playback at across devices.
+    function bestResume() {
+        var m = all();
+        var ids = m.keys();
+        var bestId = null;
+        var bestTs = null;
+        for (var i = 0; i < ids.size(); ++i) {
+            var e = m[ids[i]];
+            if ((bestTs == null) || (e[1] > bestTs)) {
+                bestTs = e[1];
+                bestId = ids[i];
+            }
+        }
+        if (bestId == null) { return null; }
+        return [bestId, m[bestId][0]];
+    }
+}

--- a/source/ProgressSync.mc
+++ b/source/ProgressSync.mc
@@ -1,0 +1,110 @@
+using Toybox.Application;
+using Toybox.System;
+
+// The two-way progress exchange, run as one bounded, SEQUENTIAL chain inside a
+// sync (SyncDelegate.onStartSync). Order matters:
+//
+//   1. PULL every downloaded book's position from ABS and last-write-wins merge
+//      it locally. This picks up a position set on another device AND resolves
+//      conflicts BEFORE we push - ABS's PATCH is a blind write, so pushing a
+//      stale offline listen first could clobber a newer position from the phone.
+//   2. PUSH whatever is still dirty after the merge (i.e. a genuinely newer
+//      local listen), stamped with the watch's own listen time so other devices
+//      order it correctly.
+//
+// One request at a time - same discipline as the download engine - so it never
+// stacks requests into the 512KB sync heap. When the chain finishes (or on any
+// error) it invokes the continuation exactly once, so downloads/deletes always
+// run even if a progress request failed. Nothing here is load-bearing for the
+// download path; it only front-runs it.
+class ProgressSync {
+
+    private var mPulls;    // [ itemId, ... ] downloaded books to pull
+    private var mPushes;   // [ itemId, ... ] still-dirty books to push (built
+                           // AFTER the pulls, so the merge has already run)
+    private var mPhase;    // 0 = pulling, 1 = pushing
+    private var mIdx;
+    private var mCurId;
+    private var mCurTs;
+    private var mCb;
+
+    function initialize() {
+        mPulls = [];
+        mPushes = [];
+        mPhase = 0;
+        mIdx = 0;
+    }
+
+    function start(cb) {
+        mCb = cb;
+        try {
+            var index = Application.Storage.getValue(Store.BOOK_INDEX);
+            if (index == null) { index = []; }
+            mPulls = index;
+        } catch (e) {
+            System.println("ProgressSync build failed: " + e.getErrorMessage());
+            mPulls = [];
+        }
+        step();
+    }
+
+    function step() {
+        try {
+            if (mPhase == 0) {
+                if (mIdx >= mPulls.size()) {
+                    // Pulls done: NOW compute what remains dirty and push it.
+                    mPushes = Progress.dirtyIds();
+                    mPhase = 1;
+                    mIdx = 0;
+                    step();
+                    return;
+                }
+                mCurId = mPulls[mIdx];
+                mIdx += 1;
+                AbsApi.getProgress(mCurId, method(:onPullDone));
+                return;
+            }
+
+            // Push phase.
+            if (mIdx >= mPushes.size()) { finish(); return; }
+            mCurId = mPushes[mIdx];
+            mIdx += 1;
+            var e = Progress.get(mCurId);
+            if (e == null) { step(); return; }
+            mCurTs = e[1];
+            // duration unknown here -> null keeps ABS's stored duration.
+            AbsApi.postProgress(mCurId, e[0], null, e[1], method(:onPushDone));
+        } catch (ex) {
+            System.println("ProgressSync step failed: " + ex.getErrorMessage());
+            // Never let a progress hiccup strand the sync - advance regardless.
+            if (mPhase == 0 && mIdx >= mPulls.size()) { mPushes = []; }
+            step();
+        }
+    }
+
+    function onPullDone(code, data) {
+        try {
+            if (code == 200) {
+                var pr = AbsApi.readProgress(data); // [posSec, tsSec] or null
+                if (pr != null) { Progress.mergeServer(mCurId, pr[0], pr[1]); }
+            }
+        } catch (ex) {
+            System.println("ProgressSync pull failed: " + ex.getErrorMessage());
+        }
+        step();
+    }
+
+    function onPushDone(code, data) {
+        if (code == 200) { Progress.markClean(mCurId, mCurTs); }
+        else { System.println("ProgressSync push failed: " + code); }
+        step();
+    }
+
+    function finish() {
+        if (mCb != null) {
+            var cb = mCb;
+            mCb = null;
+            cb.invoke();
+        }
+    }
+}

--- a/source/ProgressSync.mc
+++ b/source/ProgressSync.mc
@@ -13,10 +13,11 @@ using Toybox.System;
 //      order it correctly.
 //
 // One request at a time - same discipline as the download engine - so it never
-// stacks requests into the 512KB sync heap. When the chain finishes (or on any
-// error) it invokes the continuation exactly once, so downloads/deletes always
-// run even if a progress request failed. Nothing here is load-bearing for the
-// download path; it only front-runs it.
+// stacks requests into the 512KB sync heap. It runs as the FINAL step of a sync
+// (SyncDelegate.finishSync), AFTER downloads/deletes are done, and invokes its
+// continuation exactly once when the chain ends - even on a request error - so
+// the sync always reaches notifySyncComplete. Nothing here is load-bearing for
+// the download path: by the time it runs, downloads have already finished.
 class ProgressSync {
 
     private var mPulls;    // [ itemId, ... ] downloaded books to pull

--- a/source/SyncDelegate.mc
+++ b/source/SyncDelegate.mc
@@ -58,16 +58,13 @@ class SyncDelegate extends Communications.SyncDelegate {
         // Consume the one-shot "Sync now" flag immediately so this sync can't be
         // re-triggered by it forever.
         Application.Storage.deleteValue(Store.FORCE_SYNC);
-        // Exchange play progress with ABS FIRST (pull other devices' positions,
-        // then push our offline listens), THEN run downloads/deletes. The
-        // continuation always fires, even if a progress request fails, so the
-        // download path is never blocked by progress.
-        mProgressSync = new ProgressSync();
-        mProgressSync.start(method(:runDownloads));
-    }
-
-    // The download/delete engine, gated behind the progress exchange above.
-    function runDownloads() {
+        // Downloads/deletes run FIRST and drive the sync; the two-way progress
+        // exchange runs at the very END (finishSync). It is deliberately NOT put
+        // in front of downloads: progress must never gate, delay, or - worst
+        // case - regress the historically crash-prone download path. By the time
+        // progress runs the downloads are already done, so any progress-request
+        // failure is harmless. finishSync is reached from BOTH success paths
+        // (nothing-to-download here, and all-downloads-done in downloadNext).
         var toDelete = deletes();
 
         // Cancel any queued job for a book being deleted BEFORE counting or
@@ -95,12 +92,26 @@ class SyncDelegate extends Communications.SyncDelegate {
             if (left > 0) { mTotal += left; }
         }
         if (mTotal == 0) {
-            Communications.notifySyncComplete(null);
+            finishSync();
             return;
         }
 
         deleteQueued(toDelete);
         downloadNext();
+    }
+
+    // Final, DECOUPLED step of every successful sync: exchange play progress
+    // with ABS (pull other devices' positions + merge, then push our offline
+    // listens), then complete. ProgressSync always invokes its continuation -
+    // even if a request errors - so the sync always reaches notifySyncComplete.
+    // Kept separate from the download engine on purpose (see onStartSync).
+    function finishSync() {
+        mProgressSync = new ProgressSync();
+        mProgressSync.start(method(:onProgressDone));
+    }
+
+    function onProgressDone() {
+        Communications.notifySyncComplete(null);
     }
 
     // System-initiated cancel: stop cleanly. In-flight request is abandoned;
@@ -148,7 +159,7 @@ class SyncDelegate extends Communications.SyncDelegate {
         var jobIds = JobStore.list();
         if (jobIds.size() == 0) {
             sweepOrphans();
-            Communications.notifySyncComplete(null);
+            finishSync();
             return;
         }
 

--- a/source/SyncDelegate.mc
+++ b/source/SyncDelegate.mc
@@ -237,7 +237,8 @@ class SyncDelegate extends Communications.SyncDelegate {
     // job's cursor position and advance.
     function onTrackDownloaded(code, data, context) {
         if ((code != 200) || (data == null)) {
-            Communications.notifySyncComplete("Download failed (" + code + ")");
+            var h = Errors.hint(code);
+            Communications.notifySyncComplete((h != null) ? h : ("Download failed (" + code + ")"));
             return;
         }
 

--- a/source/SyncDelegate.mc
+++ b/source/SyncDelegate.mc
@@ -31,11 +31,13 @@ class SyncDelegate extends Communications.SyncDelegate {
     private var mTotal;         // ops planned at sync start (downloads + deletes)
     private var mDone;          // ops completed
     private var mProgressSync;  // held so its async chain isn't GC'd mid-flight
+    private var mSyncError;     // download error surfaced AFTER progress runs, or null
 
     function initialize() {
         SyncDelegate.initialize();
         mTotal = 0;
         mDone = 0;
+        mSyncError = null;
     }
 
     function deletes() {
@@ -111,7 +113,9 @@ class SyncDelegate extends Communications.SyncDelegate {
     }
 
     function onProgressDone() {
-        Communications.notifySyncComplete(null);
+        // Report a download error (if any) only now - AFTER the progress exchange
+        // has had its chance to flush a dirty offline listen. null on a clean sync.
+        Communications.notifySyncComplete(mSyncError);
     }
 
     // System-initiated cancel: stop cleanly. In-flight request is abandoned;
@@ -121,13 +125,20 @@ class SyncDelegate extends Communications.SyncDelegate {
         Communications.notifySyncComplete(null);
     }
 
-    // Delete every queued BOOK: BookStore evicts its cached chunks and drops
-    // its records; then remove it from the menu index.
+    // Delete every queued BOOK: un-index it, evict its cached chunks and records,
+    // and drop its saved progress.
     function deleteQueued(toDelete) {
         if (toDelete.size() == 0) { return; }
         for (var i = 0; i < toDelete.size(); ++i) {
-            BookStore.deleteBook(toDelete[i]);
+            // Un-index FIRST, then evict. A hard kill between the two then leaves
+            // an UNindexed book with orphan chunks (harmlessly swept next sync,
+            // never played) rather than an INDEXED book with zero chunks (which
+            // makes playback start a DIFFERENT book's audio). Prune its progress
+            // too, so a deleted book can never win bestResume() and misdirect a
+            // later native-widget resume to the wrong (or no) book.
             BookStore.removeFromIndex(toDelete[i]);
+            BookStore.deleteBook(toDelete[i]);
+            Progress.remove(toDelete[i]);
             onOpDone();
         }
 
@@ -237,8 +248,15 @@ class SyncDelegate extends Communications.SyncDelegate {
     // job's cursor position and advance.
     function onTrackDownloaded(code, data, context) {
         if ((code != 200) || (data == null)) {
+            // Download failed. Do NOT end here: a dirty offline listen still needs
+            // flushing and the progress exchange requires no successful download.
+            // Route through finishSync (which runs ProgressSync, then reports this
+            // error via onProgressDone). The failing job stays queued for the next
+            // sync to retry. ProgressSync always fires its continuation even if its
+            // own requests error, so this cannot hang.
             var h = Errors.hint(code);
-            Communications.notifySyncComplete((h != null) ? h : ("Download failed (" + code + ")"));
+            mSyncError = (h != null) ? h : ("Download failed (" + code + ")");
+            finishSync();
             return;
         }
 

--- a/source/SyncDelegate.mc
+++ b/source/SyncDelegate.mc
@@ -28,8 +28,9 @@ using Toybox.Media;
 // persisted), and was reverted.
 class SyncDelegate extends Communications.SyncDelegate {
 
-    private var mTotal;      // ops planned at sync start (downloads + deletes)
-    private var mDone;       // ops completed
+    private var mTotal;         // ops planned at sync start (downloads + deletes)
+    private var mDone;          // ops completed
+    private var mProgressSync;  // held so its async chain isn't GC'd mid-flight
 
     function initialize() {
         SyncDelegate.initialize();
@@ -42,12 +43,31 @@ class SyncDelegate extends Communications.SyncDelegate {
         return (d == null) ? [] : d;
     }
 
-    // The system only starts a sync when this is true.
+    // The system only starts a sync when this is true. Besides queued downloads
+    // and deletes, a sync is needed when we have an unflushed local listen to
+    // push (Progress.hasDirty), or when the user tapped "Sync now" (the one-shot
+    // FORCE_SYNC flag, cleared at the top of onStartSync so it can't loop).
     function isSyncNeeded() {
-        return (JobStore.list().size() != 0) || (deletes().size() != 0);
+        return (JobStore.list().size() != 0)
+            || (deletes().size() != 0)
+            || Progress.hasDirty()
+            || (Application.Storage.getValue(Store.FORCE_SYNC) != null);
     }
 
     function onStartSync() {
+        // Consume the one-shot "Sync now" flag immediately so this sync can't be
+        // re-triggered by it forever.
+        Application.Storage.deleteValue(Store.FORCE_SYNC);
+        // Exchange play progress with ABS FIRST (pull other devices' positions,
+        // then push our offline listens), THEN run downloads/deletes. The
+        // continuation always fires, even if a progress request fails, so the
+        // download path is never blocked by progress.
+        mProgressSync = new ProgressSync();
+        mProgressSync.start(method(:runDownloads));
+    }
+
+    // The download/delete engine, gated behind the progress exchange above.
+    function runDownloads() {
         var toDelete = deletes();
 
         // Cancel any queued job for a book being deleted BEFORE counting or

--- a/source/WatchShelfApp.mc
+++ b/source/WatchShelfApp.mc
@@ -27,8 +27,11 @@ class WatchShelfApp extends Application.AudioContentProviderApp {
     }
 
     // System -> playback: hand back a delegate that yields cached chapter tracks.
+    // args is the payload from Media.startPlayback - our BookActionMenu passes
+    // { item, mode } so the iterator can resume/start the chosen book; null from
+    // the native Music widget (iterator then resumes the most recent book).
     function getContentDelegate(args) {
-        return new ContentDelegate();
+        return new ContentDelegate(args);
     }
 
     // System -> sync: background download engine. getSyncDelegate() is the


### PR DESCRIPTION
## What & why

Progress was **write-only and lost when offline**. During playback the watch fire-and-forget POSTed the current position; if it couldn't reach the sidecar (a phoneless run) that position was simply dropped, and nothing was ever read back — so the watch could never resume where another device left off. `progressSeconds()` existed but was dead code, and no sidecar endpoint carried progress down.

This makes progress **two-way, durable, and precise**, so the run → car → phone → park handoff works. It's honest about the platform ceiling: Connect IQ has **no wake-on-reconnect event** and watches generally can't reach the network mid-run (no BLE bridge → `-104`, no WiFi outdoors), so sync is **eventually-consistent, not live** — automatic on the charger, plus a manual button for the moment you're about to switch devices.

## How it works

**Watch**
- **`Progress.mc`** — one small O(books) Storage dict `{ itemId => [positionSec, tsSec, dirty] }`. Every playback event persists the book-absolute position + timestamp, marked dirty. Survives being offline and an app kill mid-listen.
- **Offline flush** — the live push clears `dirty` on a 200; offline it stays queued. `isSyncNeeded()` is now true while any dirty write exists, so the OS's own charge/WiFi sync drains it with no user action.
- **`ProgressSync.mc`** — the **final, decoupled** step of a sync (after downloads, never gating them): **pull** every downloaded book's server position and last-write-wins merge it **before** pushing, so a newer position from another device wins and a stale offline listen never clobbers it. One sequential chain; its continuation always fires (even on error) so the sync always completes.
- **Precise resume** (`ContentIterator` + `Media.ActiveContent`) — playback resumes at the **exact** synced position, not just the chunk boundary. The one chunk containing the position is returned as an `ActiveContent` with `playbackStartPos` = offset-into-chunk (seconds); every other chunk uses the proven cached-obj path. If `ActiveContent` throws on a device, it degrades to chunk-start resume — never a crash. `syncProgress` adds the offset back because `onSong` reports position relative to the ActiveContent start.
- **"Sync now" button** — forces a one-shot sync (`FORCE_SYNC` flag) for the device-handoff moment the OS's scheduled sync can't cover.

**Sidecar**
- `GET /progress?item&token` → saved position from ABS item detail (`?expanded=1&include=progress`), converting `lastUpdate` **ms → sec** so it fits the watch's 32-bit Number.
- `POST /progress` now accepts `lastUpdateSec` and forwards it as ABS's client-settable `lastUpdate` (ms) — so an offline listen flushed later still orders correctly across devices instead of looking like it happened at flush time.

## Design notes
- **Timestamps are epoch seconds on the watch** (exact Number); an epoch-ms value overflows the 32-bit Number and JSON-decodes lossily. The sidecar does the `/1000` and `*1000` at the edge.
- **Last-write-wins** relies on ABS's `lastUpdate` being client-settable ("for local sync"), confirmed in the ABS source.
- **Progress runs after downloads, fully decoupled** — a progress-request failure can never delay or regress the (historically crash-prone) download path.
- **`Versions.current` is NOT bumped** (only new Storage keys `PROGRESS`/`FORCE_SYNC` are added — no existing value shape changes), so the version wipe doesn't fire and books don't force-re-download. Build `tag` → `b34`.

## Testing / validation needed
The Connect IQ SDK is macOS-only and isn't available in this environment, so the Monkey C was **not compiled here** — it was written against the existing idioms with `typecheck=0` symbol-existence in mind. Per the project's build-tag practice, this needs **simulator + on-device validation before merge**:
1. `make sim` builds cleanly (b34).
2. Offline listen → charge/WiFi → position reaches ABS.
3. Set a position on another device → "Sync now" on the watch → next play resumes at that exact position.
4. Concurrent edits resolve to the newest by timestamp (no clobber).
5. **Verify the `ActiveContent` assumption:** confirm `onSong` `playbackPosition` is reported *relative to* the configured start (the `+ startOff` correction in `syncProgress` assumes this). If it's absolute, dropping that one line is the fix. Also confirm `ActiveContent` seek behaves on the target device (forum reports note media-position quirks across devices — hence the safe fallback).
6. Confirm "Sync now" actually triggers `onStartSync` with nothing queued.

Files: `Progress.mc`, `ProgressSync.mc` (new); `AbsApi`, `ContentDelegate`, `ContentIterator`, `SyncDelegate`, `DownloadedMenu(+Delegate)`, `Constants`, `strings.xml`, `sidecar/server.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSiDojVfEmJvZ4o7EY8Zpi