### PR TITLE
fix(manifest): drop ACP-unsupported devices so the store package builds

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -20,8 +20,10 @@
             <iq:product id="fenix7spro"/>
             <iq:product id="fenix7pro"/>
             <iq:product id="fenix7xpro"/>
-            <iq:product id="fenix7pronowifi"/>
-            <iq:product id="fenix7xpronowifi"/>
+            <!-- fenix7pronowifi / fenix7xpronowifi deliberately OMITTED: they do
+                 not support the audio-content-provider-app type, so including them
+                 makes the store package (make package -> bin/WatchShelf.iq) fail to
+                 compile. Debug/sideload builds for supported devices are unaffected. -->
             <!-- fenix 8 43mm + fenix 8 Solar (MIP) + fenix 8 Pro (fenix847mm is above) -->
             <iq:product id="fenix843mm"/>
             <iq:product id="fenix8solar47mm"/>


### PR DESCRIPTION
## Why
Preparing WatchShelf for Connect IQ store submission. The store requires the multi-device bundle `bin/WatchShelf.iq` (via `make package`), which **failed to compile**:

```
ERROR: Devices 'fenix7xpronowifi' and 'fenix7pronowifi' do not support app type 'audio-content-provider-app'.
```

The store bundle must compile for **every** listed `<iq:product>`, and these two no-WiFi fenix 7 Pro variants can't run an audio-content-provider app.

## Change
Remove `fenix7pronowifi` and `fenix7xpronowifi` from the manifest product list (with an inline comment so they aren't re-added). Debug / single-device sideload builds for supported devices are unaffected.

## Result
`make package` now succeeds — **87/87 devices**, `bin/WatchShelf.iq` produced.

## Not changed: launcher icon
The `launcher icon (65x65) ... will be scaled` warnings are **cosmetic and intentionally left**. Per-device launcher sizes across the target set span 40–70px (fenix8solar 40, vivoactive5 56, epix2pro51 60, fenix847mm/fr965 65, venu3 70). The single 65×65 icon downscales crisply on everything ≤65 and only upscales ~5px on venu3; resizing to any one size (e.g. 40×40) would blur it on most devices. Truly crisp icons everywhere would need per-device launcher-icon resources — deferred as optional polish.

## Remaining before an actual store submission (not in this PR)
- Store portal listing (icon, screenshots, description) at apps.garmin.com
- Reviewer test credentials for the sidecar + Audiobookshelf dependency
- Real-device confirmation of the resume/progress feature

🧙 Built with [WOZCODE](https://wozcode.com)