### PR TITLE
Add per-book playback speed selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Traefik** is in [sidecar/GETTING_STARTED.md](sidecar/GETTING_STARTED.md).
 - **Chunks** are ~3-min, 96 kbps mono AAC in a real M4A container (~2 MB) — the
   container is what lets the native player show a position/time indicator. Tune in
   `source/Chunks.mc`.
+- **Playback speed** is selected per book (1.0x–2.0x); progress stays on the
+  Audiobookshelf source timeline.
 - **State** lives in `Application.Storage` as chunk *params* (not URLs) to stay small.
 - **Playback** is restricted to the selected book. The native player still owns its
   part-local time bar, while the scrolling artist line shows `% of book`.

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -5,6 +5,7 @@
     <string id="loading">Loading...</string>
     <string id="pickLibrary">Choose Library</string>
     <string id="pickBook">Choose Book</string>
+    <string id="chooseSpeed">Choose speed</string>
     <string id="downloaded">Downloaded</string>
     <string id="queued">Queued</string>
     <string id="deleting">Removing</string>

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -12,7 +12,8 @@ internet:
   `/files`** — lean JSON (a few KB) so listings never overflow the watch.
   `/continue` returns the user's started, unfinished books; `/files` also includes
   the saved position used to skip already-listened chunks.
-- **`/transcode`** — cuts a small on-demand AAC chunk (real M4A/MP4 container, so
+- **`/transcode`** — cuts a small on-demand AAC chunk at the selected speed (real
+  M4A/MP4 container, so
   the watch's native player knows the exact duration and can show a position bar)
   out of any file using an HTTP Range request (it never downloads the whole
   gigabyte — a 3-min chunk is ~2 MB).
@@ -70,3 +71,5 @@ PATH), then expose it the same way (step 3 above).
 - **Quality** is 96 kbps mono AAC in an M4A container (spoken-word sweet spot;
   the real container is what gives the player a duration). Change in `server.js`
   `ffArgs`.
+- **Playback speed** supports 1.0x, 1.25x, 1.5x, 1.75x, and 2.0x via ffmpeg
+  `atempo`; progress remains on the original timeline.

--- a/sidecar/package.json
+++ b/sidecar/package.json
@@ -6,6 +6,7 @@
   "description": "Tiny ffmpeg transcode/chapter-cut sidecar bridging Audiobookshelf to Garmin WatchShelf.",
   "engines": { "node": ">=18" },
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test test/*.test.js"
   }
 }

--- a/sidecar/server.js
+++ b/sidecar/server.js
@@ -19,7 +19,7 @@
 //   GET /files?item&token        -> {title,author,files:[{ino,duration}],progress}
 //                                   (or {..,files:[],fileCount,tooManyFiles:true}
 //                                    when the book has > MAX_FILES audio files)
-//   GET /transcode?item&file&fmt&start&end&token -> a small audio chunk
+//   GET /transcode?item&file&fmt&start&end&speed&token -> a small audio chunk
 //   GET /cover?item&token[&w]    -> the book's cover, hard-resized by us to a
 //                                   small JPEG (the watch decodes it in 512KB)
 //   GET  /progress?item&token -> {currentTime,duration,lastUpdate,isFinished}
@@ -72,13 +72,11 @@ function saveSessions() {
 const jwtExp = (t) => { try { return JSON.parse(Buffer.from(String(t).split('.')[1], 'base64url').toString()).exp || 0; } catch (e) { return 0; } };
 if (!ABS) { console.error('ABS_URL is required (e.g. http://127.0.0.1:13378)'); process.exit(1); }
 
-// fmt values double as the watch/sidecar PROTOCOL VERSION guard: the watch
-// (b29+) requests fmt=m4a2; an older sidecar has no such CT entry and 400s,
-// so a stale sidecar fails the sync visibly instead of feeding raw ADTS that
-// the watch would mis-cache as ENCODING_M4A (silent cache poisoning). 'm4a'
-// keeps the legacy ADTS behavior so older watch builds stay correct too.
-const CT   = { mp3: 'audio/mpeg', m4a: 'audio/aac', m4a2: 'audio/mp4' };
+// fmt=m4a2/m4a3 are protocol guards; m4a3 additionally carries playback speed.
+// 'm4a' keeps the legacy ADTS behavior for older watch builds.
+const CT   = { mp3: 'audio/mpeg', m4a: 'audio/aac', m4a2: 'audio/mp4', m4a3: 'audio/mp4' };
 const IDRE = /^[A-Za-z0-9_\-]+$/, NUM = /^[0-9]+$/;
+const SPEEDS = new Set([100, 125, 150, 175, 200]);
 const b64  = (s) => Buffer.from(String(s)).toString('base64');
 const bearer = (t) => ({ Authorization: `Bearer ${t}`, 'User-Agent': UA });
 // Renew one session's accessToken using its (rotating) refreshToken. ABS
@@ -116,7 +114,7 @@ const jsonHead = { 'Content-Type': 'application/json', 'Cache-Control': 'no-stor
 // the real HTTP status - which masked an ABS 401 as "-400" in the field.
 const fail = (res, code, msg) => { res.writeHead(code, jsonHead).end(JSON.stringify({ error: msg })); };
 
-function ffArgs(srcUrl, token, fmt, start, end, out) {
+function ffArgs(srcUrl, token, fmt, start, end, out, speed) {
   const a = ['-hide_banner', '-loglevel', 'error', '-user_agent', UA,
     '-headers', `Authorization: Bearer ${token}\r\n`,
     '-reconnect', '1', '-reconnect_streamed', '1', '-reconnect_delay_max', '2'];
@@ -131,6 +129,7 @@ function ffArgs(srcUrl, token, fmt, start, end, out) {
   // error surfaced to the app. -id3v2_version 0 additionally suppresses ffmpeg's
   // own default encoder tag, so the mp3 output carries no ID3 tag at all.
   a.push('-map_metadata', '-1', '-id3v2_version', '0');
+  if (speed !== 100) { a.push('-filter:a', `atempo=${speed / 100}`); }
   // Always TRANSCODE to AAC (not stream-copy) regardless of source codec -
   // "always re-encode to a known-good target", so any book (mp3-sourced or
   // aac-sourced) lands in the same format. m4a2 is a REAL M4A/MP4 container
@@ -143,7 +142,7 @@ function ffArgs(srcUrl, token, fmt, start, end, out) {
   // finalized at the end; +faststart then rewrites it to the front), so this
   // branch writes to a temp file (`out`) instead of pipe:1 - transcode()
   // already buffers fully anyway.
-  if (fmt === 'm4a2') { a.push('-map', '0:a:0', '-c:a', 'aac', '-b:a', '96k', '-ac', '1', '-ar', '44100', '-movflags', '+faststart', '-f', 'ipod', out); }
+  if (fmt === 'm4a2' || fmt === 'm4a3') { a.push('-map', '0:a:0', '-c:a', 'aac', '-b:a', '96k', '-ac', '1', '-ar', '44100', '-movflags', '+faststart', '-f', 'ipod', out); }
   // Legacy ADTS for watch builds <= b28, which cache this as ENCODING_ADTS.
   else if (fmt === 'm4a') { a.push('-map', '0:a:0', '-c:a', 'aac', '-b:a', '96k', '-ac', '1', '-ar', '44100', '-f', 'adts', 'pipe:1'); }
   // 44100Hz/96kbps instead of the original 22050Hz/64kbps: the file itself was
@@ -194,8 +193,10 @@ async function transcode(req, res, u) {
   const item = u.searchParams.get('item'), file = u.searchParams.get('file');
   const fmt = (u.searchParams.get('fmt') || 'mp3').toLowerCase();
   const start = u.searchParams.get('start'), end = u.searchParams.get('end');
+  const speedRaw = u.searchParams.get('speed') || '100';
+  const speed = NUM.test(speedRaw) ? Number(speedRaw) : NaN;
   const token = u.searchParams.get('token');
-  if (!item || !file || !token || !CT[fmt] || !IDRE.test(item) || !NUM.test(file)) { res.writeHead(400).end('bad params'); return; }
+  if (!item || !file || !token || !CT[fmt] || !IDRE.test(item) || !NUM.test(file) || !SPEEDS.has(speed)) { res.writeHead(400).end('bad params'); return; }
   if ((start != null && !NUM.test(start)) || (end != null && !NUM.test(end))) { res.writeHead(400).end('bad range'); return; }
   // Fresh token BEFORE ffmpeg fetches (ffmpeg's internal request can't refresh
   // itself; over a long download the accessToken would otherwise expire mid-book).
@@ -211,10 +212,10 @@ async function transcode(req, res, u) {
   // OS with a file it can't validate/size correctly, which surfaces as a
   // native "Media Error Occurred" well after the download itself already
   // reported success to the app.
-  if (fmt === 'm4a2') {
+  if (fmt === 'm4a2' || fmt === 'm4a3') {
     const out = join(tmpdir(), `watchshelf-${randomUUID()}.m4a`);
     const drop = () => unlink(out).catch(() => {});
-    const ff = spawn('ffmpeg', ffArgs(src, tok, fmt, start, end, out), { stdio: ['ignore', 'ignore', 'pipe'] });
+    const ff = spawn('ffmpeg', ffArgs(src, tok, fmt, start, end, out, speed), { stdio: ['ignore', 'ignore', 'pipe'] });
     const ffmpegStderr = captureFfmpegStderr(ff);
     let done = false;
     let cancelled = false;
@@ -253,7 +254,7 @@ async function transcode(req, res, u) {
     return;
   }
 
-  const ff = spawn('ffmpeg', ffArgs(src, tok, fmt, start, end, null), { stdio: ['ignore', 'pipe', 'pipe'] });
+  const ff = spawn('ffmpeg', ffArgs(src, tok, fmt, start, end, null, speed), { stdio: ['ignore', 'pipe', 'pipe'] });
   const ffmpegStderr = captureFfmpegStderr(ff);
   const parts = [];
   let done = false;

--- a/sidecar/server.js
+++ b/sidecar/server.js
@@ -119,9 +119,12 @@ function ffArgs(srcUrl, token, fmt, start, end, out, speed) {
     '-headers', `Authorization: Bearer ${token}\r\n`,
     '-reconnect', '1', '-reconnect_streamed', '1', '-reconnect_delay_max', '2'];
   if (start != null) { a.push('-ss', String(start)); }
-  a.push('-i', srcUrl);
+  // Bound the INPUT before changing tempo. An output-side -t is measured after
+  // atempo, so a 180s chunk at 1.5x would consume 270s and overlap the next
+  // chunk by 90s.
   if (start != null && end != null) { a.push('-t', String(Math.max(0, Number(end) - Number(start)))); }
   else if (end != null)            { a.push('-to', String(end)); }
+  a.push('-i', srcUrl);
   // Strip every inherited metadata field (title/author/comments/cover art/etc.) -
   // WatchShelf doesn't need it embedded (book metadata lives server-side), and a
   // Garmin-confirmed bug (certain characters, e.g. (c) or curly quotes, in MP3

--- a/sidecar/test/speed.test.js
+++ b/sidecar/test/speed.test.js
@@ -52,7 +52,7 @@ test('transcodes supported speeds and rejects unsupported ones', { skip: !hasFfm
   const output = join(work, 'output.m4a');
   const generated = spawnSync('ffmpeg', [
     '-hide_banner', '-loglevel', 'error', '-f', 'lavfi',
-    '-i', 'sine=frequency=440:duration=4', '-ar', '44100', input,
+    '-i', 'sine=frequency=440:duration=12', '-ar', '44100', input,
   ]);
   assert.equal(generated.status, 0, generated.stderr.toString());
   const audio = readFileSync(input);
@@ -90,17 +90,21 @@ test('transcodes supported speeds and rejects unsupported ones', { skip: !hasFfm
     });
     assert.equal(login.status, 200);
     const sessionId = (await login.json()).user.token;
-    const encoded = await fetch(`http://127.0.0.1:${sidecarPort}/transcode?item=book&file=1&fmt=m4a3&start=0&end=4&speed=200&token=${sessionId}`);
-    assert.equal(encoded.status, 200);
-    assert.equal(encoded.headers.get('content-type'), 'audio/mp4');
-    writeFileSync(output, Buffer.from(await encoded.arrayBuffer()));
-    const probe = spawnSync('ffprobe', [
-      '-v', 'error', '-show_entries', 'format=duration', '-of', 'default=nw=1:nk=1', output,
-    ]);
-    assert.equal(probe.status, 0, probe.stderr.toString());
-    const duration = Number(probe.stdout.toString().trim());
-    assert.ok(duration > 1.8 && duration < 2.2, `expected about 2s, received ${duration}s`);
-    const invalid = await fetch(`http://127.0.0.1:${sidecarPort}/transcode?item=book&file=1&fmt=m4a3&start=0&end=4&speed=130&token=${sessionId}`);
+    for (const speed of [100, 125, 150, 175, 200]) {
+      const encoded = await fetch(`http://127.0.0.1:${sidecarPort}/transcode?item=book&file=1&fmt=m4a3&start=2&end=6&speed=${speed}&token=${sessionId}`);
+      assert.equal(encoded.status, 200);
+      assert.equal(encoded.headers.get('content-type'), 'audio/mp4');
+      writeFileSync(output, Buffer.from(await encoded.arrayBuffer()));
+      const probe = spawnSync('ffprobe', [
+        '-v', 'error', '-show_entries', 'format=duration', '-of', 'default=nw=1:nk=1', output,
+      ]);
+      assert.equal(probe.status, 0, probe.stderr.toString());
+      const duration = Number(probe.stdout.toString().trim());
+      const expected = 4 / (speed / 100);
+      assert.ok(Math.abs(duration - expected) < 0.2,
+        `expected about ${expected}s at ${speed}%, received ${duration}s`);
+    }
+    const invalid = await fetch(`http://127.0.0.1:${sidecarPort}/transcode?item=book&file=1&fmt=m4a3&start=2&end=6&speed=130&token=${sessionId}`);
     assert.equal(invalid.status, 400);
   } finally {
     sidecar.kill('SIGTERM');

--- a/sidecar/test/speed.test.js
+++ b/sidecar/test/speed.test.js
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import http from 'node:http';
+import net from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const sidecarDir = fileURLToPath(new URL('../', import.meta.url));
+
+const hasFfmpeg = spawnSync('ffmpeg', ['-version']).status === 0
+  && spawnSync('ffprobe', ['-version']).status === 0;
+
+function freePort() {
+  return new Promise((resolvePort, reject) => {
+    const socket = net.createServer();
+    socket.once('error', reject);
+    socket.listen(0, '127.0.0.1', () => {
+      const { port } = socket.address();
+      socket.close((error) => error ? reject(error) : resolvePort(port));
+    });
+  });
+}
+
+function listen(server) {
+  return new Promise((resolveListen, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolveListen);
+  });
+}
+
+function close(server) {
+  return new Promise((resolveClose) => server.close(resolveClose));
+}
+
+async function waitForHealth(port) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health`);
+      if (response.ok && await response.text() === 'ok') return;
+    } catch {}
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+  }
+  throw new Error('sidecar did not become ready');
+}
+
+test('transcodes supported speeds and rejects unsupported ones', { skip: !hasFfmpeg }, async () => {
+  const work = mkdtempSync(join(tmpdir(), 'watchshelf-speed-test-'));
+  const input = join(work, 'input.wav');
+  const output = join(work, 'output.m4a');
+  const generated = spawnSync('ffmpeg', [
+    '-hide_banner', '-loglevel', 'error', '-f', 'lavfi',
+    '-i', 'sine=frequency=440:duration=4', '-ar', '44100', input,
+  ]);
+  assert.equal(generated.status, 0, generated.stderr.toString());
+  const audio = readFileSync(input);
+  const jwt = [
+    Buffer.from('{}').toString('base64url'),
+    Buffer.from(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 })).toString('base64url'),
+    'sig',
+  ].join('.');
+  const absServer = http.createServer((req, res) => {
+    if (req.method === 'POST' && req.url === '/login') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ user: { accessToken: jwt, username: 'test' } }));
+      return;
+    }
+    if (req.method === 'GET' && req.url === '/api/items/book/file/1/download') {
+      res.writeHead(200, { 'Content-Type': 'audio/wav', 'Content-Length': audio.length });
+      res.end(audio);
+      return;
+    }
+    res.writeHead(404).end();
+  });
+  await listen(absServer);
+  const sidecarPort = await freePort();
+  const sidecar = spawn('node', [join(sidecarDir, 'server.js')], {
+    cwd: sidecarDir,
+    env: { ...process.env, ABS_URL: `http://127.0.0.1:${absServer.address().port}`,
+      BIND: '127.0.0.1', PORT: String(sidecarPort), BASE_PATH: '' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  try {
+    await waitForHealth(sidecarPort);
+    const login = await fetch(`http://127.0.0.1:${sidecarPort}/login`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'test', password: 'test' }),
+    });
+    assert.equal(login.status, 200);
+    const sessionId = (await login.json()).user.token;
+    const encoded = await fetch(`http://127.0.0.1:${sidecarPort}/transcode?item=book&file=1&fmt=m4a3&start=0&end=4&speed=200&token=${sessionId}`);
+    assert.equal(encoded.status, 200);
+    assert.equal(encoded.headers.get('content-type'), 'audio/mp4');
+    writeFileSync(output, Buffer.from(await encoded.arrayBuffer()));
+    const probe = spawnSync('ffprobe', [
+      '-v', 'error', '-show_entries', 'format=duration', '-of', 'default=nw=1:nk=1', output,
+    ]);
+    assert.equal(probe.status, 0, probe.stderr.toString());
+    const duration = Number(probe.stdout.toString().trim());
+    assert.ok(duration > 1.8 && duration < 2.2, `expected about 2s, received ${duration}s`);
+    const invalid = await fetch(`http://127.0.0.1:${sidecarPort}/transcode?item=book&file=1&fmt=m4a3&start=0&end=4&speed=130&token=${sessionId}`);
+    assert.equal(invalid.status, 400);
+  } finally {
+    sidecar.kill('SIGTERM');
+    await close(absServer);
+    rmSync(work, { recursive: true, force: true });
+  }
+});

--- a/source/AbsApi.mc
+++ b/source/AbsApi.mc
@@ -88,13 +88,12 @@ module AbsApi {
 
     // One CHUNK of a file as a small AAC chunk in a REAL M4A container (the
     // container is what gives the native player a track duration - see
-    // SyncDelegate). fmt=m4a2 doubles as the watch/sidecar protocol-version
-    // guard: an older sidecar doesn't know it and 400s, so the sync fails
-    // VISIBLY instead of the old sidecar's raw ADTS being silently cached
-    // under ENCODING_M4A (which would poison every downloaded chunk).
-    function sidecarChunkUrl(itemId, ino, startSec, endSec) {
+    // SyncDelegate). fmt=m4a3 requires speed-aware sidecar support; an older
+    // sidecar returns 400 instead of silently serving incompatible audio.
+    function sidecarChunkUrl(itemId, ino, startSec, endSec, speed) {
         return sidecarBase() + "/transcode?item=" + itemId + "&file=" + ino
-            + "&fmt=m4a2&start=" + startSec.toString() + "&end=" + endSec.toString()
+            + "&fmt=m4a3&start=" + startSec.toString() + "&end=" + endSec.toString()
+            + "&speed=" + PlaybackSpeed.normalize(speed).toString()
             + "&token=" + authToken();
     }
 

--- a/source/BookMenuDelegate.mc
+++ b/source/BookMenuDelegate.mc
@@ -12,10 +12,12 @@ using Toybox.WatchUi;
 class BookFilesListener {
     private var mOwner;
     private var mItemId;
+    private var mSpeed;
 
-    function initialize(owner, itemId) {
+    function initialize(owner, itemId, speed) {
         mOwner = owner;
         mItemId = itemId;
+        mSpeed = speed;
     }
 
     function onResponse(code, data) {
@@ -23,7 +25,39 @@ class BookFilesListener {
         // can start another /files request before this one returns; using one
         // mutable delegate field would then queue the first book's file list
         // under the second book's id and make every transcode fail.
-        mOwner.onFiles(mItemId, code, data);
+        mOwner.onFiles(mItemId, mSpeed, code, data);
+    }
+}
+
+class BookSpeedMenu extends WatchUi.Menu2 {
+    function initialize(title) {
+        Menu2.initialize({ :title => title });
+        addItem(new WatchUi.MenuItem("1.0x", null, "100", null));
+        addItem(new WatchUi.MenuItem("1.25x", null, "125", null));
+        addItem(new WatchUi.MenuItem("1.5x", null, "150", null));
+        addItem(new WatchUi.MenuItem("1.75x", null, "175", null));
+        addItem(new WatchUi.MenuItem("2.0x", null, "200", null));
+    }
+}
+
+class BookSpeedMenuDelegate extends WatchUi.Menu2InputDelegate {
+    private var mOwner;
+    private var mItemId;
+
+    function initialize(owner, itemId) {
+        Menu2InputDelegate.initialize();
+        mOwner = owner;
+        mItemId = itemId;
+    }
+
+    function onSelect(item) {
+        var speed = item.getId().toNumber();
+        WatchUi.popView(WatchUi.SLIDE_RIGHT);
+        mOwner.downloadAtSpeed(mItemId, PlaybackSpeed.normalize(speed));
+    }
+
+    function onBack() {
+        WatchUi.popView(WatchUi.SLIDE_RIGHT);
     }
 }
 
@@ -35,11 +69,16 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
 
     function onSelect(item) {
         var itemId = item.getId();
-        var listener = new BookFilesListener(self, itemId);
+        WatchUi.pushView(new BookSpeedMenu(WatchUi.loadResource(Rez.Strings.chooseSpeed)),
+            new BookSpeedMenuDelegate(self, itemId), WatchUi.SLIDE_LEFT);
+    }
+
+    function downloadAtSpeed(itemId, speed) {
+        var listener = new BookFilesListener(self, itemId, speed);
         AbsApi.getFiles(itemId, listener.method(:onResponse));
     }
 
-    function onFiles(itemId, code, data) {
+    function onFiles(itemId, speed, code, data) {
         // Session expired -> re-login instead of a dead-end error.
         if (code == 401) { Login.reauth(); return; }
         if (code != 200 || data == null) {
@@ -157,6 +196,7 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
         if (meta != null) {
             drifted = (forceFull && (BookStore.first(itemId) > 0))
                 || !Chunks.same(meta["durs"], durs)
+                || (PlaybackSpeed.normalize(meta["speed"]) != speed)
                 || (!inBookIndex(itemId) && !containsId(JobStore.list(), itemId));
         }
 
@@ -243,6 +283,7 @@ class BookMenuDelegate extends WatchUi.Menu2InputDelegate {
             "durs"   => durs,
             "title"  => title,
             "author" => author,
+            "speed"  => speed,
             "base"   => base,
             "done"   => done,
             "gen"    => gen

--- a/source/BookStore.mc
+++ b/source/BookStore.mc
@@ -51,19 +51,19 @@ module BookStore {
         return "arti:" + itemId;
     }
 
-    // Book metadata { "title", "author", "durs", "first" }, or null if
+    // Book metadata { "title", "author", "durs", "first", "speed" }, or null if
     // nothing recorded yet. "author" and "first" may be absent/null on records
     // written by older builds; an absent first means the legacy chunk 0.
     function get(itemId) {
         return Application.Storage.getValue(key(itemId));
     }
 
-    function ensureMeta(itemId, title, author, durs, firstChunk) {
+    function ensureMeta(itemId, title, author, durs, firstChunk, speed) {
         if (get(itemId) == null) {
             if (firstChunk == null) { firstChunk = 0; }
             Application.Storage.setValue(key(itemId),
                 { "title" => title, "author" => author, "durs" => durs,
-                  "first" => firstChunk });
+                  "first" => firstChunk, "speed" => PlaybackSpeed.normalize(speed) });
         }
     }
 

--- a/source/ChunksTests.mc
+++ b/source/ChunksTests.mc
@@ -31,6 +31,21 @@ function chunksTailCoordinates(logger) {
     return true;
 }
 
+(:test)
+function playbackSpeedTimelineMapping(logger) {
+    Test.assertEqual(PlaybackSpeed.normalize(null), 100);
+    Test.assertEqual(PlaybackSpeed.normalize(130), 100);
+    Test.assertEqual(PlaybackSpeed.normalize(125), 125);
+    Test.assertEqual(PlaybackSpeed.normalize(200), 200);
+    Test.assertEqual(PlaybackSpeed.sourceSeconds(60, 100), 60);
+    Test.assertEqual(PlaybackSpeed.sourceSeconds(60, 125), 75);
+    Test.assertEqual(PlaybackSpeed.sourceSeconds(60, 150), 90);
+    Test.assertEqual(PlaybackSpeed.sourceSeconds(59, 125), 74);
+    Test.assertEqual(PlaybackSpeed.sourceSeconds(60, null), 60);
+    logger.debug("compressed playback maps to the source timeline");
+    return true;
+}
+
 // Restarting a completed book becomes an ordinary dirty position write. The
 // client deliberately omits isFinished:false: current ABS resets currentTime
 // and discards the supplied position when that explicit flag is used.

--- a/source/ContentDelegate.mc
+++ b/source/ContentDelegate.mc
@@ -7,7 +7,7 @@ using Toybox.System;
 class ContentDelegate extends Media.ContentDelegate {
 
     private var mIterator;
-    private var mProgressLookup; // refId => [item,start,duration,isFinal,span], lazy
+    private var mProgressLookup; // refId => [item,start,duration,isFinal,span,speed], lazy
     private var mArtItemId;      // book whose cover is currently on the player
     private var mArgs;           // args for the NEXT iterator reset
     private var mSelectedItem;   // one book for this playback session
@@ -121,7 +121,7 @@ class ContentDelegate extends Media.ContentDelegate {
         }
     }
 
-    // { refId => [itemId,start,bookDuration,isActualFinalPart,chunkSpan] },
+    // { refId => [itemId,start,bookDuration,isActualFinalPart,chunkSpan,speed] },
     // built once
     // per playback
     // session (the downloaded set can't change while the player is running -
@@ -158,7 +158,8 @@ class ContentDelegate extends Media.ContentDelegate {
                 var start = perBook[refIds[i]][1];
                 var span = (perBook[refIds[i]].size() > 2) ? perBook[refIds[i]][2] : null;
                 mProgressLookup[refIds[i]] = [index[b], start, total,
-                    (finalStart != null) && (start == finalStart), span];
+                    (finalStart != null) && (start == finalStart), span,
+                    PlaybackSpeed.normalize((meta != null) ? meta["speed"] : null)];
             }
         }
     }
@@ -178,7 +179,8 @@ class ContentDelegate extends Media.ContentDelegate {
             hit[0].equals(mSessionFinishedItem)) {
             return;
         }
-        var absolute = hit[1] + positionInChapter;
+        var speed = (hit.size() > 5) ? PlaybackSpeed.normalize(hit[5]) : PlaybackSpeed.NORMAL;
+        var absolute = hit[1] + PlaybackSpeed.sourceSeconds(positionInChapter, speed);
         // A final COMPLETE is authoritative even on firmware that reports a
         // zero/rounded playbackPosition for AAC. Garmin also permits the
         // PLAYBACK_POSITION_END sentinel (-1) on COMPLETE; use the derived

--- a/source/JobStore.mc
+++ b/source/JobStore.mc
@@ -5,7 +5,8 @@ using Toybox.Application;
 //
 //   "jobidx"        => [ itemId, ... ]
 //   "job:" + itemId => { "inos" => [str], "durs" => [num], "title" => str,
-//                        "author" => str or null, "base" => num,
+//                        "author" => str or null, "speed" => integer percent,
+//                        "base" => num,
 //                        "done" => num, "gen" => num }
 // `base` and `done` are GLOBAL chunk indexes. base is the first unlistened
 // chunk selected for a tail-only download; done is its persisted next cursor.

--- a/source/PlaybackSpeed.mc
+++ b/source/PlaybackSpeed.mc
@@ -1,0 +1,16 @@
+// Integer percentages shared by the watch and sidecar.
+module PlaybackSpeed {
+    const NORMAL = 100;
+
+    function normalize(value) {
+        if ((value == 125) || (value == 150) || (value == 175) || (value == 200)) {
+            return value;
+        }
+        return NORMAL;
+    }
+
+    // Map seconds on the compressed output back to the source timeline.
+    function sourceSeconds(outputSeconds, speed) {
+        return ((((outputSeconds * normalize(speed)) + 50) / 100).toNumber());
+    }
+}

--- a/source/SyncDelegate.mc
+++ b/source/SyncDelegate.mc
@@ -251,7 +251,7 @@ class SyncDelegate extends Communications.SyncDelegate {
         var context = { "item" => itemId, "k" => job["done"], "gen" => job["gen"] };
         var delegate = new RequestDelegate(method(:onTrackDownloaded), context);
         var url = AbsApi.sidecarChunkUrl(itemId, job["inos"][c["file"]],
-                                        c["cstart"], c["cend"]);
+                                        c["cstart"], c["cend"], job["speed"]);
         delegate.makeWebRequest(url, null, options);
     }
 
@@ -319,7 +319,8 @@ class SyncDelegate extends Communications.SyncDelegate {
 
         var k = job["done"];
         var base = (job["base"] != null) ? job["base"] : 0;
-        BookStore.ensureMeta(itemId, job["title"], job["author"], job["durs"], base);
+        BookStore.ensureMeta(itemId, job["title"], job["author"], job["durs"],
+            base, PlaybackSpeed.normalize(job["speed"]));
         BookStore.saveChunk(itemId, k, refId);
         BookStore.addToIndex(itemId);
 


### PR DESCRIPTION
## Summary

- add per-book 1.0x, 1.25x, 1.5x, 1.75x, and 2.0x selection
- encode the selected speed in the sidecar with ffmpeg `atempo`
- map compressed playback time back to the Audiobookshelf source timeline
- redownload a book when its selected encoding speed changes

`fmt=m4a3` acts as a protocol guard so a speed-aware watch build cannot silently use an older sidecar. Existing watch builds remain compatible with the sidecar's legacy formats.

This branch is based directly on `main` and does not include #46 or the long-book playlist follow-up.

## Validation

- `make build DEVICE=fr965`
- Monkey C test build with `-t`
- `node --test sidecar/test/speed.test.js`
- 1.5x encoding and playback verified on a Forerunner 965