### PR TITLE
Pull before pushing live progress updates

### DIFF
--- a/source/AbsApi.mc
+++ b/source/AbsApi.mc
@@ -296,14 +296,40 @@ class LiveProgressWorker {
             mCurId = shiftQueue();
             var e = Progress.get(mCurId);
             if ((e == null) || !e[2]) { continue; }
-            mCurPos = e[0];
-            mCurTs = e[1];
-            mCurFinished = Progress.entryFinished(e);
             mBusy = true;
-            AbsApi.postProgress(mCurId, mCurPos, duration(mCurId), mCurTs,
-                mCurFinished ? true : null, method(:onResponse));
+            // Pull-before-push, same as ProgressSync: a live position event is
+            // stamped with the watch's OWN clock, which is always "now" - so a
+            // blind post here would beat a slightly-earlier-but-further-along
+            // write from another device on every single resume, not just a
+            // genuine race. Merge against the server's current value first and
+            // only push if this book is still dirty afterward (i.e. the local
+            // write is a real, further-along position - not a stale resume).
+            AbsApi.getProgress(mCurId, method(:onPullDone));
             return;
         }
+    }
+
+    function onPullDone(code, data) {
+        if (code == 200) {
+            var pr = AbsApi.readProgress(data); // [posSec, tsSec, finished] or null
+            if (pr != null) {
+                var finished = (pr.size() > 2) ? pr[2] : null;
+                Progress.mergeServer(mCurId, pr[0], pr[1], finished);
+            }
+        }
+        var e = Progress.get(mCurId);
+        if ((e == null) || !e[2]) {
+            // The pull already caught this book up to (or past) the server -
+            // nothing left to push.
+            mBusy = false;
+            drain();
+            return;
+        }
+        mCurPos = e[0];
+        mCurTs = e[1];
+        mCurFinished = Progress.entryFinished(e);
+        AbsApi.postProgress(mCurId, mCurPos, duration(mCurId), mCurTs,
+            mCurFinished ? true : null, method(:onResponse));
     }
 
     function onResponse(code, data) {


### PR DESCRIPTION
## What this fixes

Live progress pushes (pause, notify, and complete events during playback) post straight to ABS with no check against the server's current value. Every write is stamped with the watch's own clock, so a stale resume position can beat a genuinely newer position from another device just by being written more recently. In practice this means opening the watch app after listening further on another device can silently roll your progress backward.

ProgressSync already handles this correctly for the periodic sync path: pull the server value, merge with last write wins, then push only what is still dirty. This change applies the same pull, merge, and maybe push sequence to the live push worker in AbsApi.mc.

## Trade off

Each live progress update now costs an extra HTTP round trip (a pull before the push). These events fire on discrete playback actions rather than continuously, so it should not be noticeable in normal use, but flagging it in case it matters on a slow connection.

## Testing

Built clean for fr265 and confirmed on a real device: after a manual server side correction to a known good position, playing the watch caused it to pull and merge that position instead of overwriting it, then push forward normally as listening continued.