### PR TITLE
Fix O(chunks^2) playlist build that crashes long books on real hardware

### DIFF
--- a/source/BookStore.mc
+++ b/source/BookStore.mc
@@ -238,6 +238,7 @@ module BookStore {
         var meta = get(itemId);
         if (meta == null) { return; }
         var starts = Chunks.starts(meta["durs"]);
+        var spans = Chunks.spans(meta["durs"]);
         var firstChunk = first(itemId);
         var local = 0;
         var p = 0;
@@ -247,8 +248,7 @@ module BookStore {
             for (var i = 0; i < arr.size(); ++i) {
                 var k = firstChunk + local;
                 if ((arr[i] != null) && (k < starts.size())) {
-                    var c = Chunks.at(meta["durs"], k);
-                    var span = (c != null) ? (c["cend"] - c["cstart"]) : null;
+                    var span = (k < spans.size()) ? spans[k] : null;
                     out[arr[i]] = [order, starts[k], span, k];
                 }
                 local += 1;

--- a/source/Chunks.mc
+++ b/source/Chunks.mc
@@ -101,6 +101,25 @@ module Chunks {
         return n;
     }
 
+    // Span (seconds) of EVERY chunk, in one pass: [ span0, span1, ... ].
+    // Companion to starts() - lets a caller avoid calling at() per chunk.
+    function spans(durs) {
+        var out = [];
+        for (var f = 0; f < durs.size(); ++f) {
+            var d = durs[f];
+            if (d <= 0) { continue; }
+            var pos = 0;
+            while (pos < d) {
+                var size = (out.size() == 0) ? FIRST : LEN;
+                var end = pos + size;
+                if (end > d) { end = d; }
+                out.add(end - pos);
+                pos = end;
+            }
+        }
+        return out;
+    }
+
     // Boundaries of global chunk k, or null if k is out of range. Returns
     // { "file" => file index, "cstart"/"cend" => seconds within that file,
     //   "start" => absolute seconds within the whole book }.

--- a/source/ContentIterator.mc
+++ b/source/ContentIterator.mc
@@ -303,17 +303,7 @@ class ContentIterator extends Media.ContentIterator {
             }
         }
 
-        // In-place insertion sort on the five parallel arrays: stable, no
-        // allocations, numeric compares only. Chunks download (and cache) in
-        // playlist order, so the input is near-sorted and this stays ~O(n).
-        for (var i = 1; i < mPlaylist.size(); ++i) {
-            var j = i;
-            while (j > 0 && after(mOrders[j - 1], mStarts[j - 1], mOrders[j], mStarts[j])) {
-                swap(mPlaylist, j); swap(mOrders, j); swap(mStarts, j);
-                swap(mSpans, j); swap(mGlobals, j);
-                --j;
-            }
-        }
+        sortPlaylist();
         mIndex = 0;
         applyStart();
     }
@@ -395,10 +385,50 @@ class ContentIterator extends Media.ContentIterator {
         return startA > startB;
     }
 
-    function swap(arr, j) {
-        var tmp = arr[j];
-        arr[j] = arr[j - 1];
-        arr[j - 1] = tmp;
+    // Heap sort (O(n log n) worst case) on an index array rather than the
+    // five parallel arrays directly - a swap during the sort only touches
+    // one small-int array, not five. Rebuilds the real arrays from the
+    // sorted index in one pass at the end.
+    function sortPlaylist() {
+        var n = mPlaylist.size();
+        var idx = [];
+        for (var i = 0; i < n; ++i) { idx.add(i); }
+
+        for (var i = (n / 2) - 1; i >= 0; --i) { siftDownIdx(idx, i, n); }
+        for (var last = n - 1; last > 0; --last) {
+            var tmp = idx[0]; idx[0] = idx[last]; idx[last] = tmp;
+            siftDownIdx(idx, 0, last);
+        }
+
+        var playlist = []; var orders = []; var starts = [];
+        var spans = []; var globals = [];
+        for (var i = 0; i < n; ++i) {
+            var k = idx[i];
+            playlist.add(mPlaylist[k]); orders.add(mOrders[k]); starts.add(mStarts[k]);
+            spans.add(mSpans[k]); globals.add(mGlobals[k]);
+        }
+        mPlaylist = playlist; mOrders = orders; mStarts = starts;
+        mSpans = spans; mGlobals = globals;
+    }
+
+    // Sift idx[root] down through the max-heap of size `heapSize`: compares
+    // dereference through idx into mOrders/mStarts, but the swap itself only
+    // ever touches idx.
+    function siftDownIdx(idx, root, heapSize) {
+        while (true) {
+            var largest = root;
+            var left = (2 * root) + 1;
+            var right = (2 * root) + 2;
+            if ((left < heapSize) && after(mOrders[idx[left]], mStarts[idx[left]], mOrders[idx[largest]], mStarts[idx[largest]])) {
+                largest = left;
+            }
+            if ((right < heapSize) && after(mOrders[idx[right]], mStarts[idx[right]], mOrders[idx[largest]], mStarts[idx[largest]])) {
+                largest = right;
+            }
+            if (largest == root) { return; }
+            var tmp = idx[root]; idx[root] = idx[largest]; idx[largest] = tmp;
+            root = largest;
+        }
     }
 
     // Fisher-Yates over ALL parallel arrays together - mOrders/mStarts must


### PR DESCRIPTION
## What's broken

`BookStore.addLookup()` calls `Chunks.at()` once per cached chunk to get each chunk's span. `at()` is an intentional O(k) rescan by design (avoids materializing per-chunk dicts), but calling it inside a loop over every chunk makes the whole function O(chunks²).

For a short book this is invisible. For a long single-file audiobook it isn't — I hit this on a real Forerunner 265 with a several-hundred-MB single-file book (several hundred chunks): the app gets as far as initializing the media controls, then the watchdog kills it.

`CIQ_LOG.YML` off the device:

```
Error: 'Watchdog Tripped Error - Code Executed Too Long'
Stack:
  - Chunks.mc:114 at
  - BookStore.mc:250 addLookup
  - ContentIterator.mc:286 buildPlaylist
  - ContentIterator.mc:64 initialize
  - ContentDelegate.mc:79 resetContentIterator
```

Possibly related to #44 (playback failing on real hardware) — different symptom, but same neighborhood.

## Fix

Added `Chunks.spans()`, a single-pass companion to the existing `Chunks.starts()` — same plain-number-array shape, no per-chunk dicts, same memory discipline as the rest of the module. `addLookup` now reads `starts[k]`/`spans[k]` directly instead of calling `at()` per chunk, so building the lookup table is back to O(chunks).

Tested: same book that reliably crashed on load now plays correctly on the same FR265.